### PR TITLE
feat: implement restore CLI command

### DIFF
--- a/api/freehold/cli.py
+++ b/api/freehold/cli.py
@@ -50,5 +50,40 @@ def export(
         raise typer.Exit(1)
 
 
+@app.command()
+def restore(
+    bundle: Path = typer.Argument(..., help="Path to the export bundle zip file"),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="DATABASE_URL", help="PostgreSQL connection URL"
+    ),
+    storage_path: str | None = typer.Option(
+        None, "--storage-path", envvar="STORAGE_PATH", help="Path to attachment storage directory"
+    ),
+) -> None:
+    """Restore a workspace from an export bundle."""
+    load_dotenv()
+
+    import os
+
+    from .db import get_session
+    from .restore import restore_workspace
+    from .storage import LocalFilesystemAdapter
+
+    storage_root = storage_path or os.getenv("STORAGE_PATH", "/var/lib/freehold/attachments")
+    storage = LocalFilesystemAdapter(storage_root)
+
+    try:
+        with get_session(database_url) as session:
+            slug = restore_workspace(bundle, session, storage)
+            session.commit()
+        typer.echo(f"Restored workspace '{slug}'")
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
+    except (RuntimeError, FileNotFoundError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1)
+
+
 if __name__ == "__main__":
     app()

--- a/api/freehold/export.py
+++ b/api/freehold/export.py
@@ -76,6 +76,15 @@ def _build_manifest(
     attachment_records: list[dict],
     export_timestamp: str,
 ) -> dict:
+    spaces = workspace.spaces
+    collections = [c for s in spaces for c in s.collections]
+
+    revision_records = [
+        {"id": str(rev.id), "page_id": str(rev.page_id), "created_at": rev.created_at.isoformat()}
+        for page in pages
+        for rev in page.revisions
+    ]
+
     return {
         "schema_version": SCHEMA_VERSION,
         "export_timestamp": export_timestamp,
@@ -85,8 +94,40 @@ def _build_manifest(
             "name": workspace.name,
             "created_at": workspace.created_at.isoformat(),
         },
-        "page_count": len(pages),
-        "attachment_count": len(attachment_records),
+        "spaces": [
+            {
+                "id": str(s.id),
+                "workspace_id": str(s.workspace_id),
+                "slug": s.slug,
+                "name": s.name,
+                "created_at": s.created_at.isoformat(),
+            }
+            for s in spaces
+        ],
+        "collections": [
+            {
+                "id": str(c.id),
+                "space_id": str(c.space_id),
+                "slug": c.slug,
+                "name": c.name,
+                "created_at": c.created_at.isoformat(),
+            }
+            for c in collections
+        ],
+        "pages": [
+            {
+                "id": str(p.id),
+                "collection_id": str(p.collection_id),
+                "slug": p.slug,
+                "title": p.title,
+                "current_revision_id": (
+                    str(p.current_revision_id) if p.current_revision_id else None
+                ),
+                "created_at": p.created_at.isoformat(),
+            }
+            for p in pages
+        ],
+        "revisions": revision_records,
         "attachments": attachment_records,
     }
 
@@ -158,6 +199,7 @@ def export_workspace(
                     "filename": att.filename,
                     "hash": att.hash,
                     "size_bytes": att.size_bytes,
+                    "created_at": att.created_at.isoformat(),
                 }
             )
 

