### PR TITLE
feat: implement export CLI command

### DIFF
--- a/api/freehold/cli.py
+++ b/api/freehold/cli.py
@@ -1,0 +1,54 @@
+"""Freehold CLI entry point."""
+
+from pathlib import Path
+
+import typer
+from dotenv import load_dotenv
+
+app = typer.Typer(help="Freehold — self-hosted knowledge base tools.")
+
+
+@app.command()
+def export(
+    workspace: str = typer.Option(..., "--workspace", "-w", help="Workspace slug to export"),
+    output: Path | None = typer.Option(
+        None, "--output", "-o", help="Output path (file or directory; defaults to cwd)"
+    ),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="DATABASE_URL", help="PostgreSQL connection URL"
+    ),
+    storage_path: str | None = typer.Option(
+        None, "--storage-path", envvar="STORAGE_PATH", help="Path to attachment storage directory"
+    ),
+) -> None:
+    """Export a workspace to a portable zip bundle."""
+    load_dotenv()
+
+    import os
+
+    from .db import get_session
+    from .export import export_workspace
+    from .storage import LocalFilesystemAdapter
+
+    storage_root = storage_path or os.getenv("STORAGE_PATH", "/var/lib/freehold/attachments")
+    storage = LocalFilesystemAdapter(storage_root)
+
+    try:
+        with get_session(database_url) as session:
+            result = export_workspace(
+                slug=workspace,
+                session=session,
+                storage=storage,
+                output_path=output,
+            )
+        typer.echo(f"Exported to {result}")
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
+    except (RuntimeError, FileNotFoundError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
+
+
+if __name__ == "__main__":
+    app()

--- a/api/freehold/db.py
+++ b/api/freehold/db.py
@@ -1,0 +1,24 @@
+"""Database session factory."""
+
+import os
+from contextlib import contextmanager
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+
+def _database_url(override: str | None = None) -> str:
+    url = override or os.getenv("DATABASE_URL")
+    if not url:
+        raise RuntimeError("DATABASE_URL environment variable is not set")
+    return url
+
+
+@contextmanager
+def get_session(database_url: str | None = None):
+    engine = create_engine(_database_url(database_url))
+    try:
+        with Session(engine) as session:
+            yield session
+    finally:
+        engine.dispose()

--- a/api/freehold/export.py
+++ b/api/freehold/export.py
@@ -1,0 +1,173 @@
+"""Export a workspace to a portable zip bundle.
+
+Bundle layout:
+    freehold-export-{workspace-slug}-{timestamp}.zip
+    ├── manifest.json
+    ├── pages/{page-id}.md
+    ├── assets/{asset-id}{ext}
+    ├── revisions/{page-id}/{revision-id}.md
+    └── links.json
+"""
+
+import hashlib
+import json
+import re
+import zipfile
+from datetime import datetime, timezone
+from io import BytesIO
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from .models import Attachment, Page, Workspace
+from .storage import StorageAdapter
+
+SCHEMA_VERSION = "1"
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _extract_hrefs(content: str) -> list[str]:
+    """Return all link targets found in Markdown content."""
+    return re.findall(r"\[(?:[^\]]*)\]\(([^)]+)\)", content)
+
+
+def _collect_pages(workspace: Workspace) -> list[Page]:
+    pages: list[Page] = []
+    for space in workspace.spaces:
+        for collection in space.collections:
+            pages.extend(collection.pages)
+    return pages
+
+
+def _build_links(pages: list[Page], page_id_set: set[str]) -> dict:
+    internal_links: list[dict] = []
+    broken_links: list[dict] = []
+
+    for page in pages:
+        if page.current_revision is None:
+            continue
+        for href in _extract_hrefs(page.current_revision.content or ""):
+            source = str(page.id)
+            # Treat /pages/<id> paths and bare UUIDs that match known pages as internal.
+            candidate = href.removeprefix("/pages/").rstrip("/")
+            if candidate in page_id_set:
+                internal_links.append(
+                    {"source_page_id": source, "target_page_id": candidate, "href": href}
+                )
+            elif href.startswith("/") or not href.startswith(("http://", "https://")):
+                broken_links.append({"source_page_id": source, "href": href})
+
+    linked_ids = {lnk["target_page_id"] for lnk in internal_links}
+    orphaned = [str(p.id) for p in pages if str(p.id) not in linked_ids]
+
+    return {
+        "internal_links": internal_links,
+        "broken_links": broken_links,
+        "orphaned_pages": orphaned,
+    }
+
+
+def _build_manifest(
+    workspace: Workspace,
+    pages: list[Page],
+    attachment_records: list[dict],
+    export_timestamp: str,
+) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "export_timestamp": export_timestamp,
+        "workspace": {
+            "id": str(workspace.id),
+            "slug": workspace.slug,
+            "name": workspace.name,
+            "created_at": workspace.created_at.isoformat(),
+        },
+        "page_count": len(pages),
+        "attachment_count": len(attachment_records),
+        "attachments": attachment_records,
+    }
+
+
+def export_workspace(
+    slug: str,
+    session: Session,
+    storage: StorageAdapter,
+    output_path: Path | None = None,
+) -> Path:
+    """Export *slug* to a zip bundle and return the path of the written file."""
+    workspace = session.query(Workspace).filter_by(slug=slug).first()
+    if workspace is None:
+        raise ValueError(f"Workspace '{slug}' not found")
+
+    pages = _collect_pages(workspace)
+    page_id_set = {str(p.id) for p in pages}
+
+    # Eagerly touch lazy-loaded relationships while the session is open.
+    for page in pages:
+        _ = page.current_revision
+        _ = page.revisions
+        _ = page.attachments
+
+    export_timestamp = datetime.now(timezone.utc).isoformat()
+    timestamp_fmt = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    bundle_name = f"freehold-export-{workspace.slug}-{timestamp_fmt}.zip"
+
+    if output_path is None:
+        output_path = Path.cwd() / bundle_name
+    elif output_path.is_dir():
+        output_path = output_path / bundle_name
+
+    attachment_records: list[dict] = []
+    buf = BytesIO()
+
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for page in pages:
+            page_id = str(page.id)
+
+            # Current page content.
+            content = page.current_revision.content if page.current_revision else ""
+            zf.writestr(f"pages/{page_id}.md", content)
+
+            # Every revision (append-only history).
+            for rev in page.revisions:
+                zf.writestr(f"revisions/{page_id}/{rev.id}.md", rev.content)
+
+        # Attachments — verify hash before including.
+        all_attachments: list[Attachment] = []
+        for page in pages:
+            all_attachments.extend(page.attachments)
+
+        for att in all_attachments:
+            att_id = str(att.id)
+            ext = Path(att.filename).suffix
+            data = storage.read(att_id, att.filename)
+            actual_hash = _sha256(data)
+            if actual_hash != att.hash:
+                raise RuntimeError(
+                    f"Hash mismatch for attachment {att_id} ({att.filename}): "
+                    f"expected {att.hash}, got {actual_hash}"
+                )
+            zf.writestr(f"assets/{att_id}{ext}", data)
+            attachment_records.append(
+                {
+                    "id": att_id,
+                    "page_id": str(att.page_id),
+                    "filename": att.filename,
+                    "hash": att.hash,
+                    "size_bytes": att.size_bytes,
+                }
+            )
+
+        zf.writestr("links.json", json.dumps(_build_links(pages, page_id_set), indent=2))
+        zf.writestr(
+            "manifest.json",
+            json.dumps(
+                _build_manifest(workspace, pages, attachment_records, export_timestamp), indent=2
+            ),
+        )
+
+    output_path.write_bytes(buf.getvalue())
+    return output_path

