### PR TITLE
feat: add .env.example for local development setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ __pycache__/
 venv/
 .env
 .env.*
-!.env.sample
+!.env.example
 
 .vscode/
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,8 @@
+# Database
+DATABASE_URL=postgresql://user:password@localhost:5432/freehold
+
+# Security
+SECRET_KEY=changeme
+
+# Storage
+STORAGE_PATH=/var/lib/freehold/attachments


### PR DESCRIPTION
## Summary
- Adds `api/.env.example` with template values for `DATABASE_URL`, `SECRET_KEY`, and `STORAGE_PATH`
- Updates `.gitignore` to allow `.env.example` (replacing the previous `.env.sample` exception)

## Test plan
- [x] Confirm `api/.env.example` is visible after cloning the repo
- [x] Confirm `api/.env` (real secrets) remains gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)