--- a/api/freehold/restore.py
+++ b/api/freehold/restore.py
@@ -1,0 +1,176 @@
+"""Restore a workspace from an export bundle.
+
+Usage:
+    freehold restore <bundle.zip>
+"""
+
+import hashlib
+import json
+import uuid
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from .export import SCHEMA_VERSION
+from .models import Attachment, Collection, Page, Revision, Space, Workspace
+from .storage import StorageAdapter
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _dt(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def restore_workspace(
+    bundle_path: Path,
+    session: Session,
+    storage: StorageAdapter,
+) -> str:
+    """Restore a workspace from *bundle_path* into *session*.
+
+    Returns the workspace slug on success. Raises on any validation failure.
+    The caller is responsible for committing the session.
+    """
+    if not zipfile.is_zipfile(bundle_path):
+        raise ValueError(f"Not a valid zip file: {bundle_path}")
+
+    with zipfile.ZipFile(bundle_path) as zf:
+        names = set(zf.namelist())
+        if "manifest.json" not in names:
+            raise ValueError(f"Not a valid Freehold bundle: manifest.json missing in {bundle_path}")
+
+        manifest = json.loads(zf.read("manifest.json"))
+
+        schema_version = manifest.get("schema_version")
+        if schema_version != SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported bundle schema version '{schema_version}' "
+                f"(expected '{SCHEMA_VERSION}')"
+            )
+
+        ws_meta = manifest["workspace"]
+        ws_id = uuid.UUID(ws_meta["id"])
+
+        # Duplicate checks — fail loudly rather than silently overwriting.
+        if session.get(Workspace, ws_id) is not None:
+            raise ValueError(
+                f"Workspace with id={ws_meta['id']} already exists. Delete it before restoring."
+            )
+        if session.query(Workspace).filter_by(slug=ws_meta["slug"]).first() is not None:
+            raise ValueError(
+                f"A workspace with slug '{ws_meta['slug']}' already exists. "
+                "Delete it before restoring."
+            )
+
+        # --- Workspace ---
+        session.add(
+            Workspace(
+                id=ws_id,
+                slug=ws_meta["slug"],
+                name=ws_meta["name"],
+                created_at=_dt(ws_meta["created_at"]),
+            )
+        )
+        session.flush()
+
+        # --- Spaces ---
+        for s in manifest["spaces"]:
+            session.add(
+                Space(
+                    id=uuid.UUID(s["id"]),
+                    workspace_id=uuid.UUID(s["workspace_id"]),
+                    slug=s["slug"],
+                    name=s["name"],
+                    created_at=_dt(s["created_at"]),
+                )
+            )
+        session.flush()
+
+        # --- Collections ---
+        for c in manifest["collections"]:
+            session.add(
+                Collection(
+                    id=uuid.UUID(c["id"]),
+                    space_id=uuid.UUID(c["space_id"]),
+                    slug=c["slug"],
+                    name=c["name"],
+                    created_at=_dt(c["created_at"]),
+                )
+            )
+        session.flush()
+
+        # --- Pages (current_revision_id set after revisions are inserted) ---
+        page_current_revisions: dict[uuid.UUID, uuid.UUID] = {}
+        for p in manifest["pages"]:
+            page_id = uuid.UUID(p["id"])
+            session.add(
+                Page(
+                    id=page_id,
+                    collection_id=uuid.UUID(p["collection_id"]),
+                    slug=p["slug"],
+                    title=p["title"],
+                    current_revision_id=None,
+                    created_at=_dt(p["created_at"]),
+                )
+            )
+            if p["current_revision_id"]:
+                page_current_revisions[page_id] = uuid.UUID(p["current_revision_id"])
+        session.flush()
+
+        # --- Revisions ---
+        for r in manifest["revisions"]:
+            rev_file = f"revisions/{r['page_id']}/{r['id']}.md"
+            if rev_file not in names:
+                raise ValueError(f"Bundle is missing revision file: {rev_file}")
+            content = zf.read(rev_file).decode()
+            session.add(
+                Revision(
+                    id=uuid.UUID(r["id"]),
+                    page_id=uuid.UUID(r["page_id"]),
+                    content=content,
+                    created_at=_dt(r["created_at"]),
+                )
+            )
+        session.flush()
+
+        # --- Wire up current_revision_id now that revisions exist ---
+        for page_id, rev_id in page_current_revisions.items():
+            page = session.get(Page, page_id)
+            page.current_revision_id = rev_id
+        session.flush()
+
+        # --- Attachments ---
+        for att in manifest["attachments"]:
+            att_id = att["id"]
+            ext = Path(att["filename"]).suffix
+            asset_file = f"assets/{att_id}{ext}"
+            if asset_file not in names:
+                raise ValueError(f"Bundle is missing asset file: {asset_file}")
+
+            data = zf.read(asset_file)
+            actual_hash = _sha256(data)
+            if actual_hash != att["hash"]:
+                raise RuntimeError(
+                    f"Hash mismatch for attachment {att_id} ({att['filename']}): "
+                    f"expected {att['hash']}, got {actual_hash}"
+                )
+
+            storage.write(att_id, att["filename"], data)
+            session.add(
+                Attachment(
+                    id=uuid.UUID(att_id),
+                    page_id=uuid.UUID(att["page_id"]),
+                    filename=att["filename"],
+                    hash=att["hash"],
+                    size_bytes=att["size_bytes"],
+                    created_at=_dt(att["created_at"]),
+                )
+            )
+        session.flush()
+
+    return ws_meta["slug"]

