### PR TITLE
fix: prevent BlockNote SSR crash (window is not defined)

### DIFF
--- a/web/app/w/[workspaceId]/pages/[pageId]/page.tsx
+++ b/web/app/w/[workspaceId]/pages/[pageId]/page.tsx
@@ -1,5 +1,5 @@
 import { getPage } from "@/lib/api";
-import { PageEditor } from "@/components/page-editor";
+import { PageEditorLoader } from "@/components/page-editor-loader";
 
 interface Props {
   params: Promise<{ workspaceId: string; pageId: string }>;
@@ -9,5 +9,5 @@ export default async function PageRoute({ params }: Props) {
   const { pageId } = await params;
   const page = await getPage(pageId);
 
-  return <PageEditor initialPage={page} />;
+  return <PageEditorLoader initialPage={page} />;
 }

--- a/web/components/page-editor-loader.tsx
+++ b/web/components/page-editor-loader.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { Page } from "@/lib/types";
+
+const PageEditor = dynamic(
+  () => import("@/components/page-editor").then((m) => m.PageEditor),
+  { ssr: false }
+);
+
+export function PageEditorLoader({ initialPage }: { initialPage: Page }) {
+  return <PageEditor initialPage={initialPage} />;
+}


### PR DESCRIPTION
## Summary
- Added `page-editor-loader.tsx` — a thin client wrapper that uses `next/dynamic` with `ssr: false` to lazy-load `PageEditor`
- `useCreateBlockNote()` accesses `window` at module level, which crashes during server-side rendering in Next.js 16

Closes #29

## Test plan
- [x] Navigate to a page in the editor — no runtime error
- [x] Editor loads and content is editable
- [x] Auto-save, revision history, and attachments still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)