--- a/api/freehold/storage.py
+++ b/api/freehold/storage.py
@@ -1,0 +1,30 @@
+"""Storage adapter interface and local filesystem implementation."""
+
+import os
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class StorageAdapter(ABC):
+    @abstractmethod
+    def read(self, attachment_id: str, filename: str) -> bytes:
+        """Return the raw bytes for an attachment."""
+        ...
+
+
+class LocalFilesystemAdapter(StorageAdapter):
+    """Reads attachments from a local directory tree: <base>/<attachment_id>/<filename>."""
+
+    def __init__(self, base_path: str | Path) -> None:
+        self.base_path = Path(base_path)
+
+    def read(self, attachment_id: str, filename: str) -> bytes:
+        path = self.base_path / attachment_id / filename
+        if not path.exists():
+            raise FileNotFoundError(f"Attachment file not found: {path}")
+        return path.read_bytes()
+
+
+def get_default_adapter() -> StorageAdapter:
+    storage_path = os.getenv("STORAGE_PATH", "/var/lib/freehold/attachments")
+    return LocalFilesystemAdapter(storage_path)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -9,7 +9,11 @@ dependencies = [
     "alembic>=1.14",
     "psycopg2-binary>=2.9",
     "python-dotenv>=1.0",
+    "typer>=0.12",
 ]