--- a/api/freehold/storage.py
+++ b/api/freehold/storage.py
@@ -11,9 +11,14 @@ class StorageAdapter(ABC):
         """Return the raw bytes for an attachment."""
         ...
 
+    @abstractmethod
+    def write(self, attachment_id: str, filename: str, data: bytes) -> None:
+        """Persist *data* for an attachment."""
+        ...
+
 
 class LocalFilesystemAdapter(StorageAdapter):
-    """Reads attachments from a local directory tree: <base>/<attachment_id>/<filename>."""
+    """Reads/writes attachments in a local directory tree: <base>/<attachment_id>/<filename>."""
 
     def __init__(self, base_path: str | Path) -> None:
         self.base_path = Path(base_path)
@@ -23,6 +28,11 @@ class LocalFilesystemAdapter(StorageAdapter):
         if not path.exists():
             raise FileNotFoundError(f"Attachment file not found: {path}")
         return path.read_bytes()
+
+    def write(self, attachment_id: str, filename: str, data: bytes) -> None:
+        path = self.base_path / attachment_id / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
 
 
 def get_default_adapter() -> StorageAdapter:

--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -26,15 +26,18 @@ DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localho
 
 
 class FakeStorageAdapter(StorageAdapter):
-    def __init__(self, files: dict[tuple[str, str], bytes]) -> None:
+    def __init__(self, files: dict[tuple[str, str], bytes] | None = None) -> None:
         # keys are (attachment_id, filename)
-        self._files = files
+        self._files: dict[tuple[str, str], bytes] = files or {}
 
     def read(self, attachment_id: str, filename: str) -> bytes:
         key = (attachment_id, filename)
         if key not in self._files:
             raise FileNotFoundError(f"No fake file for {key}")
         return self._files[key]
+
+    def write(self, attachment_id: str, filename: str, data: bytes) -> None:
+        self._files[(attachment_id, filename)] = data
 
 
 # ---------------------------------------------------------------------------
@@ -186,12 +189,17 @@ def test_manifest_content(seeded, session, tmp_path):
     assert manifest["schema_version"] == SCHEMA_VERSION
     assert manifest["workspace"]["slug"] == ws.slug
     assert manifest["workspace"]["id"] == str(ws.id)
-    assert manifest["page_count"] == 2
-    assert manifest["attachment_count"] == 1
+
+    assert len(manifest["spaces"]) == 1
+    assert len(manifest["collections"]) == 1
+    assert len(manifest["pages"]) == 2
+    assert len(manifest["revisions"]) == 4  # rev1a, rev1b, rev1c, rev2
+    assert len(manifest["attachments"]) == 1
 
     att_record = manifest["attachments"][0]
     assert att_record["hash"] == seeded["attachment"].hash
     assert att_record["filename"] == "photo.png"
+    assert "created_at" in att_record
 
 
 def test_page_content_matches_current_revision(seeded, session, tmp_path):

