### PR TITLE
chore: align .env.example DATABASE_URL with Docker Compose

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,5 +1,5 @@
 # Database
-DATABASE_URL=postgresql://user:password@localhost:5432/freehold
+DATABASE_URL=postgresql://freehold:freehold@localhost:5433/freehold
 
 # Security
 SECRET_KEY=changeme


### PR DESCRIPTION
Closes #12

## Summary
- Updates `DATABASE_URL` in `api/.env.example` to match the credentials and port defined in `docker-compose.yml` (`freehold:freehold@localhost:5433/freehold`)

## Test plan
See #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)