+
+[project.scripts]
+freehold = "freehold.cli:app"
 
 [project.optional-dependencies]
 dev = [
@@ -18,6 +22,9 @@ dev = [
     "httpx>=0.28",
     "ruff>=0.9",
 ]
+
+[tool.setuptools.packages.find]
+include = ["freehold*"]
 
 [tool.ruff]
 target-version = "py311"

--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -1,0 +1,286 @@
+"""Integration tests for the export command.
+
+Runs against a live PostgreSQL database (same Docker Compose default as other tests).
+Each test rolls back its transaction so the DB stays clean between runs.
+"""
+
+import hashlib
+import json
+import os
+import zipfile
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from freehold.export import SCHEMA_VERSION, export_workspace
+from freehold.models import Attachment, Collection, Page, Revision, Space, Workspace
+from freehold.storage import StorageAdapter
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
+
+
+# ---------------------------------------------------------------------------
+# Fake storage adapter (in-memory; no filesystem required)
+# ---------------------------------------------------------------------------
+
+
+class FakeStorageAdapter(StorageAdapter):
+    def __init__(self, files: dict[tuple[str, str], bytes]) -> None:
+        # keys are (attachment_id, filename)
+        self._files = files
+
+    def read(self, attachment_id: str, filename: str) -> bytes:
+        key = (attachment_id, filename)
+        if key not in self._files:
+            raise FileNotFoundError(f"No fake file for {key}")
+        return self._files[key]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def engine():
+    eng = create_engine(DATABASE_URL)
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def session(engine):
+    with Session(engine) as s:
+        yield s
+        s.rollback()
+
+
+@pytest.fixture
+def seeded(session):
+    """Seed a workspace with two pages (two revisions each) and one attachment."""
+    ws = Workspace(slug="export-test-ws", name="Export Test Workspace")
+    session.add(ws)
+    session.flush()
+
+    space = Space(workspace_id=ws.id, slug="sp", name="Space")
+    session.add(space)
+    session.flush()
+
+    col = Collection(space_id=space.id, slug="col", name="Collection")
+    session.add(col)
+    session.flush()
+
+    # Page 1 with two revisions and one internal link to page 2 (added later).
+    page1 = Page(collection_id=col.id, slug="page-one", title="Page One")
+    session.add(page1)
+    session.flush()
+
+    rev1a = Revision(page_id=page1.id, content="# Page One\nFirst draft.")
+    session.add(rev1a)
+    session.flush()
+
+    rev1b = Revision(page_id=page1.id, content="# Page One\nSecond draft.")
+    session.add(rev1b)
+    session.flush()
+
+    page1.current_revision_id = rev1b.id
+    session.flush()
+
+    # Page 2 (target of internal link from page 1).
+    page2 = Page(collection_id=col.id, slug="page-two", title="Page Two")
+    session.add(page2)
+    session.flush()
+
+    rev2 = Revision(page_id=page2.id, content="# Page Two\nOnly revision.")
+    session.add(rev2)
+    session.flush()
+
+    page2.current_revision_id = rev2.id
+    session.flush()
+
+    # Update page1 current revision to include a link to page2.
+    link_content = f"# Page One\n[See page two](/pages/{page2.id})"
+    rev1c = Revision(page_id=page1.id, content=link_content)
+    session.add(rev1c)
+    session.flush()
+
+    page1.current_revision_id = rev1c.id
+    session.flush()
+
+    # Attachment on page1.
+    att_data = b"fake image bytes"
+    att_hash = hashlib.sha256(att_data).hexdigest()
+    att = Attachment(
+        page_id=page1.id,
+        filename="photo.png",
+        hash=att_hash,
+        size_bytes=len(att_data),
+    )
+    session.add(att)
+    session.flush()
+
+    storage = FakeStorageAdapter({(str(att.id), "photo.png"): att_data})
+
+    return {
+        "workspace": ws,
+        "pages": [page1, page2],
+        "attachment": att,
+        "attachment_data": att_data,
+        "storage": storage,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_export_produces_zip(seeded, session, tmp_path):
+    result = export_workspace(
+        slug="export-test-ws",
+        session=session,
+        storage=seeded["storage"],
+        output_path=tmp_path,
+    )
+
+    assert result.exists()
+    assert result.suffix == ".zip"
+    assert "export-test-ws" in result.name
+
+
+def test_zip_contains_expected_members(seeded, session, tmp_path):
+    result = export_workspace(
+        slug="export-test-ws",
+        session=session,
+        storage=seeded["storage"],
+        output_path=tmp_path,
+    )
+
+    with zipfile.ZipFile(result) as zf:
+        names = set(zf.namelist())
+
+    page1_id = str(seeded["pages"][0].id)
+    page2_id = str(seeded["pages"][1].id)
+    att_id = str(seeded["attachment"].id)
+
+    assert "manifest.json" in names
+    assert "links.json" in names
+    assert f"pages/{page1_id}.md" in names
+    assert f"pages/{page2_id}.md" in names
+    assert f"assets/{att_id}.png" in names
+
+
+def test_manifest_content(seeded, session, tmp_path):
+    ws = seeded["workspace"]
+    result = export_workspace(
+        slug="export-test-ws",
+        session=session,
+        storage=seeded["storage"],
+        output_path=tmp_path,
+    )
+
+    with zipfile.ZipFile(result) as zf:
+        manifest = json.loads(zf.read("manifest.json"))
+
+    assert manifest["schema_version"] == SCHEMA_VERSION
+    assert manifest["workspace"]["slug"] == ws.slug
+    assert manifest["workspace"]["id"] == str(ws.id)
+    assert manifest["page_count"] == 2
+    assert manifest["attachment_count"] == 1
+
+    att_record = manifest["attachments"][0]
+    assert att_record["hash"] == seeded["attachment"].hash
+    assert att_record["filename"] == "photo.png"
+
+
+def test_page_content_matches_current_revision(seeded, session, tmp_path):
+    page1 = seeded["pages"][0]
+    result = export_workspace(
+        slug="export-test-ws",
+        session=session,
+        storage=seeded["storage"],
+        output_path=tmp_path,
+    )
+
+    with zipfile.ZipFile(result) as zf:
+        content = zf.read(f"pages/{page1.id}.md").decode()
+
+    assert f"/pages/{seeded['pages'][1].id}" in content
+
+
+def test_all_revisions_are_included(seeded, session, tmp_path):
+    page1 = seeded["pages"][0]
+    result = export_workspace(
+        slug="export-test-ws",
+        session=session,
+        storage=seeded["storage"],
+        output_path=tmp_path,
+    )
+
+    with zipfile.ZipFile(result) as zf:
+        rev_files = [n for n in zf.namelist() if n.startswith(f"revisions/{page1.id}/")]
+
+    # page1 has three revisions (rev1a, rev1b, rev1c)
+    assert len(rev_files) == 3
+
+
+def test_links_json(seeded, session, tmp_path):
+    page1_id = str(seeded["pages"][0].id)
+    page2_id = str(seeded["pages"][1].id)
+
+    result = export_workspace(
+        slug="export-test-ws",
+        session=session,
+        storage=seeded["storage"],
+        output_path=tmp_path,
+    )
+
+    with zipfile.ZipFile(result) as zf:
+        links = json.loads(zf.read("links.json"))
+
+    internal = links["internal_links"]
+    assert len(internal) == 1
+    assert internal[0]["source_page_id"] == page1_id
+    assert internal[0]["target_page_id"] == page2_id
+
+    # page2 is linked to, so only page1 is orphaned (nothing links to it)
+    assert page2_id not in links["orphaned_pages"]
+    assert page1_id in links["orphaned_pages"]
+
+
+def test_attachment_hash_mismatch_raises(seeded, session, tmp_path):
+    att = seeded["attachment"]
+    bad_storage = FakeStorageAdapter({(str(att.id), "photo.png"): b"corrupted bytes"})
+
+    with pytest.raises(RuntimeError, match="Hash mismatch"):
+        export_workspace(
+            slug="export-test-ws",
+            session=session,
+            storage=bad_storage,
+            output_path=tmp_path,
+        )
+
+
+def test_missing_workspace_raises(session, tmp_path):
+    from freehold.storage import LocalFilesystemAdapter
+
+    storage = LocalFilesystemAdapter("/tmp")
+    with pytest.raises(ValueError, match="not found"):
+        export_workspace(
+            slug="no-such-workspace",
+            session=session,
+            storage=storage,
+            output_path=tmp_path,
+        )
+
+
+def test_output_filename_default(seeded, session, tmp_path):
+    result = export_workspace(
+        slug="export-test-ws",
+        session=session,
+        storage=seeded["storage"],
+        output_path=tmp_path,
+    )
+    assert result.name.startswith("freehold-export-export-test-ws-")
+    assert result.name.endswith(".zip")


### PR DESCRIPTION
Closes #9

## Summary

- Adds `freehold export --workspace <slug>` CLI command that produces a zip bundle matching the documented format
- Introduces `LocalFilesystemAdapter` (the first storage adapter implementation) and a `get_session()` database session factory as foundational infrastructure for future commands

## Bundle contents

```
freehold-export-{workspace-slug}-{timestamp}.zip
├── manifest.json        # workspace metadata, schema version, export timestamp, attachment hashes
├── pages/{page-id}.md   # current revision content for each page
├── assets/{id}{ext}     # attachment files (SHA-256 verified before inclusion)
├── revisions/{page-id}/{revision-id}.md  # full append-only revision history
└── links.json           # internal links, broken links, orphaned pages
```

## Test plan

- [x] `test_export_produces_zip` — command writes a `.zip` file with the workspace slug in its name
- [x] `test_zip_contains_expected_members` — all expected paths are present in the archive
- [x] `test_manifest_content` — schema version, workspace metadata, and attachment records are correct
- [x] `test_page_content_matches_current_revision` — page `.md` reflects the latest revision
- [x] `test_all_revisions_are_included` — every revision in the append-only history is exported
- [x] `test_links_json` — internal links are detected, orphaned pages identified correctly
- [x] `test_attachment_hash_mismatch_raises` — corrupted attachment data aborts with a clear `RuntimeError`
- [x] `test_missing_workspace_raises` — unknown workspace slug raises `ValueError`
- [x] `test_output_filename_default` — bundle name follows `freehold-export-{slug}-{timestamp}.zip` convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)