--- a/api/tests/test_restore.py
+++ b/api/tests/test_restore.py
@@ -1,0 +1,314 @@
+"""Integration tests for the restore command.
+
+Runs against a live PostgreSQL database. Each test uses hand-crafted bundles
+with unique UUIDs and rolls back its transaction so the DB stays clean.
+"""
+
+import hashlib
+import json
+import os
+import uuid
+import zipfile
+from datetime import datetime, timezone
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from freehold.export import SCHEMA_VERSION
+from freehold.models import Attachment, Page, Revision, Workspace
+from freehold.restore import restore_workspace
+from freehold.storage import StorageAdapter
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
+
+
+# ---------------------------------------------------------------------------
+# Fake storage adapter (in-memory)
+# ---------------------------------------------------------------------------
+
+
+class FakeStorageAdapter(StorageAdapter):
+    def __init__(self) -> None:
+        self._files: dict[tuple[str, str], bytes] = {}
+
+    def read(self, attachment_id: str, filename: str) -> bytes:
+        key = (attachment_id, filename)
+        if key not in self._files:
+            raise FileNotFoundError(f"No fake file for {key}")
+        return self._files[key]
+
+    def write(self, attachment_id: str, filename: str, data: bytes) -> None:
+        self._files[(attachment_id, filename)] = data
+
+    def has(self, attachment_id: str, filename: str) -> bool:
+        return (attachment_id, filename) in self._files
+
+
+# ---------------------------------------------------------------------------
+# Bundle builder helper
+# ---------------------------------------------------------------------------
+
+
+def _make_bundle(
+    *,
+    ws_id: uuid.UUID | None = None,
+    ws_slug: str = "test-ws",
+    ws_name: str = "Test Workspace",
+    with_attachment: bool = False,
+    attachment_data: bytes = b"attachment bytes",
+    corrupt_attachment: bool = False,
+    schema_version: str = SCHEMA_VERSION,
+    omit_manifest: bool = False,
+    omit_revision_file: bool = False,
+) -> tuple[Path, dict]:
+    """Return (bundle_path written to a tmp BytesIO, manifest dict)."""
+    now = datetime.now(timezone.utc).isoformat()
+
+    ws_id = ws_id or uuid.uuid4()
+    space_id = uuid.uuid4()
+    col_id = uuid.uuid4()
+    page_id = uuid.uuid4()
+    rev_id = uuid.uuid4()
+    att_id = uuid.uuid4()
+
+    att_hash = hashlib.sha256(attachment_data).hexdigest()
+
+    manifest: dict = {
+        "schema_version": schema_version,
+        "export_timestamp": now,
+        "workspace": {"id": str(ws_id), "slug": ws_slug, "name": ws_name, "created_at": now},
+        "spaces": [
+            {
+                "id": str(space_id),
+                "workspace_id": str(ws_id),
+                "slug": "sp",
+                "name": "Space",
+                "created_at": now,
+            }
+        ],
+        "collections": [
+            {
+                "id": str(col_id),
+                "space_id": str(space_id),
+                "slug": "col",
+                "name": "Col",
+                "created_at": now,
+            }
+        ],
+        "pages": [
+            {
+                "id": str(page_id),
+                "collection_id": str(col_id),
+                "slug": "pg",
+                "title": "Page",
+                "current_revision_id": str(rev_id),
+                "created_at": now,
+            }
+        ],
+        "revisions": [{"id": str(rev_id), "page_id": str(page_id), "created_at": now}],
+        "attachments": (
+            [
+                {
+                    "id": str(att_id),
+                    "page_id": str(page_id),
+                    "filename": "file.txt",
+                    "hash": att_hash,
+                    "size_bytes": len(attachment_data),
+                    "created_at": now,
+                }
+            ]
+            if with_attachment
+            else []
+        ),
+    }
+
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        if not omit_manifest:
+            zf.writestr("manifest.json", json.dumps(manifest))
+        if not omit_revision_file:
+            zf.writestr(f"revisions/{page_id}/{rev_id}.md", "# Page\nContent.")
+        zf.writestr(f"pages/{page_id}.md", "# Page\nContent.")
+        zf.writestr(
+            "links.json",
+            json.dumps(
+                {"internal_links": [], "broken_links": [], "orphaned_pages": [str(page_id)]}
+            ),
+        )
+        if with_attachment:
+            asset_bytes = b"corrupted" if corrupt_attachment else attachment_data
+            zf.writestr(f"assets/{att_id}.txt", asset_bytes)
+
+    return buf.getvalue(), manifest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def engine():
+    eng = create_engine(DATABASE_URL)
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def session(engine):
+    with Session(engine) as s:
+        yield s
+        s.rollback()
+
+
+@pytest.fixture
+def storage():
+    return FakeStorageAdapter()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _write_bundle(tmp_path: Path, bundle_bytes: bytes, name: str = "bundle.zip") -> Path:
+    p = tmp_path / name
+    p.write_bytes(bundle_bytes)
+    return p
+
+
+def test_restore_creates_workspace(session, storage, tmp_path):
+    bundle_bytes, manifest = _make_bundle(ws_slug="restore-creates-ws")
+    path = _write_bundle(tmp_path, bundle_bytes)
+
+    slug = restore_workspace(path, session, storage)
+
+    assert slug == "restore-creates-ws"
+    ws = session.query(Workspace).filter_by(slug="restore-creates-ws").first()
+    assert ws is not None
+    assert str(ws.id) == manifest["workspace"]["id"]
+
+
+def test_restore_preserves_full_hierarchy(session, storage, tmp_path):
+    bundle_bytes, manifest = _make_bundle(ws_slug="restore-hierarchy-ws")
+    path = _write_bundle(tmp_path, bundle_bytes)
+
+    restore_workspace(path, session, storage)
+
+    ws = session.query(Workspace).filter_by(slug="restore-hierarchy-ws").first()
+    assert len(ws.spaces) == 1
+    space = ws.spaces[0]
+    assert str(space.id) == manifest["spaces"][0]["id"]
+    assert len(space.collections) == 1
+    col = space.collections[0]
+    assert str(col.id) == manifest["collections"][0]["id"]
+    assert len(col.pages) == 1
+    page = col.pages[0]
+    assert str(page.id) == manifest["pages"][0]["id"]
+    assert len(page.revisions) == 1
+    assert str(page.current_revision_id) == manifest["pages"][0]["current_revision_id"]
+
+
+def test_restore_preserves_page_content(session, storage, tmp_path):
+    bundle_bytes, manifest = _make_bundle(ws_slug="restore-content-ws")
+    path = _write_bundle(tmp_path, bundle_bytes)
+
+    restore_workspace(path, session, storage)
+
+    page_id = manifest["pages"][0]["id"]
+    rev_id = manifest["revisions"][0]["id"]
+    page = session.get(Page, uuid.UUID(page_id))
+    rev = session.get(Revision, uuid.UUID(rev_id))
+    assert rev is not None
+    assert rev.content == "# Page\nContent."
+    assert str(page.current_revision_id) == rev_id
+
+
+def test_restore_with_attachment(session, storage, tmp_path):
+    att_data = b"hello attachment"
+    bundle_bytes, manifest = _make_bundle(
+        ws_slug="restore-att-ws", with_attachment=True, attachment_data=att_data
+    )
+    path = _write_bundle(tmp_path, bundle_bytes)
+
+    restore_workspace(path, session, storage)
+
+    att_meta = manifest["attachments"][0]
+    att = session.get(Attachment, uuid.UUID(att_meta["id"]))
+    assert att is not None
+    assert att.hash == att_meta["hash"]
+    assert att.size_bytes == len(att_data)
+    assert storage.has(att_meta["id"], "file.txt")
+    assert storage._files[(att_meta["id"], "file.txt")] == att_data
+
+
+def test_restore_verifies_attachment_hash(session, storage, tmp_path):
+    bundle_bytes, _ = _make_bundle(
+        ws_slug="restore-hash-ws", with_attachment=True, corrupt_attachment=True
+    )
+    path = _write_bundle(tmp_path, bundle_bytes)
+
+    with pytest.raises(RuntimeError, match="Hash mismatch"):
+        restore_workspace(path, session, storage)
+
+
+def test_restore_duplicate_id_raises(session, storage, tmp_path):
+    ws_id = uuid.uuid4()
+    bundle_bytes, _ = _make_bundle(ws_id=ws_id, ws_slug="restore-dup-id-ws")
+    path = _write_bundle(tmp_path, bundle_bytes)
+
+    restore_workspace(path, session, storage)
+
+    # Second restore with same ID.
+    bundle_bytes2, _ = _make_bundle(ws_id=ws_id, ws_slug="restore-dup-id-ws-2")
+    path2 = _write_bundle(tmp_path, bundle_bytes2, name="bundle2.zip")
+    with pytest.raises(ValueError, match="already exists"):
+        restore_workspace(path2, session, storage)
+
+
+def test_restore_duplicate_slug_raises(session, storage, tmp_path):
+    bundle_bytes, _ = _make_bundle(ws_slug="restore-dup-slug-ws")
+    path = _write_bundle(tmp_path, bundle_bytes)
+
+    restore_workspace(path, session, storage)
+
+    # Second restore with same slug but different ID.
+    bundle_bytes2, _ = _make_bundle(ws_slug="restore-dup-slug-ws")
+    path2 = _write_bundle(tmp_path, bundle_bytes2, name="bundle2.zip")
+    with pytest.raises(ValueError, match="already exists"):
+        restore_workspace(path2, session, storage)
+
+
+def test_restore_missing_manifest_raises(session, storage, tmp_path):
+    bundle_bytes, _ = _make_bundle(ws_slug="restore-no-manifest-ws", omit_manifest=True)
+    path = _write_bundle(tmp_path, bundle_bytes)
+
+    with pytest.raises(ValueError, match="manifest.json missing"):
+        restore_workspace(path, session, storage)
+
+
+def test_restore_unsupported_schema_version_raises(session, storage, tmp_path):
+    bundle_bytes, _ = _make_bundle(ws_slug="restore-bad-version-ws", schema_version="99")
+    path = _write_bundle(tmp_path, bundle_bytes)
+
+    with pytest.raises(ValueError, match="Unsupported bundle schema version"):
+        restore_workspace(path, session, storage)
+
+
+def test_restore_missing_revision_file_raises(session, storage, tmp_path):
+    bundle_bytes, _ = _make_bundle(ws_slug="restore-missing-rev-ws", omit_revision_file=True)
+    path = _write_bundle(tmp_path, bundle_bytes)
+
+    with pytest.raises(ValueError, match="missing revision file"):
+        restore_workspace(path, session, storage)
+
+
+def test_restore_not_a_zip_raises(session, storage, tmp_path):
+    path = tmp_path / "notazip.zip"
+    path.write_bytes(b"this is not a zip")
+
+    with pytest.raises(ValueError, match="Not a valid zip"):
+        restore_workspace(path, session, storage)


### PR DESCRIPTION
Closes #10

## Summary

- Adds `freehold restore <bundle.zip>` which rehydrates a workspace from an export bundle into a fresh database, preserving all original IDs and timestamps
- Expands the export manifest to include the full hierarchy (spaces, collections, pages, revisions metadata) needed for restore — this is a breaking change to the bundle format but we're pre-release
- Adds `write()` to the `StorageAdapter` interface and `LocalFilesystemAdapter`

## Acceptance criteria

- [x] All pages, revisions, and attachments are restored with original IDs and metadata intact
- [x] Asset hashes are verified on restore — mismatch causes the command to fail loudly with a clear error message
- [x] Running restore twice on the same bundle is handled gracefully — fails with a clear error on duplicate workspace ID or slug

## Test plan

- [x] `test_restore_creates_workspace` — workspace is present in DB with the original ID after restore
- [x] `test_restore_preserves_full_hierarchy` — spaces, collections, pages, and revisions all restored with original IDs
- [x] `test_restore_preserves_page_content` — revision content matches the `.md` file; `current_revision_id` is wired correctly
- [x] `test_restore_with_attachment` — attachment record is created in DB and bytes are written to storage
- [x] `test_restore_verifies_attachment_hash` — corrupt asset file aborts with `RuntimeError`
- [x] `test_restore_duplicate_id_raises` — second restore with same workspace ID fails with a clear error
- [x] `test_restore_duplicate_slug_raises` — second restore with same workspace slug fails with a clear error
- [x] `test_restore_missing_manifest_raises` — bundle without `manifest.json` fails with `ValueError`
- [x] `test_restore_unsupported_schema_version_raises` — unknown schema version fails with `ValueError`
- [x] `test_restore_missing_revision_file_raises` — manifest references a revision file not in the zip, fails with `ValueError`
- [x] `test_restore_not_a_zip_raises` — non-zip file fails with `ValueError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)