### PR TITLE
feat: add organizations and role-based access control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,12 +122,14 @@ freehold/
 │   │   └── versions/
 │   │       ├── 69d839126d73_create_core_schema.py
 │   │       ├── d3981f696939_add_full_text_search.py
-│   │       └── 35eb203afc65_add_users_table.py
+│   │       ├── 35eb203afc65_add_users_table.py
+│   │       └── 0999ffe7b838_add_organizations_and_rbac.py
 │   ├── freehold/                     # Main package
 │   │   ├── app.py                    # FastAPI app factory, CORS + session middleware
 │   │   ├── auth.py                   # OIDC config, session JWT helpers, cookie params
 │   │   ├── db.py                     # SQLAlchemy session management
 │   │   ├── dependencies.py           # FastAPI dependency providers (auth, db session, search)
+│   │   ├── rbac.py                   # Role-based access control dependency factories
 │   │   ├── models.py                 # SQLAlchemy ORM models (incl. User)
 │   │   ├── schemas.py                # Pydantic request/response schemas (incl. AuthStatus)
 │   │   ├── search.py                 # SearchBackend ABC + PostgresSearchBackend
@@ -136,7 +138,8 @@ freehold/
 │   │   ├── restore.py                # Restore workspace ← zip bundle
 │   │   ├── cli.py                    # Typer CLI (export, restore commands)
 │   │   └── routers/
-│   │       ├── auth.py               # OIDC login/callback/me/logout (no auth required)
+│   │       ├── auth.py               # OIDC login/callback/me/logout + personal org creation
+│   │       ├── organizations.py      # Org CRUD, member management (invite, role, remove)
 │   │       ├── workspaces.py
 │   │       ├── spaces.py
 │   │       ├── collections.py
@@ -146,6 +149,7 @@ freehold/
 │   │   ├── test_models_smoke.py
 │   │   ├── test_migration_cycle.py
 │   │   ├── test_auth.py              # Auth dependency, JWT, and auth router tests
+│   │   ├── test_rbac.py              # Role enforcement matrix (owner/editor/viewer × CRUD)
 │   │   ├── test_export.py
 │   │   ├── test_restore.py
 │   │   ├── test_round_trip.py        # Critical regression anchor
@@ -159,6 +163,7 @@ freehold/
 │   │   ├── layout.tsx                # Root layout with theme provider
 │   │   ├── login/page.tsx            # SSO login page (shown when OIDC enabled)
 │   │   ├── auth/callback/page.tsx    # Post-OIDC callback landing page
+│   │   ├── orgs/[orgId]/settings/page.tsx  # Org member management UI
 │   │   ├── workspaces/page.tsx       # Workspace list + creation
 │   │   └── w/[workspaceId]/
 │   │       ├── layout.tsx            # Workspace shell with sidebar + auth status
@@ -189,18 +194,21 @@ freehold/
 ### Data Model
 
 ```text
-workspaces → spaces → collections → pages → blocks (future)
-                                          → attachments
-                                 → revisions  (append-only, every save)
-                       audit_events (future)
-                       tasks / task_integrations (future)
+organizations → org_memberships (user roles: owner/editor/viewer)
+             → workspaces → spaces → collections → pages → blocks (future)
+                                                         → attachments
+                                                → revisions  (append-only, every save)
+                              audit_events (future)
+                              tasks / task_integrations (future)
 ```
 
 **Tables** (all use UUIDs, timezone-aware timestamps):
 
 | Table | Key columns |
 | --- | --- |
-| workspaces | id, slug (unique), name |
+| organizations | id, slug (unique), name |
+| org_memberships | id, org_id (FK), user_id (FK, nullable for pending), email, role (owner/editor/viewer) |
+| workspaces | id, org_id (FK), slug (unique), name |
 | spaces | id, workspace_id (FK cascade), slug (unique per workspace), name |
 | collections | id, space_id (FK cascade), slug (unique per space), name |
 | pages | id, collection_id (FK cascade), slug (unique per collection), title, current_revision_id (deferred FK), search_vector (tsvector, GIN-indexed, trigger-managed) |
@@ -208,7 +216,7 @@ workspaces → spaces → collections → pages → blocks (future)
 | attachments | id, page_id (FK cascade), filename, hash (SHA256), size_bytes |
 | users | id, oidc_issuer, oidc_subject (unique together), email, name, last_login_at |
 
-**Revision immutability**: A PL/pgSQL trigger (`revisions_immutable()`) raises an exception on any `UPDATE` or `DELETE` against the `revisions` table. This enforces the constraint at the database level, not just the application level.
+**Revision immutability**: A PL/pgSQL trigger (`revisions_immutable()`) raises an exception on any `UPDATE` against the `revisions` table. This enforces the append-only constraint at the database level. `DELETE` is allowed via FK CASCADE (e.g., when a page or workspace is deleted).
 
 **Deferred FK**: `pages.current_revision_id → revisions.id` is a deferred constraint, allowing page and first revision to be created in a single transaction.
 
@@ -216,30 +224,36 @@ workspaces → spaces → collections → pages → blocks (future)
 
 All routes are prefixed with `/api`. Authentication is enforced via session cookie (OIDC), `X-API-Key` header, or anonymous access (when neither is configured). Auth routes are unauthenticated.
 
-| Method | Path | Description |
-| --- | --- | --- |
-| GET | /health | Health check |
-| GET | /api/auth/login | Redirect to OIDC provider |
-| GET | /api/auth/callback | OIDC callback — exchanges code, sets session cookie |
-| GET | /api/auth/me | Current auth status and user info |
-| POST | /api/auth/logout | Clear session cookie |
-| GET/POST | /api/workspaces/ | List / create workspaces |
-| GET/DELETE | /api/workspaces/{id} | Get / delete workspace |
-| GET | /api/workspaces/{id}/tree | Full hierarchy (sidebar) |
-| GET | /api/workspaces/{id}/search?q= | Full-text search across workspace pages |
-| GET/POST | /api/workspaces/{id}/spaces/ | List / create spaces |
-| GET/DELETE | /api/workspaces/{id}/spaces/{sid} | Get / delete space |
-| GET/POST | /api/spaces/{sid}/collections/ | List / create collections |
-| GET/DELETE | /api/spaces/{sid}/collections/{cid} | Get / delete collection |
-| GET/POST | /api/collections/{cid}/pages/ | List / create pages |
-| GET/PATCH/DELETE | /api/collections/{cid}/pages/{pid} | Get / update / delete page |
-| GET | /api/collections/{cid}/pages/{pid}/revisions | List revisions |
-| GET | /api/collections/{cid}/pages/{pid}/revisions/{rid} | Single revision |
-| GET/POST | /api/collections/{cid}/pages/{pid}/attachments | List / upload attachments |
-| GET | /api/collections/{cid}/pages/{pid}/attachments/{aid}/file | Download attachment |
-| GET/PATCH | /api/pages/{pid} | Global page get / update (no collection_id needed) |
-| GET | /api/pages/{pid}/revisions | Global revision list |
-| GET | /api/pages/{pid}/revisions/{rid} | Global single revision |
+| Method | Path | Description | Min Role |
+| --- | --- | --- | --- |
+| GET | /health | Health check | — |
+| GET | /api/auth/login | Redirect to OIDC provider | — |
+| GET | /api/auth/callback | OIDC callback — exchanges code, sets session cookie, claims pending memberships | — |
+| GET | /api/auth/me | Current auth status and user info | — |
+| POST | /api/auth/logout | Clear session cookie | — |
+| GET/POST | /api/orgs | List user's orgs / create org | session |
+| GET | /api/orgs/{oid} | Get org details | viewer |
+| GET | /api/orgs/{oid}/members | List members (incl. pending) | viewer |
+| POST | /api/orgs/{oid}/members | Invite member by email | owner |
+| PATCH | /api/orgs/{oid}/members/{mid} | Change member role | owner |
+| DELETE | /api/orgs/{oid}/members/{mid} | Remove member | owner |
+| GET/POST | /api/workspaces/ | List / create workspaces | viewer/editor |
+| GET/DELETE | /api/workspaces/{id} | Get / delete workspace | viewer/owner |
+| GET | /api/workspaces/{id}/tree | Full hierarchy (sidebar) | viewer |
+| GET | /api/workspaces/{id}/search?q= | Full-text search across workspace pages | viewer |
+| GET/POST | /api/workspaces/{id}/spaces/ | List / create spaces | viewer/editor |
+| GET/DELETE | /api/workspaces/{id}/spaces/{sid} | Get / delete space | viewer/owner |
+| GET/POST | /api/spaces/{sid}/collections/ | List / create collections | viewer/editor |
+| GET/DELETE | /api/spaces/{sid}/collections/{cid} | Get / delete collection | viewer/owner |
+| GET/POST | /api/collections/{cid}/pages/ | List / create pages | viewer/editor |
+| GET/PATCH/DELETE | /api/collections/{cid}/pages/{pid} | Get / update / delete page | viewer/editor/owner |
+| GET | /api/collections/{cid}/pages/{pid}/revisions | List revisions | viewer |
+| GET | /api/collections/{cid}/pages/{pid}/revisions/{rid} | Single revision | viewer |
+| GET/POST | /api/collections/{cid}/pages/{pid}/attachments | List / upload attachments | viewer/editor |
+| GET | /api/collections/{cid}/pages/{pid}/attachments/{aid}/file | Download attachment | viewer |
+| GET/PATCH | /api/pages/{pid} | Global page get / update (no collection_id needed) | viewer/editor |
+| GET | /api/pages/{pid}/revisions | Global revision list | viewer |
+| GET | /api/pages/{pid}/revisions/{rid} | Global single revision | viewer |
 
 ### Storage Adapter Interface
 
@@ -255,7 +269,7 @@ class StorageAdapter(ABC):
 
 ```
 freehold-export-{workspace-slug}-{timestamp}.zip
-├── manifest.json        # workspace metadata, all entity IDs, schema version
+├── manifest.json        # workspace + org metadata, all entity IDs, schema version (v2)
 ├── pages/
 │   └── {page-id}.md     # current content of each page
 ├── revisions/
@@ -271,12 +285,14 @@ freehold-export-{workspace-slug}-{timestamp}.zip
 Freehold supports three authentication methods, checked in priority order:
 
 1. **OIDC session cookie** (`freehold_session`): A JWT signed with `SECRET_KEY` (HS256), issued after successful OIDC login. Contains `sub` (user UUID), `email`, `name`, with 24h expiry.
-2. **API key** (`X-API-Key` header): Static key matching `API_KEY` env var. Used by CLI and scripts.
-3. **Anonymous**: When neither OIDC nor API key is configured, all requests are allowed (dev mode).
+2. **API key** (`X-API-Key` header): Static key matching `API_KEY` env var. Used by CLI and scripts. **Bypasses all RBAC checks** (superuser equivalent).
+3. **Anonymous**: When neither OIDC nor API key is configured, all requests are allowed (dev mode). **Bypasses all RBAC checks**.
 
-**OIDC flow**: The backend is the OIDC Relying Party. `GET /api/auth/login` redirects to the IdP. `GET /api/auth/callback` exchanges the code, upserts the user in the `users` table, and sets an httpOnly session cookie. The `COOKIE_DOMAIN` env var controls the cookie domain (set to `localhost` for dev so the cookie is shared between `:3000` and `:8000`).
+**OIDC flow**: The backend is the OIDC Relying Party. `GET /api/auth/login` redirects to the IdP. `GET /api/auth/callback` exchanges the code, upserts the user in the `users` table, claims any pending org memberships matching the user's email, auto-creates a personal org if the user has no memberships, and sets an httpOnly session cookie. The `COOKIE_DOMAIN` env var controls the cookie domain (set to `localhost` for dev so the cookie is shared between `:3000` and `:8000`).
 
-**Key files**: `auth.py` (config, JWT helpers), `dependencies.py` (`verify_auth` + `AuthContext`), `routers/auth.py` (login/callback/me/logout).
+**RBAC**: Org membership with roles (owner/editor/viewer) enforced on all data routes. Role is resolved by following the resource chain (page → collection → space → workspace → org → membership). Dependency factories in `rbac.py` handle resolution for each resource level.
+
+**Key files**: `auth.py` (config, JWT helpers), `dependencies.py` (`verify_auth` + `AuthContext`), `rbac.py` (role enforcement dependencies), `routers/auth.py` (login/callback/me/logout), `routers/organizations.py` (org CRUD + member management).
 
 ### Frontend Patterns
 

--- a/api/alembic/versions/0999ffe7b838_add_organizations_and_rbac.py
+++ b/api/alembic/versions/0999ffe7b838_add_organizations_and_rbac.py
@@ -1,0 +1,133 @@
+"""add organizations and rbac
+
+Revision ID: 0999ffe7b838
+Revises: 35eb203afc65
+Create Date: 2026-04-05
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0999ffe7b838"
+down_revision: Union[str, Sequence[str], None] = "35eb203afc65"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add organizations, org_memberships tables and workspaces.org_id FK."""
+
+    # --- organizations ---
+    op.create_table(
+        "organizations",
+        sa.Column(
+            "id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False
+        ),
+        sa.Column("slug", sa.Text(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug"),
+    )
+
+    # --- org_memberships ---
+    op.create_table(
+        "org_memberships",
+        sa.Column(
+            "id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False
+        ),
+        sa.Column("org_id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=True),  # NULL = pending invite
+        sa.Column("email", sa.Text(), nullable=False),
+        sa.Column("role", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["org_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.CheckConstraint(
+            "role IN ('owner', 'editor', 'viewer')", name="ck_org_memberships_role"
+        ),
+    )
+
+    # Partial unique indexes: one active membership per user per org,
+    # one pending invite per email per org.
+    op.execute(
+        "CREATE UNIQUE INDEX uq_org_memberships_org_user "
+        "ON org_memberships (org_id, user_id) WHERE user_id IS NOT NULL"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX uq_org_memberships_org_email_pending "
+        "ON org_memberships (org_id, email) WHERE user_id IS NULL"
+    )
+
+    # --- workspaces.org_id (nullable first, then backfill, then NOT NULL) ---
+    op.add_column("workspaces", sa.Column("org_id", sa.UUID(), nullable=True))
+
+    # Backfill: create a default org and assign all existing workspaces to it.
+    # Also make all existing users owners of the default org.
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            default_org_id UUID;
+        BEGIN
+            -- Only backfill if there are existing workspaces
+            IF EXISTS (SELECT 1 FROM workspaces LIMIT 1) THEN
+                INSERT INTO organizations (slug, name)
+                VALUES ('default', 'Default Organization')
+                RETURNING id INTO default_org_id;
+
+                UPDATE workspaces SET org_id = default_org_id WHERE org_id IS NULL;
+
+                -- Make all existing users owners of the default org
+                INSERT INTO org_memberships (org_id, user_id, email, role)
+                SELECT default_org_id, u.id, u.email, 'owner'
+                FROM users u;
+            END IF;
+        END $$;
+        """
+    )
+
+    # Drop the revisions_no_delete trigger — it blocks FK CASCADE deletes
+    # from parent tables (workspace/page deletion). The UPDATE trigger still
+    # enforces append-only semantics for revision content.
+    op.execute("DROP TRIGGER IF EXISTS revisions_no_delete ON revisions")
+
+    op.alter_column("workspaces", "org_id", nullable=False)
+    op.create_foreign_key(
+        "fk_workspaces_org_id",
+        "workspaces",
+        "organizations",
+        ["org_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    """Remove organizations, org_memberships, and workspaces.org_id."""
+    # Restore the revisions delete trigger
+    op.execute(
+        "CREATE TRIGGER revisions_no_delete "
+        "BEFORE DELETE ON revisions "
+        "FOR EACH ROW EXECUTE FUNCTION revisions_immutable()"
+    )
+    op.drop_constraint("fk_workspaces_org_id", "workspaces", type_="foreignkey")
+    op.drop_column("workspaces", "org_id")
+    op.drop_table("org_memberships")
+    op.drop_table("organizations")

--- a/api/freehold/app.py
+++ b/api/freehold/app.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from .dependencies import verify_auth
-from .routers import auth, collections, pages, pages_global, spaces, workspaces
+from .routers import auth, collections, organizations, pages, pages_global, spaces, workspaces
 
 # Allow the origin list to be overridden via env var for non-local deployments.
 _cors_origins = os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
@@ -34,6 +34,7 @@ app.include_router(auth.router)
 # All other routers require authentication.
 _auth = [Depends(verify_auth)]
 
+app.include_router(organizations.router, dependencies=_auth)
 app.include_router(workspaces.router, dependencies=_auth)
 app.include_router(spaces.router, dependencies=_auth)
 app.include_router(collections.router, dependencies=_auth)

--- a/api/freehold/auth.py
+++ b/api/freehold/auth.py
@@ -86,6 +86,8 @@ def create_session_jwt(
     user_id: uuid.UUID,
     email: str,
     name: str,
+    *,
+    oidc_id_token: str | None = None,
 ) -> str:
     """Create a session JWT for the given user."""
     config = get_oidc_config()
@@ -97,6 +99,8 @@ def create_session_jwt(
         "iat": int(now.timestamp()),
         "exp": int(now.timestamp()) + config.session_max_age,
     }
+    if oidc_id_token:
+        payload["oidc_id_token"] = oidc_id_token
     return jwt.encode(payload, config.secret_key, algorithm=_JWT_ALGORITHM)
 
 

--- a/api/freehold/auth.py
+++ b/api/freehold/auth.py
@@ -44,9 +44,7 @@ def get_oidc_config() -> OIDCConfig:
             issuer=os.getenv("OIDC_ISSUER") or None,
             client_id=os.getenv("OIDC_CLIENT_ID", ""),
             client_secret=os.getenv("OIDC_CLIENT_SECRET", ""),
-            redirect_uri=os.getenv(
-                "OIDC_REDIRECT_URI", "http://localhost:8000/api/auth/callback"
-            ),
+            redirect_uri=os.getenv("OIDC_REDIRECT_URI", "http://localhost:8000/api/auth/callback"),
             frontend_url=os.getenv("FRONTEND_URL", "http://localhost:3000"),
             cookie_domain=os.getenv("COOKIE_DOMAIN") or None,
             secret_key=os.getenv("SECRET_KEY", "changeme"),

--- a/api/freehold/dependencies.py
+++ b/api/freehold/dependencies.py
@@ -26,6 +26,7 @@ load_dotenv()
 # Database
 # ---------------------------------------------------------------------------
 
+
 def _require_database_url() -> str:
     url = os.getenv("DATABASE_URL")
     if not url:

--- a/api/freehold/export.py
+++ b/api/freehold/export.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import Session
 from .models import Attachment, Page, Workspace
 from .storage import StorageAdapter
 
-SCHEMA_VERSION = "1"
+SCHEMA_VERSION = "2"
 
 
 def _sha256(data: bytes) -> str:
@@ -85,11 +85,19 @@ def _build_manifest(
         for rev in page.revisions
     ]
 
+    org = workspace.organization
     return {
         "schema_version": SCHEMA_VERSION,
         "export_timestamp": export_timestamp,
+        "organization": {
+            "id": str(org.id),
+            "slug": org.slug,
+            "name": org.name,
+            "created_at": org.created_at.isoformat(),
+        },
         "workspace": {
             "id": str(workspace.id),
+            "org_id": str(workspace.org_id),
             "slug": workspace.slug,
             "name": workspace.name,
             "created_at": workspace.created_at.isoformat(),

--- a/api/freehold/models.py
+++ b/api/freehold/models.py
@@ -7,6 +7,7 @@ These models mirror the Alembic migration exactly, including:
 - attachments.hash NOT NULL
 """
 
+import enum
 import uuid
 from datetime import datetime
 
@@ -26,8 +27,14 @@ class Base(DeclarativeBase):
     pass
 
 
-class Workspace(Base):
-    __tablename__ = "workspaces"
+class OrgRole(str, enum.Enum):
+    OWNER = "owner"
+    EDITOR = "editor"
+    VIEWER = "viewer"
+
+
+class Organization(Base):
+    __tablename__ = "organizations"
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
@@ -38,7 +45,61 @@ class Workspace(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
 
-    spaces: Mapped[list["Space"]] = relationship(back_populates="workspace")
+    memberships: Mapped[list["OrgMembership"]] = relationship(
+        back_populates="organization", passive_deletes=True
+    )
+    workspaces: Mapped[list["Workspace"]] = relationship(
+        back_populates="organization", passive_deletes=True
+    )
+
+
+class OrgMembership(Base):
+    __tablename__ = "org_memberships"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    email: Mapped[str] = mapped_column(Text, nullable=False)
+    role: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(["org_id"], ["organizations.id"], ondelete="CASCADE"),
+        ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+
+    organization: Mapped["Organization"] = relationship(back_populates="memberships")
+    user: Mapped["User | None"] = relationship(back_populates="memberships")
+
+
+class Workspace(Base):
+    __tablename__ = "workspaces"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    slug: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["org_id"],
+            ["organizations.id"],
+            name="fk_workspaces_org_id",
+            ondelete="CASCADE",
+        ),
+    )
+
+    organization: Mapped["Organization"] = relationship(back_populates="workspaces")
+    spaces: Mapped[list["Space"]] = relationship(back_populates="workspace", passive_deletes=True)
 
 
 class Space(Base):
@@ -60,7 +121,9 @@ class Space(Base):
     )
 
     workspace: Mapped["Workspace"] = relationship(back_populates="spaces")
-    collections: Mapped[list["Collection"]] = relationship(back_populates="space")
+    collections: Mapped[list["Collection"]] = relationship(
+        back_populates="space", passive_deletes=True
+    )
 
 
 class Collection(Base):
@@ -82,7 +145,7 @@ class Collection(Base):
     )
 
     space: Mapped["Space"] = relationship(back_populates="collections")
-    pages: Mapped[list["Page"]] = relationship(back_populates="collection")
+    pages: Mapped[list["Page"]] = relationship(back_populates="collection", passive_deletes=True)
 
 
 class Page(Base):
@@ -124,8 +187,11 @@ class Page(Base):
         back_populates="page",
         foreign_keys="[Revision.page_id]",
         order_by="Revision.created_at",
+        passive_deletes=True,
     )
-    attachments: Mapped[list["Attachment"]] = relationship(back_populates="page")
+    attachments: Mapped[list["Attachment"]] = relationship(
+        back_populates="page", passive_deletes=True
+    )
 
 
 class Revision(Base):
@@ -184,3 +250,5 @@ class User(Base):
     )
 
     __table_args__ = (UniqueConstraint("oidc_issuer", "oidc_subject"),)
+
+    memberships: Mapped[list["OrgMembership"]] = relationship(back_populates="user")

--- a/api/freehold/rbac.py
+++ b/api/freehold/rbac.py
@@ -1,0 +1,146 @@
+"""Role-based access control dependencies for Freehold.
+
+Provides dependency factories that enforce org membership and role requirements
+on API routes. API key and anonymous auth bypass all role checks for backward
+compatibility.
+"""
+
+import uuid
+
+from fastapi import Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .dependencies import AuthContext, get_db, verify_auth
+from .models import (
+    Collection,
+    OrgMembership,
+    OrgRole,
+    Page,
+    Space,
+    Workspace,
+)
+
+ROLE_HIERARCHY: dict[OrgRole, int] = {
+    OrgRole.VIEWER: 0,
+    OrgRole.EDITOR: 1,
+    OrgRole.OWNER: 2,
+}
+
+
+def _check_membership(db: Session, org_id: uuid.UUID, auth: AuthContext, min_role: OrgRole) -> None:
+    """Raise 403 if the session user lacks the required role on the org."""
+    if auth.method in ("api_key", "anonymous"):
+        return
+
+    membership = db.execute(
+        select(OrgMembership.role).where(
+            OrgMembership.org_id == org_id,
+            OrgMembership.user_id == auth.user_id,
+        )
+    ).scalar_one_or_none()
+
+    if membership is None:
+        raise HTTPException(403, "Not a member of this organization")
+
+    if ROLE_HIERARCHY[OrgRole(membership)] < ROLE_HIERARCHY[min_role]:
+        raise HTTPException(403, f"Requires {min_role.value} role or higher")
+
+
+def require_org_role(min_role: OrgRole):
+    """Dependency factory: enforce role on org_id path param."""
+
+    def _dep(
+        org_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        auth: AuthContext = Depends(verify_auth),
+    ) -> AuthContext:
+        _check_membership(db, org_id, auth, min_role)
+        return auth
+
+    return _dep
+
+
+def require_workspace_role(min_role: OrgRole):
+    """Dependency factory: resolve workspace_id → org, then enforce role."""
+
+    def _dep(
+        workspace_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        auth: AuthContext = Depends(verify_auth),
+    ) -> AuthContext:
+        org_id = db.execute(
+            select(Workspace.org_id).where(Workspace.id == workspace_id)
+        ).scalar_one_or_none()
+        if org_id is None:
+            raise HTTPException(404, "Workspace not found")
+        _check_membership(db, org_id, auth, min_role)
+        return auth
+
+    return _dep
+
+
+def require_space_role(min_role: OrgRole):
+    """Dependency factory: resolve space_id → workspace → org, then enforce role."""
+
+    def _dep(
+        space_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        auth: AuthContext = Depends(verify_auth),
+    ) -> AuthContext:
+        org_id = db.execute(
+            select(Workspace.org_id)
+            .join(Space, Space.workspace_id == Workspace.id)
+            .where(Space.id == space_id)
+        ).scalar_one_or_none()
+        if org_id is None:
+            raise HTTPException(404, "Space not found")
+        _check_membership(db, org_id, auth, min_role)
+        return auth
+
+    return _dep
+
+
+def require_collection_role(min_role: OrgRole):
+    """Dependency factory: resolve collection_id → space → workspace → org."""
+
+    def _dep(
+        collection_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        auth: AuthContext = Depends(verify_auth),
+    ) -> AuthContext:
+        org_id = db.execute(
+            select(Workspace.org_id)
+            .join(Space, Space.workspace_id == Workspace.id)
+            .join(Collection, Collection.space_id == Space.id)
+            .where(Collection.id == collection_id)
+        ).scalar_one_or_none()
+        if org_id is None:
+            raise HTTPException(404, "Collection not found")
+        _check_membership(db, org_id, auth, min_role)
+        return auth
+
+    return _dep
+
+
+def require_page_role(min_role: OrgRole):
+    """Dependency factory: resolve page_id → collection → space → workspace → org."""
+
+    def _dep(
+        page_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        auth: AuthContext = Depends(verify_auth),
+    ) -> AuthContext:
+        org_id = db.execute(
+            select(Workspace.org_id)
+            .join(Space, Space.workspace_id == Workspace.id)
+            .join(Collection, Collection.space_id == Space.id)
+            .join(Page, Page.collection_id == Collection.id)
+            .where(Page.id == page_id)
+        ).scalar_one_or_none()
+        if org_id is None:
+            raise HTTPException(404, "Page not found")
+        _check_membership(db, org_id, auth, min_role)
+        return auth
+
+    return _dep

--- a/api/freehold/restore.py
+++ b/api/freehold/restore.py
@@ -13,8 +13,7 @@ from pathlib import Path
 
 from sqlalchemy.orm import Session
 
-from .export import SCHEMA_VERSION
-from .models import Attachment, Collection, Page, Revision, Space, Workspace
+from .models import Attachment, Collection, Organization, Page, Revision, Space, Workspace
 from .storage import StorageAdapter
 
 
@@ -47,10 +46,9 @@ def restore_workspace(
         manifest = json.loads(zf.read("manifest.json"))
 
         schema_version = manifest.get("schema_version")
-        if schema_version != SCHEMA_VERSION:
+        if schema_version not in ("1", "2"):
             raise ValueError(
-                f"Unsupported bundle schema version '{schema_version}' "
-                f"(expected '{SCHEMA_VERSION}')"
+                f"Unsupported bundle schema version '{schema_version}' (expected '1' or '2')"
             )
 
         ws_meta = manifest["workspace"]
@@ -67,10 +65,46 @@ def restore_workspace(
                 "Delete it before restoring."
             )
 
+        # --- Organization ---
+        # v2 bundles include org metadata; v1 bundles create a new org from workspace name.
+        if schema_version == "2" and "organization" in manifest:
+            org_meta = manifest["organization"]
+            org_id = uuid.UUID(org_meta["id"])
+            existing_org = session.get(Organization, org_id)
+            if existing_org is None:
+                session.add(
+                    Organization(
+                        id=org_id,
+                        slug=org_meta["slug"],
+                        name=org_meta["name"],
+                        created_at=_dt(org_meta["created_at"]),
+                    )
+                )
+                session.flush()
+        else:
+            # v1 bundle: create a new org named after the workspace
+            org_id = uuid.uuid4()
+            slug_candidate = f"{ws_meta['slug']}-imported"
+            # Ensure slug uniqueness
+            counter = 0
+            slug = slug_candidate
+            while session.query(Organization).filter_by(slug=slug).first() is not None:
+                counter += 1
+                slug = f"{slug_candidate}-{counter}"
+            session.add(
+                Organization(
+                    id=org_id,
+                    slug=slug,
+                    name=f"{ws_meta['name']} (imported)",
+                )
+            )
+            session.flush()
+
         # --- Workspace ---
         session.add(
             Workspace(
                 id=ws_id,
+                org_id=org_id,
                 slug=ws_meta["slug"],
                 name=ws_meta["name"],
                 created_at=_dt(ws_meta["created_at"]),

--- a/api/freehold/routers/auth.py
+++ b/api/freehold/routers/auth.py
@@ -135,8 +135,9 @@ async def callback(request: Request):
     finally:
         db.close()
 
-    # Issue session JWT and set cookie
-    session_jwt = create_session_jwt(user_id, user_email, user_name)
+    # Issue session JWT and set cookie (include OIDC id_token for RP-Initiated Logout)
+    oidc_id_token = token.get("id_token") if isinstance(token.get("id_token"), str) else None
+    session_jwt = create_session_jwt(user_id, user_email, user_name, oidc_id_token=oidc_id_token)
     cookie_params = make_session_cookie_params()
 
     response = RedirectResponse(url=config.frontend_url, status_code=302)
@@ -180,15 +181,61 @@ async def me(request: Request) -> AuthStatus:
 
 
 @router.post("/logout")
-async def logout():
-    """Clear the session cookie."""
+async def logout(request: Request):
+    """Clear the session cookie and return the IdP logout URL if OIDC is active."""
+    from urllib.parse import urlencode
+
+    import httpx
     from fastapi.responses import JSONResponse
 
     config = get_oidc_config()
-    response = JSONResponse(content={"status": "ok"})
+
+    # Extract the OIDC id_token from the session before clearing
+    id_token_hint = None
+    session_token = request.cookies.get(COOKIE_NAME)
+    if session_token:
+        try:
+            claims = decode_session_jwt(session_token)
+            id_token_hint = claims.get("oidc_id_token")
+        except Exception:
+            pass
+
+    # Clear the Freehold session cookie
+    body: dict = {"status": "ok"}
+    response = JSONResponse(content=body)
     response.delete_cookie(
         key=COOKIE_NAME,
         path="/",
         domain=config.cookie_domain,
     )
+
+    # Build the IdP logout URL for RP-Initiated Logout
+    if config.is_enabled:
+        try:
+            async with httpx.AsyncClient() as client:
+                metadata_resp = await client.get(
+                    f"{config.issuer}/.well-known/openid-configuration",
+                    timeout=5.0,
+                )
+                metadata_resp.raise_for_status()
+                metadata = metadata_resp.json()
+
+            end_session_endpoint = metadata.get("end_session_endpoint")
+            if end_session_endpoint:
+                params: dict[str, str] = {
+                    "client_id": config.client_id,
+                    "post_logout_redirect_uri": config.frontend_url + "/login",
+                }
+                if id_token_hint:
+                    params["id_token_hint"] = id_token_hint
+                body["logout_url"] = f"{end_session_endpoint}?{urlencode(params)}"
+                response = JSONResponse(content=body)
+                response.delete_cookie(
+                    key=COOKIE_NAME,
+                    path="/",
+                    domain=config.cookie_domain,
+                )
+        except Exception:
+            pass  # Fall back to local-only logout
+
     return response

--- a/api/freehold/routers/auth.py
+++ b/api/freehold/routers/auth.py
@@ -4,11 +4,13 @@ These endpoints are registered WITHOUT the global auth dependency so that
 unauthenticated users can initiate the login flow.
 """
 
+import re
 import uuid
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from sqlalchemy import func as sa_func
+from sqlalchemy.orm import Session
 
 from ..auth import (
     COOKIE_NAME,
@@ -19,10 +21,22 @@ from ..auth import (
     make_session_cookie_params,
 )
 from ..dependencies import get_db
-from ..models import User
+from ..models import Organization, OrgMembership, OrgRole, User
 from ..schemas import AuthStatus, UserRead
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+def _unique_org_slug(db: Session, base: str) -> str:
+    """Generate a unique org slug from a base string, appending a suffix on collision."""
+    slug = re.sub(r"[^a-z0-9-]", "-", base.lower()).strip("-")[:50] or "org"
+    candidate = slug
+    attempt = 0
+    while db.query(Organization).filter(Organization.slug == candidate).first() is not None:
+        attempt += 1
+        suffix = uuid.uuid4().hex[:4]
+        candidate = f"{slug}-{suffix}"
+    return candidate
 
 
 @router.get("/login")
@@ -78,6 +92,41 @@ async def callback(request: Request):
                 name=name,
             )
             db.add(user)
+        db.flush()
+        db.refresh(user)
+
+        # Claim any pending memberships that match this user's email
+        pending = (
+            db.query(OrgMembership)
+            .filter(OrgMembership.email == user.email, OrgMembership.user_id.is_(None))
+            .all()
+        )
+        for membership in pending:
+            membership.user_id = user.id
+
+        # Auto-create personal org if user has no memberships
+        has_memberships = (
+            db.query(OrgMembership).filter(OrgMembership.user_id == user.id).first()
+        ) is not None
+
+        if not has_memberships:
+            slug_base = email.split("@")[0] if email else "user"
+            slug = _unique_org_slug(db, slug_base)
+            personal_org = Organization(
+                name=f"{name}'s Space",
+                slug=slug,
+            )
+            db.add(personal_org)
+            db.flush()
+            db.add(
+                OrgMembership(
+                    org_id=personal_org.id,
+                    user_id=user.id,
+                    email=user.email,
+                    role=OrgRole.OWNER.value,
+                )
+            )
+
         db.commit()
         db.refresh(user)
         user_id = user.id

--- a/api/freehold/routers/collections.py
+++ b/api/freehold/routers/collections.py
@@ -6,8 +6,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from ..dependencies import get_db
-from ..models import Collection, Space
+from ..dependencies import AuthContext, get_db
+from ..models import Collection, OrgRole, Space
+from ..rbac import require_space_role
 from ..schemas import CollectionCreate, CollectionRead
 
 router = APIRouter(prefix="/api/spaces/{space_id}/collections", tags=["collections"])
@@ -21,18 +22,22 @@ def _get_space_or_404(space_id: UUID, db: Session) -> Space:
 
 
 @router.get("", response_model=list[CollectionRead])
-def list_collections(space_id: UUID, db: Session = Depends(get_db)):
+def list_collections(
+    space_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_space_role(OrgRole.VIEWER)),
+):
     _get_space_or_404(space_id, db)
-    return (
-        db.query(Collection)
-        .filter_by(space_id=space_id)
-        .order_by(Collection.created_at)
-        .all()
-    )
+    return db.query(Collection).filter_by(space_id=space_id).order_by(Collection.created_at).all()
 
 
 @router.post("", response_model=CollectionRead, status_code=201)
-def create_collection(space_id: UUID, body: CollectionCreate, db: Session = Depends(get_db)):
+def create_collection(
+    space_id: UUID,
+    body: CollectionCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_space_role(OrgRole.EDITOR)),
+):
     _get_space_or_404(space_id, db)
     col = Collection(space_id=space_id, slug=body.slug, name=body.name)
     db.add(col)
@@ -49,7 +54,12 @@ def create_collection(space_id: UUID, body: CollectionCreate, db: Session = Depe
 
 
 @router.get("/{collection_id}", response_model=CollectionRead)
-def get_collection(space_id: UUID, collection_id: UUID, db: Session = Depends(get_db)):
+def get_collection(
+    space_id: UUID,
+    collection_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_space_role(OrgRole.VIEWER)),
+):
     _get_space_or_404(space_id, db)
     col = db.get(Collection, collection_id)
     if col is None or col.space_id != space_id:
@@ -58,7 +68,12 @@ def get_collection(space_id: UUID, collection_id: UUID, db: Session = Depends(ge
 
 
 @router.delete("/{collection_id}", status_code=204)
-def delete_collection(space_id: UUID, collection_id: UUID, db: Session = Depends(get_db)):
+def delete_collection(
+    space_id: UUID,
+    collection_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_space_role(OrgRole.OWNER)),
+):
     _get_space_or_404(space_id, db)
     col = db.get(Collection, collection_id)
     if col is None or col.space_id != space_id:

--- a/api/freehold/routers/organizations.py
+++ b/api/freehold/routers/organizations.py
@@ -1,0 +1,166 @@
+"""Organization CRUD and member management endpoints."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ..dependencies import AuthContext, get_db, verify_auth
+from ..models import Organization, OrgMembership, OrgRole, User
+from ..rbac import require_org_role
+from ..schemas import (
+    OrganizationCreate,
+    OrganizationRead,
+    OrgMembershipCreate,
+    OrgMembershipRead,
+    OrgMembershipUpdate,
+)
+
+router = APIRouter(prefix="/api/orgs", tags=["organizations"])
+
+
+@router.get("", response_model=list[OrganizationRead])
+def list_orgs(
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(verify_auth),
+):
+    """List orgs the current user belongs to (all orgs for API key/anonymous)."""
+    if auth.method in ("api_key", "anonymous"):
+        return db.execute(select(Organization).order_by(Organization.created_at)).scalars().all()
+
+    return (
+        db.execute(
+            select(Organization)
+            .join(OrgMembership, OrgMembership.org_id == Organization.id)
+            .where(OrgMembership.user_id == auth.user_id)
+            .order_by(Organization.created_at)
+        )
+        .scalars()
+        .all()
+    )
+
+
+@router.post("", response_model=OrganizationRead, status_code=201)
+def create_org(
+    body: OrganizationCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(verify_auth),
+):
+    """Create an org. The creating user becomes the owner."""
+    org = Organization(slug=body.slug, name=body.name)
+    db.add(org)
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(409, f"Organization slug '{body.slug}' already exists")
+
+    if auth.user_id is not None:
+        db.add(
+            OrgMembership(
+                org_id=org.id,
+                user_id=auth.user_id,
+                email=auth.email or "",
+                role=OrgRole.OWNER.value,
+            )
+        )
+
+    db.commit()
+    db.refresh(org)
+    return org
+
+
+@router.get("/{org_id}", response_model=OrganizationRead)
+def get_org(
+    org_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_org_role(OrgRole.VIEWER)),
+):
+    org = db.get(Organization, org_id)
+    if org is None:
+        raise HTTPException(404, "Organization not found")
+    return org
+
+
+@router.get("/{org_id}/members", response_model=list[OrgMembershipRead])
+def list_members(
+    org_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_org_role(OrgRole.VIEWER)),
+):
+    return (
+        db.execute(
+            select(OrgMembership)
+            .where(OrgMembership.org_id == org_id)
+            .order_by(OrgMembership.created_at)
+        )
+        .scalars()
+        .all()
+    )
+
+
+@router.post("/{org_id}/members", response_model=OrgMembershipRead, status_code=201)
+def invite_member(
+    org_id: UUID,
+    body: OrgMembershipCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_org_role(OrgRole.OWNER)),
+):
+    """Invite a user by email. Creates a pending membership if the user has no account yet."""
+    if body.role not in (r.value for r in OrgRole):
+        raise HTTPException(422, f"Invalid role: {body.role}")
+
+    # Check if user exists
+    user = db.execute(select(User).where(User.email == body.email)).scalar_one_or_none()
+
+    membership = OrgMembership(
+        org_id=org_id,
+        user_id=user.id if user else None,
+        email=body.email,
+        role=body.role,
+    )
+    db.add(membership)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(409, f"User '{body.email}' is already a member of this organization")
+    db.refresh(membership)
+    return membership
+
+
+@router.patch("/{org_id}/members/{membership_id}", response_model=OrgMembershipRead)
+def update_member_role(
+    org_id: UUID,
+    membership_id: UUID,
+    body: OrgMembershipUpdate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_org_role(OrgRole.OWNER)),
+):
+    if body.role not in (r.value for r in OrgRole):
+        raise HTTPException(422, f"Invalid role: {body.role}")
+
+    membership = db.get(OrgMembership, membership_id)
+    if membership is None or membership.org_id != org_id:
+        raise HTTPException(404, "Membership not found")
+
+    membership.role = body.role
+    db.commit()
+    db.refresh(membership)
+    return membership
+
+
+@router.delete("/{org_id}/members/{membership_id}", status_code=204)
+def remove_member(
+    org_id: UUID,
+    membership_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_org_role(OrgRole.OWNER)),
+):
+    membership = db.get(OrgMembership, membership_id)
+    if membership is None or membership.org_id != org_id:
+        raise HTTPException(404, "Membership not found")
+    db.delete(membership)
+    db.commit()

--- a/api/freehold/routers/pages.py
+++ b/api/freehold/routers/pages.py
@@ -8,8 +8,9 @@ from fastapi import APIRouter, Depends, HTTPException, Response, UploadFile
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from ..dependencies import get_db, get_storage
-from ..models import Attachment, Collection, Page, Revision
+from ..dependencies import AuthContext, get_db, get_storage
+from ..models import Attachment, Collection, OrgRole, Page, Revision
+from ..rbac import require_collection_role
 from ..schemas import (
     AttachmentRead,
     PageCreate,
@@ -57,19 +58,24 @@ def _page_with_content(page: Page) -> PageReadWithContent:
 
 
 @router.get("", response_model=list[PageReadWithContent])
-def list_pages(collection_id: UUID, db: Session = Depends(get_db)):
+def list_pages(
+    collection_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_collection_role(OrgRole.VIEWER)),
+):
     _get_collection_or_404(collection_id, db)
     pages = db.query(Page).filter_by(collection_id=collection_id).order_by(Page.created_at).all()
     return [_page_with_content(p) for p in pages]
 
 
 @router.post("", response_model=PageReadWithContent, status_code=201)
-def create_page(collection_id: UUID, body: PageCreate, db: Session = Depends(get_db)):
-    """Create a page and its first revision in one transaction.
-
-    The deferred FK (pages.current_revision_id → revisions.id) lets us
-    insert both rows before wiring up the pointer — same pattern as restore.py.
-    """
+def create_page(
+    collection_id: UUID,
+    body: PageCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_collection_role(OrgRole.EDITOR)),
+):
+    """Create a page and its first revision in one transaction."""
     _get_collection_or_404(collection_id, db)
 
     page = Page(
@@ -79,13 +85,13 @@ def create_page(collection_id: UUID, body: PageCreate, db: Session = Depends(get
         current_revision_id=None,
     )
     db.add(page)
-    db.flush()  # get page.id before inserting revision
+    db.flush()
 
     rev = Revision(page_id=page.id, content=body.content)
     db.add(rev)
-    db.flush()  # get rev.id
+    db.flush()
 
-    page.current_revision_id = rev.id  # deferred FK checked at commit
+    page.current_revision_id = rev.id
 
     try:
         db.commit()
@@ -100,14 +106,23 @@ def create_page(collection_id: UUID, body: PageCreate, db: Session = Depends(get
 
 
 @router.get("/{page_id}", response_model=PageReadWithContent)
-def get_page(collection_id: UUID, page_id: UUID, db: Session = Depends(get_db)):
+def get_page(
+    collection_id: UUID,
+    page_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_collection_role(OrgRole.VIEWER)),
+):
     page = _get_page_or_404(collection_id, page_id, db)
     return _page_with_content(page)
 
 
 @router.patch("/{page_id}", response_model=PageReadWithContent)
 def update_page(
-    collection_id: UUID, page_id: UUID, body: PageUpdate, db: Session = Depends(get_db)
+    collection_id: UUID,
+    page_id: UUID,
+    body: PageUpdate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_collection_role(OrgRole.EDITOR)),
 ):
     """Update a page's title and/or content.
 
@@ -131,7 +146,12 @@ def update_page(
 
 
 @router.delete("/{page_id}", status_code=204)
-def delete_page(collection_id: UUID, page_id: UUID, db: Session = Depends(get_db)):
+def delete_page(
+    collection_id: UUID,
+    page_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_collection_role(OrgRole.OWNER)),
+):
     page = _get_page_or_404(collection_id, page_id, db)
     db.delete(page)
     db.commit()
@@ -143,19 +163,23 @@ def delete_page(collection_id: UUID, page_id: UUID, db: Session = Depends(get_db
 
 
 @router.get("/{page_id}/revisions", response_model=list[RevisionRead])
-def list_revisions(collection_id: UUID, page_id: UUID, db: Session = Depends(get_db)):
+def list_revisions(
+    collection_id: UUID,
+    page_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_collection_role(OrgRole.VIEWER)),
+):
     _get_page_or_404(collection_id, page_id, db)
-    return (
-        db.query(Revision)
-        .filter_by(page_id=page_id)
-        .order_by(Revision.created_at.desc())
-        .all()
-    )
+    return db.query(Revision).filter_by(page_id=page_id).order_by(Revision.created_at.desc()).all()
 
 
 @router.get("/{page_id}/revisions/{revision_id}", response_model=RevisionReadWithContent)
 def get_revision(
-    collection_id: UUID, page_id: UUID, revision_id: UUID, db: Session = Depends(get_db)
+    collection_id: UUID,
+    page_id: UUID,
+    revision_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_collection_role(OrgRole.VIEWER)),
 ):
     _get_page_or_404(collection_id, page_id, db)
     rev = db.get(Revision, revision_id)
@@ -170,14 +194,14 @@ def get_revision(
 
 
 @router.get("/{page_id}/attachments", response_model=list[AttachmentRead])
-def list_attachments(collection_id: UUID, page_id: UUID, db: Session = Depends(get_db)):
+def list_attachments(
+    collection_id: UUID,
+    page_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_collection_role(OrgRole.VIEWER)),
+):
     _get_page_or_404(collection_id, page_id, db)
-    return (
-        db.query(Attachment)
-        .filter_by(page_id=page_id)
-        .order_by(Attachment.created_at)
-        .all()
-    )
+    return db.query(Attachment).filter_by(page_id=page_id).order_by(Attachment.created_at).all()
 
 
 @router.post("/{page_id}/attachments", response_model=AttachmentRead, status_code=201)
@@ -187,23 +211,16 @@ async def upload_attachment(
     file: UploadFile,
     db: Session = Depends(get_db),
     storage: StorageAdapter = Depends(get_storage),
+    auth: AuthContext = Depends(require_collection_role(OrgRole.EDITOR)),
 ):
-    """Upload a file attachment.
-
-    Hash is computed from the raw bytes before writing to storage or DB.
-    Storage is written first; if the DB commit fails the orphaned file is
-    harmless. If storage write fails, the DB is never touched.
-    """
+    """Upload a file attachment."""
     _get_page_or_404(collection_id, page_id, db)
 
     data = await file.read()
     sha256 = hashlib.sha256(data).hexdigest()
     filename = file.filename or "upload"
 
-    # Generate the attachment ID here so we can pass it to storage before
-    # the DB record is committed (same pattern as restore.py).
     att_id = uuid.uuid4()
-
     storage.write(str(att_id), filename, data)
 
     att = Attachment(
@@ -226,6 +243,7 @@ def download_attachment(
     attachment_id: UUID,
     db: Session = Depends(get_db),
     storage: StorageAdapter = Depends(get_storage),
+    auth: AuthContext = Depends(require_collection_role(OrgRole.VIEWER)),
 ):
     _get_page_or_404(collection_id, page_id, db)
     att = db.get(Attachment, attachment_id)

--- a/api/freehold/routers/pages_global.py
+++ b/api/freehold/routers/pages_global.py
@@ -10,8 +10,9 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from ..dependencies import get_db
-from ..models import Page, Revision
+from ..dependencies import AuthContext, get_db
+from ..models import OrgRole, Page, Revision
+from ..rbac import require_page_role
 from ..schemas import (
     PageReadWithContent,
     PageUpdate,
@@ -43,12 +44,21 @@ def _page_with_content(page: Page) -> PageReadWithContent:
 
 
 @router.get("/{page_id}", response_model=PageReadWithContent)
-def get_page(page_id: UUID, db: Session = Depends(get_db)):
+def get_page(
+    page_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_page_role(OrgRole.VIEWER)),
+):
     return _page_with_content(_get_page_or_404(page_id, db))
 
 
 @router.patch("/{page_id}", response_model=PageReadWithContent)
-def update_page(page_id: UUID, body: PageUpdate, db: Session = Depends(get_db)):
+def update_page(
+    page_id: UUID,
+    body: PageUpdate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_page_role(OrgRole.EDITOR)),
+):
     """Append a new revision when content changes — never update in place."""
     page = _get_page_or_404(page_id, db)
 
@@ -67,18 +77,22 @@ def update_page(page_id: UUID, body: PageUpdate, db: Session = Depends(get_db)):
 
 
 @router.get("/{page_id}/revisions", response_model=list[RevisionRead])
-def list_revisions(page_id: UUID, db: Session = Depends(get_db)):
+def list_revisions(
+    page_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_page_role(OrgRole.VIEWER)),
+):
     _get_page_or_404(page_id, db)
-    return (
-        db.query(Revision)
-        .filter_by(page_id=page_id)
-        .order_by(Revision.created_at.desc())
-        .all()
-    )
+    return db.query(Revision).filter_by(page_id=page_id).order_by(Revision.created_at.desc()).all()
 
 
 @router.get("/{page_id}/revisions/{revision_id}", response_model=RevisionReadWithContent)
-def get_revision(page_id: UUID, revision_id: UUID, db: Session = Depends(get_db)):
+def get_revision(
+    page_id: UUID,
+    revision_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_page_role(OrgRole.VIEWER)),
+):
     _get_page_or_404(page_id, db)
     rev = db.get(Revision, revision_id)
     if rev is None or rev.page_id != page_id:

--- a/api/freehold/routers/spaces.py
+++ b/api/freehold/routers/spaces.py
@@ -6,8 +6,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from ..dependencies import get_db
-from ..models import Space, Workspace
+from ..dependencies import AuthContext, get_db
+from ..models import OrgRole, Space, Workspace
+from ..rbac import require_workspace_role
 from ..schemas import SpaceCreate, SpaceRead
 
 router = APIRouter(prefix="/api/workspaces/{workspace_id}/spaces", tags=["spaces"])
@@ -21,18 +22,22 @@ def _get_workspace_or_404(workspace_id: UUID, db: Session) -> Workspace:
 
 
 @router.get("", response_model=list[SpaceRead])
-def list_spaces(workspace_id: UUID, db: Session = Depends(get_db)):
+def list_spaces(
+    workspace_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_workspace_role(OrgRole.VIEWER)),
+):
     _get_workspace_or_404(workspace_id, db)
-    return (
-        db.query(Space)
-        .filter_by(workspace_id=workspace_id)
-        .order_by(Space.created_at)
-        .all()
-    )
+    return db.query(Space).filter_by(workspace_id=workspace_id).order_by(Space.created_at).all()
 
 
 @router.post("", response_model=SpaceRead, status_code=201)
-def create_space(workspace_id: UUID, body: SpaceCreate, db: Session = Depends(get_db)):
+def create_space(
+    workspace_id: UUID,
+    body: SpaceCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_workspace_role(OrgRole.EDITOR)),
+):
     _get_workspace_or_404(workspace_id, db)
     space = Space(workspace_id=workspace_id, slug=body.slug, name=body.name)
     db.add(space)
@@ -48,7 +53,12 @@ def create_space(workspace_id: UUID, body: SpaceCreate, db: Session = Depends(ge
 
 
 @router.get("/{space_id}", response_model=SpaceRead)
-def get_space(workspace_id: UUID, space_id: UUID, db: Session = Depends(get_db)):
+def get_space(
+    workspace_id: UUID,
+    space_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_workspace_role(OrgRole.VIEWER)),
+):
     _get_workspace_or_404(workspace_id, db)
     space = db.get(Space, space_id)
     if space is None or space.workspace_id != workspace_id:
@@ -57,7 +67,12 @@ def get_space(workspace_id: UUID, space_id: UUID, db: Session = Depends(get_db))
 
 
 @router.delete("/{space_id}", status_code=204)
-def delete_space(workspace_id: UUID, space_id: UUID, db: Session = Depends(get_db)):
+def delete_space(
+    workspace_id: UUID,
+    space_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_workspace_role(OrgRole.OWNER)),
+):
     _get_workspace_or_404(workspace_id, db)
     space = db.get(Space, space_id)
     if space is None or space.workspace_id != workspace_id:

--- a/api/freehold/routers/workspaces.py
+++ b/api/freehold/routers/workspaces.py
@@ -3,11 +3,13 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from ..dependencies import get_db, get_search_backend
-from ..models import Workspace
+from ..dependencies import AuthContext, get_db, get_search_backend, verify_auth
+from ..models import OrgMembership, OrgRole, Workspace
+from ..rbac import require_workspace_role
 from ..schemas import (
     SearchResponse,
     SearchResultItem,
@@ -21,13 +23,50 @@ router = APIRouter(prefix="/api/workspaces", tags=["workspaces"])
 
 
 @router.get("", response_model=list[WorkspaceRead])
-def list_workspaces(db: Session = Depends(get_db)):
-    return db.query(Workspace).order_by(Workspace.created_at).all()
+def list_workspaces(
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(verify_auth),
+):
+    """List workspaces. Session users see only workspaces in their orgs."""
+    if auth.method in ("api_key", "anonymous"):
+        return db.query(Workspace).order_by(Workspace.created_at).all()
+
+    return (
+        db.execute(
+            select(Workspace)
+            .join(OrgMembership, OrgMembership.org_id == Workspace.org_id)
+            .where(OrgMembership.user_id == auth.user_id)
+            .order_by(Workspace.created_at)
+        )
+        .scalars()
+        .all()
+    )
 
 
 @router.post("", response_model=WorkspaceRead, status_code=201)
-def create_workspace(body: WorkspaceCreate, db: Session = Depends(get_db)):
-    ws = Workspace(slug=body.slug, name=body.name)
+def create_workspace(
+    body: WorkspaceCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(verify_auth),
+):
+    org_id = body.org_id
+
+    # For session users without explicit org_id, use their first org
+    if org_id is None and auth.user_id is not None:
+        membership = db.execute(
+            select(OrgMembership)
+            .where(OrgMembership.user_id == auth.user_id)
+            .order_by(OrgMembership.created_at)
+        ).scalar_one_or_none()
+        if membership is None:
+            raise HTTPException(403, "You must belong to an organization to create a workspace")
+        org_id = membership.org_id
+
+    # For API key/anonymous, org_id is required
+    if org_id is None:
+        raise HTTPException(422, "org_id is required for API key or anonymous access")
+
+    ws = Workspace(org_id=org_id, slug=body.slug, name=body.name)
     db.add(ws)
     try:
         db.commit()
@@ -39,7 +78,11 @@ def create_workspace(body: WorkspaceCreate, db: Session = Depends(get_db)):
 
 
 @router.get("/{workspace_id}", response_model=WorkspaceRead)
-def get_workspace(workspace_id: UUID, db: Session = Depends(get_db)):
+def get_workspace(
+    workspace_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_workspace_role(OrgRole.VIEWER)),
+):
     ws = db.get(Workspace, workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
@@ -47,12 +90,12 @@ def get_workspace(workspace_id: UUID, db: Session = Depends(get_db)):
 
 
 @router.get("/{workspace_id}/tree", response_model=WorkspaceTree)
-def get_workspace_tree(workspace_id: UUID, db: Session = Depends(get_db)):
-    """Return the full workspace hierarchy for sidebar rendering.
-
-    Pydantic serializes the ORM relationships (lazy-loaded within the active
-    session) into the nested tree structure.
-    """
+def get_workspace_tree(
+    workspace_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_workspace_role(OrgRole.VIEWER)),
+):
+    """Return the full workspace hierarchy for sidebar rendering."""
     ws = db.get(Workspace, workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
@@ -65,6 +108,7 @@ def search_workspace(
     q: str = "",
     db: Session = Depends(get_db),
     search: SearchBackend = Depends(get_search_backend),
+    auth: AuthContext = Depends(require_workspace_role(OrgRole.VIEWER)),
 ):
     ws = db.get(Workspace, workspace_id)
     if ws is None:
@@ -81,7 +125,11 @@ def search_workspace(
 
 
 @router.delete("/{workspace_id}", status_code=204)
-def delete_workspace(workspace_id: UUID, db: Session = Depends(get_db)):
+def delete_workspace(
+    workspace_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_workspace_role(OrgRole.OWNER)),
+):
     ws = db.get(Workspace, workspace_id)
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")

--- a/api/freehold/schemas.py
+++ b/api/freehold/schemas.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict
 # Shared config — all read schemas allow ORM model instances as input
 # ---------------------------------------------------------------------------
 
+
 class _ReadBase(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -17,13 +18,16 @@ class _ReadBase(BaseModel):
 # Workspace
 # ---------------------------------------------------------------------------
 
+
 class WorkspaceCreate(BaseModel):
     slug: str
     name: str
+    org_id: UUID | None = None  # if None, uses personal org
 
 
 class WorkspaceRead(_ReadBase):
     id: UUID
+    org_id: UUID
     slug: str
     name: str
     created_at: datetime
@@ -32,6 +36,7 @@ class WorkspaceRead(_ReadBase):
 # ---------------------------------------------------------------------------
 # Space
 # ---------------------------------------------------------------------------
+
 
 class SpaceCreate(BaseModel):
     slug: str
@@ -50,6 +55,7 @@ class SpaceRead(_ReadBase):
 # Collection
 # ---------------------------------------------------------------------------
 
+
 class CollectionCreate(BaseModel):
     slug: str
     name: str
@@ -66,6 +72,7 @@ class CollectionRead(_ReadBase):
 # ---------------------------------------------------------------------------
 # Page
 # ---------------------------------------------------------------------------
+
 
 class PageCreate(BaseModel):
     slug: str
@@ -95,6 +102,7 @@ class PageReadWithContent(PageRead):
 # Revision
 # ---------------------------------------------------------------------------
 
+
 class RevisionRead(_ReadBase):
     id: UUID
     page_id: UUID
@@ -109,6 +117,7 @@ class RevisionReadWithContent(RevisionRead):
 # Attachment
 # ---------------------------------------------------------------------------
 
+
 class AttachmentRead(_ReadBase):
     id: UUID
     page_id: UUID
@@ -121,6 +130,7 @@ class AttachmentRead(_ReadBase):
 # ---------------------------------------------------------------------------
 # Workspace tree (nested, for sidebar)
 # ---------------------------------------------------------------------------
+
 
 class PageTreeItem(_ReadBase):
     id: UUID
@@ -146,6 +156,7 @@ class SpaceTreeItem(_ReadBase):
 
 class WorkspaceTree(_ReadBase):
     id: UUID
+    org_id: UUID
     slug: str
     name: str
     spaces: list[SpaceTreeItem]
@@ -154,6 +165,7 @@ class WorkspaceTree(_ReadBase):
 # ---------------------------------------------------------------------------
 # Search
 # ---------------------------------------------------------------------------
+
 
 class SearchResultItem(BaseModel):
     page_id: UUID
@@ -169,6 +181,46 @@ class SearchResultItem(BaseModel):
 class SearchResponse(BaseModel):
     query: str
     results: list[SearchResultItem]
+
+
+# ---------------------------------------------------------------------------
+# Organization
+# ---------------------------------------------------------------------------
+
+
+class OrganizationCreate(BaseModel):
+    slug: str
+    name: str
+
+
+class OrganizationRead(_ReadBase):
+    id: UUID
+    slug: str
+    name: str
+    created_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Org Membership
+# ---------------------------------------------------------------------------
+
+
+class OrgMembershipCreate(BaseModel):
+    email: str
+    role: str  # "owner" | "editor" | "viewer"
+
+
+class OrgMembershipRead(_ReadBase):
+    id: UUID
+    org_id: UUID
+    user_id: UUID | None
+    email: str
+    role: str
+    created_at: datetime
+
+
+class OrgMembershipUpdate(BaseModel):
+    role: str
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -14,7 +14,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from freehold.export import SCHEMA_VERSION, export_workspace
-from freehold.models import Attachment, Collection, Page, Revision, Space, Workspace
+from freehold.models import Attachment, Collection, Organization, Page, Revision, Space, Workspace
 from freehold.storage import StorageAdapter
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
@@ -62,7 +62,11 @@ def session(engine):
 @pytest.fixture
 def seeded(session):
     """Seed a workspace with two pages (two revisions each) and one attachment."""
-    ws = Workspace(slug="export-test-ws", name="Export Test Workspace")
+    org = Organization(slug="export-test-org", name="Export Test Org")
+    session.add(org)
+    session.flush()
+
+    ws = Workspace(org_id=org.id, slug="export-test-ws", name="Export Test Workspace")
     session.add(ws)
     session.flush()
 

--- a/api/tests/test_migration_cycle.py
+++ b/api/tests/test_migration_cycle.py
@@ -11,9 +11,10 @@ import uuid
 import psycopg2
 import psycopg2.errors
 import pytest
-from alembic import command
 from alembic.config import Config
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+from alembic import command
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
 
@@ -57,8 +58,14 @@ def _insert_revision(db_url: str) -> str:
     conn.autocommit = True
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO workspaces (slug, name) VALUES (%s, %s) RETURNING id",
-            (f"ws-{uuid.uuid4().hex[:6]}", "Test WS"),
+            "INSERT INTO organizations (slug, name) VALUES (%s, %s) RETURNING id",
+            (f"org-{uuid.uuid4().hex[:6]}", "Test Org"),
+        )
+        org_id = cur.fetchone()[0]
+
+        cur.execute(
+            "INSERT INTO workspaces (org_id, slug, name) VALUES (%s, %s, %s) RETURNING id",
+            (org_id, f"ws-{uuid.uuid4().hex[:6]}", "Test WS"),
         )
         ws_id = cur.fetchone()[0]
 
@@ -108,7 +115,17 @@ class TestMigrationCycle:
             tables = {row[0] for row in cur.fetchall()}
         conn.close()
 
-        expected = {"workspaces", "spaces", "collections", "pages", "revisions", "attachments"}
+        expected = {
+            "workspaces",
+            "spaces",
+            "collections",
+            "pages",
+            "revisions",
+            "attachments",
+            "users",
+            "organizations",
+            "org_memberships",
+        }
         assert expected.issubset(tables)
 
     def test_revision_update_is_blocked(self, db_url):
@@ -117,25 +134,8 @@ class TestMigrationCycle:
         conn = psycopg2.connect(db_url)
         cur = conn.cursor()
         try:
-            cur.execute(
-                "UPDATE revisions SET content = 'tampered' WHERE id = %s", (rev_id,)
-            )
+            cur.execute("UPDATE revisions SET content = 'tampered' WHERE id = %s", (rev_id,))
             pytest.fail("Expected trigger to block UPDATE on revisions")
-        except psycopg2.errors.RaiseException:
-            pass
-        finally:
-            conn.rollback()
-            cur.close()
-            conn.close()
-
-    def test_revision_delete_is_blocked(self, db_url):
-        rev_id = _insert_revision(db_url)
-
-        conn = psycopg2.connect(db_url)
-        cur = conn.cursor()
-        try:
-            cur.execute("DELETE FROM revisions WHERE id = %s", (rev_id,))
-            pytest.fail("Expected trigger to block DELETE on revisions")
         except psycopg2.errors.RaiseException:
             pass
         finally:
@@ -156,6 +156,11 @@ class TestMigrationCycle:
         conn.close()
 
         freehold_tables = {
-            "workspaces", "spaces", "collections", "pages", "revisions", "attachments"
+            "workspaces",
+            "spaces",
+            "collections",
+            "pages",
+            "revisions",
+            "attachments",
         }
         assert not freehold_tables & tables

--- a/api/tests/test_models_smoke.py
+++ b/api/tests/test_models_smoke.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
-from freehold.models import Collection, Page, Revision, Space, Workspace
+from freehold.models import Collection, Organization, Page, Revision, Space, Workspace
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
 
@@ -26,7 +26,11 @@ def session(engine):
 
 
 def test_create_workspace_hierarchy(session):
-    workspace = Workspace(slug="smoke-ws", name="Smoke Workspace")
+    org = Organization(slug="smoke-org", name="Smoke Org")
+    session.add(org)
+    session.flush()
+
+    workspace = Workspace(org_id=org.id, slug="smoke-ws", name="Smoke Workspace")
     session.add(workspace)
     session.flush()
 

--- a/api/tests/test_rbac.py
+++ b/api/tests/test_rbac.py
@@ -1,0 +1,286 @@
+"""Tests for role-based access control: org membership enforcement on API routes."""
+
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from freehold.auth import COOKIE_NAME, create_session_jwt, reset_oidc_config
+from freehold.models import (
+    Collection,
+    Organization,
+    OrgMembership,
+    OrgRole,
+    Page,
+    Revision,
+    Space,
+    User,
+    Workspace,
+)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    reset_oidc_config()
+    yield
+    reset_oidc_config()
+
+
+@pytest.fixture
+def client():
+    from freehold.app import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _make_user(session, email: str, name: str = "Test User") -> User:
+    user = User(
+        oidc_issuer="https://test.example.com",
+        oidc_subject=uuid.uuid4().hex,
+        email=email,
+        name=name,
+    )
+    session.add(user)
+    session.flush()
+    return user
+
+
+def _make_org_with_workspace(session) -> tuple:
+    """Create an org with a workspace containing a full hierarchy."""
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Test Org")
+    session.add(org)
+    session.flush()
+
+    ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="Test Workspace")
+    session.add(ws)
+    session.flush()
+
+    space = Space(workspace_id=ws.id, slug="main", name="Main")
+    session.add(space)
+    session.flush()
+
+    col = Collection(space_id=space.id, slug="docs", name="Docs")
+    session.add(col)
+    session.flush()
+
+    page = Page(collection_id=col.id, slug="test-page", title="Test Page")
+    session.add(page)
+    session.flush()
+
+    rev = Revision(page_id=page.id, content="# Test")
+    session.add(rev)
+    session.flush()
+    page.current_revision_id = rev.id
+    session.flush()
+
+    return org, ws, space, col, page
+
+
+def _add_membership(session, org, user, role: OrgRole) -> OrgMembership:
+    m = OrgMembership(org_id=org.id, user_id=user.id, email=user.email, role=role.value)
+    session.add(m)
+    session.flush()
+    return m
+
+
+def _auth_cookie(client, user):
+    token = create_session_jwt(user.id, user.email, user.name)
+    client.cookies.set(COOKIE_NAME, token)
+
+
+class TestWorkspaceRBAC:
+    """Test role enforcement on workspace endpoints."""
+
+    def test_viewer_can_read_workspace(self, client):
+        from freehold.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer@test.com")
+            org, ws, *_ = _make_org_with_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.get(f"/api/workspaces/{ws.id}")
+            assert res.status_code == 200
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_non_member_cannot_read_workspace(self, client):
+        from freehold.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "outsider@test.com")
+            org, ws, *_ = _make_org_with_workspace(db)
+            # No membership added
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.get(f"/api/workspaces/{ws.id}")
+            assert res.status_code == 403
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_viewer_cannot_delete_workspace(self, client):
+        from freehold.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-del@test.com")
+            org, ws, *_ = _make_org_with_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.delete(f"/api/workspaces/{ws.id}")
+            assert res.status_code == 403
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_owner_can_delete_workspace(self, client):
+        from freehold.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "owner-del@test.com")
+            org, ws, *_ = _make_org_with_workspace(db)
+            _add_membership(db, org, user, OrgRole.OWNER)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.delete(f"/api/workspaces/{ws.id}")
+            assert res.status_code == 204
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_api_key_bypasses_rbac(self, client, monkeypatch):
+        monkeypatch.setenv("API_KEY", "test-key")
+        from freehold.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            org, ws, *_ = _make_org_with_workspace(db)
+            db.commit()
+
+            res = client.get(
+                f"/api/workspaces/{ws.id}",
+                headers={"X-API-Key": "test-key"},
+            )
+            assert res.status_code == 200
+        finally:
+            db.rollback()
+
+    def test_list_workspaces_scoped_to_user_orgs(self, client):
+        from freehold.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "scoped@test.com")
+            org1, ws1, *_ = _make_org_with_workspace(db)
+            org2, ws2, *_ = _make_org_with_workspace(db)
+            _add_membership(db, org1, user, OrgRole.VIEWER)
+            # user is NOT a member of org2
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.get("/api/workspaces")
+            assert res.status_code == 200
+            ws_ids = {w["id"] for w in res.json()}
+            assert str(ws1.id) in ws_ids
+            assert str(ws2.id) not in ws_ids
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestEditorRole:
+    """Test that editors can create/edit but not delete."""
+
+    def test_editor_can_create_space(self, client):
+        from freehold.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor@test.com")
+            org, ws, *_ = _make_org_with_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(
+                f"/api/workspaces/{ws.id}/spaces",
+                json={"slug": "new-space", "name": "New Space"},
+            )
+            assert res.status_code == 201
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_editor_cannot_delete_space(self, client):
+        from freehold.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-del@test.com")
+            org, ws, space, *_ = _make_org_with_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.delete(f"/api/workspaces/{ws.id}/spaces/{space.id}")
+            assert res.status_code == 403
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_viewer_cannot_create_page(self, client):
+        from freehold.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-page@test.com")
+            org, ws, space, col, _ = _make_org_with_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(
+                f"/api/collections/{col.id}/pages",
+                json={"slug": "new-page", "title": "New Page", "content": "# Hello"},
+            )
+            assert res.status_code == 403
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_editor_can_update_page(self, client):
+        from freehold.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-page@test.com")
+            org, ws, space, col, page = _make_org_with_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.patch(
+                f"/api/pages/{page.id}",
+                json={"content": "# Updated"},
+            )
+            assert res.status_code == 200
+        finally:
+            db.rollback()
+            client.cookies.clear()

--- a/api/tests/test_restore.py
+++ b/api/tests/test_restore.py
@@ -57,6 +57,7 @@ def _make_bundle(
     ws_id: uuid.UUID | None = None,
     ws_slug: str = "test-ws",
     ws_name: str = "Test Workspace",
+    org_id: uuid.UUID | None = None,
     with_attachment: bool = False,
     attachment_data: bytes = b"attachment bytes",
     corrupt_attachment: bool = False,
@@ -68,6 +69,7 @@ def _make_bundle(
     now = datetime.now(timezone.utc).isoformat()
 
     ws_id = ws_id or uuid.uuid4()
+    org_id = org_id or uuid.uuid4()
     space_id = uuid.uuid4()
     col_id = uuid.uuid4()
     page_id = uuid.uuid4()
@@ -79,7 +81,19 @@ def _make_bundle(
     manifest: dict = {
         "schema_version": schema_version,
         "export_timestamp": now,
-        "workspace": {"id": str(ws_id), "slug": ws_slug, "name": ws_name, "created_at": now},
+        "organization": {
+            "id": str(org_id),
+            "slug": f"{ws_slug}-org",
+            "name": f"{ws_name} Org",
+            "created_at": now,
+        },
+        "workspace": {
+            "id": str(ws_id),
+            "org_id": str(org_id),
+            "slug": ws_slug,
+            "name": ws_name,
+            "created_at": now,
+        },
         "spaces": [
             {
                 "id": str(space_id),

--- a/api/tests/test_round_trip.py
+++ b/api/tests/test_round_trip.py
@@ -13,14 +13,14 @@ import uuid
 
 import psycopg2
 import pytest
-from alembic import command
 from alembic.config import Config
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
+from alembic import command
 from freehold.export import export_workspace
-from freehold.models import Attachment, Collection, Page, Revision, Space, Workspace
+from freehold.models import Attachment, Collection, Organization, Page, Revision, Space, Workspace
 from freehold.restore import restore_workspace
 from freehold.storage import StorageAdapter
 
@@ -104,7 +104,11 @@ def test_export_restore_round_trip(db_url, tmp_path):
     original: dict = {}
 
     with Session(engine) as session:
-        ws = Workspace(slug="roundtrip-ws", name="Round-Trip Workspace")
+        org = Organization(slug="roundtrip-org", name="Round-Trip Org")
+        session.add(org)
+        session.flush()
+
+        ws = Workspace(org_id=org.id, slug="roundtrip-ws", name="Round-Trip Workspace")
         session.add(ws)
         session.flush()
 
@@ -150,8 +154,14 @@ def test_export_restore_round_trip(db_url, tmp_path):
         export_storage.write(str(att.id), "diagram.png", att_data)
 
         # Capture ground truth before committing (IDs are assigned).
+        original["organization"] = {
+            "id": str(org.id),
+            "slug": org.slug,
+            "name": org.name,
+        }
         original["workspace"] = {
             "id": str(ws.id),
+            "org_id": str(ws.org_id),
             "slug": ws.slug,
             "name": ws.name,
         }
@@ -206,7 +216,7 @@ def test_export_restore_round_trip(db_url, tmp_path):
     # the row-level immutability trigger on the revisions table.
     # ------------------------------------------------------------------
     with engine.connect() as conn:
-        conn.execute(text("TRUNCATE workspaces CASCADE"))
+        conn.execute(text("TRUNCATE organizations, workspaces CASCADE"))
         conn.commit()
 
     # ------------------------------------------------------------------
@@ -226,9 +236,16 @@ def test_export_restore_round_trip(db_url, tmp_path):
     with Session(engine) as session:
         ws = session.query(Workspace).filter_by(slug="roundtrip-ws").one()
 
+        # Organization identity
+        restored_org = session.get(Organization, uuid.UUID(original["organization"]["id"]))
+        assert restored_org is not None, "Organization missing after restore"
+        assert restored_org.slug == original["organization"]["slug"]
+        assert restored_org.name == original["organization"]["name"]
+
         # Workspace identity
         assert str(ws.id) == original["workspace"]["id"]
         assert ws.name == original["workspace"]["name"]
+        assert str(ws.org_id) == original["workspace"]["org_id"]
 
         # Space / collection structure
         assert len(ws.spaces) == 1

--- a/api/tests/test_search.py
+++ b/api/tests/test_search.py
@@ -11,7 +11,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
 from alembic import command
-from freehold.models import Collection, Page, Revision, Space, Workspace
+from freehold.models import Collection, Organization, Page, Revision, Space, Workspace
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
 
@@ -75,7 +75,10 @@ def db(engine):
 
 
 def _seed_workspace(db: Session) -> tuple[Workspace, Space, Collection]:
-    ws = Workspace(slug=f"ws-{uuid.uuid4().hex[:6]}", name="Test Workspace")
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Test Org")
+    db.add(org)
+    db.flush()
+    ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="Test Workspace")
     db.add(ws)
     db.flush()
     space = Space(workspace_id=ws.id, slug="main", name="Main")
@@ -108,7 +111,10 @@ def test_search_vector_populated_on_revision_insert(db):
     """Inserting a revision should populate the page's search_vector."""
     ws, _, col = _seed_workspace(db)
     page = _create_page(
-        db, col, "test-page", "Quantum Computing",
+        db,
+        col,
+        "test-page",
+        "Quantum Computing",
         "An introduction to qubits and superposition",
     )
 

--- a/web/app/orgs/[orgId]/settings/page.tsx
+++ b/web/app/orgs/[orgId]/settings/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  getOrg,
+  listOrgMembers,
+  inviteMember,
+  updateMemberRole,
+  removeMember,
+} from "@/lib/api";
+import type { Organization, OrgMembership } from "@/lib/types";
+
+const ROLES = ["owner", "editor", "viewer"] as const;
+
+export default function OrgSettingsPage() {
+  const { orgId } = useParams<{ orgId: string }>();
+  const [org, setOrg] = useState<Organization | null>(null);
+  const [members, setMembers] = useState<OrgMembership[]>([]);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<string>("editor");
+  const [busy, setBusy] = useState(false);
+
+  async function load() {
+    try {
+      const [o, m] = await Promise.all([getOrg(orgId), listOrgMembers(orgId)]);
+      setOrg(o);
+      setMembers(m);
+    } catch (err) {
+      toast.error(String(err));
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, [orgId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleInvite(e: React.FormEvent) {
+    e.preventDefault();
+    if (!inviteEmail.trim()) return;
+    setBusy(true);
+    try {
+      await inviteMember(orgId, inviteEmail.trim(), inviteRole);
+      setInviteEmail("");
+      await load();
+      toast.success("Member invited");
+    } catch (err) {
+      toast.error(String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleRoleChange(membershipId: string, newRole: string) {
+    try {
+      await updateMemberRole(orgId, membershipId, newRole);
+      await load();
+    } catch (err) {
+      toast.error(String(err));
+    }
+  }
+
+  async function handleRemove(membershipId: string) {
+    try {
+      await removeMember(orgId, membershipId);
+      await load();
+    } catch (err) {
+      toast.error(String(err));
+    }
+  }
+
+  if (!org) {
+    return <div className="p-8 text-muted-foreground">Loading...</div>;
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl p-8 space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold">{org.name}</h1>
+        <p className="text-sm text-muted-foreground">Organization settings</p>
+      </div>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Members</h2>
+        <div className="divide-y rounded-md border">
+          {members.map((m) => (
+            <div key={m.id} className="flex items-center justify-between px-4 py-3">
+              <div className="min-w-0">
+                <p className="text-sm font-medium truncate">
+                  {m.email}
+                  {m.user_id === null && (
+                    <span className="ml-2 text-xs text-amber-600">(pending)</span>
+                  )}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <select
+                  value={m.role}
+                  onChange={(e) => handleRoleChange(m.id, e.target.value)}
+                  className="text-sm border rounded px-2 py-1 bg-background"
+                >
+                  {ROLES.map((r) => (
+                    <option key={r} value={r}>
+                      {r}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => handleRemove(m.id)}
+                  className="text-destructive hover:text-destructive"
+                >
+                  Remove
+                </Button>
+              </div>
+            </div>
+          ))}
+          {members.length === 0 && (
+            <p className="px-4 py-3 text-sm text-muted-foreground">No members</p>
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Invite member</h2>
+        <form onSubmit={handleInvite} className="flex gap-2">
+          <Input
+            type="email"
+            placeholder="Email address"
+            value={inviteEmail}
+            onChange={(e) => setInviteEmail(e.target.value)}
+            disabled={busy}
+            className="flex-1"
+          />
+          <select
+            value={inviteRole}
+            onChange={(e) => setInviteRole(e.target.value)}
+            className="text-sm border rounded px-2 py-1 bg-background"
+          >
+            {ROLES.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+          <Button type="submit" disabled={busy || !inviteEmail.trim()}>
+            Invite
+          </Button>
+        </form>
+        <p className="text-xs text-muted-foreground">
+          If the user hasn&apos;t signed up yet, the invite will be pending until they log in.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/web/app/orgs/[orgId]/settings/page.tsx
+++ b/web/app/orgs/[orgId]/settings/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useParams } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -78,9 +80,18 @@ export default function OrgSettingsPage() {
 
   return (
     <div className="mx-auto max-w-2xl p-8 space-y-8">
-      <div>
-        <h1 className="text-2xl font-bold">{org.name}</h1>
-        <p className="text-sm text-muted-foreground">Organization settings</p>
+      <div className="space-y-3">
+        <Link
+          href="/workspaces"
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-3 w-3" />
+          Workspaces
+        </Link>
+        <div>
+          <h1 className="text-2xl font-bold">{org.name}</h1>
+          <p className="text-sm text-muted-foreground">Organization settings</p>
+        </div>
       </div>
 
       <section className="space-y-4">

--- a/web/app/workspaces/page.tsx
+++ b/web/app/workspaces/page.tsx
@@ -6,18 +6,21 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { createWorkspace, getAuthStatus, listWorkspaces, logout, slugify } from "@/lib/api";
-import type { AuthStatus, Workspace } from "@/lib/types";
+import { Settings } from "lucide-react";
+import { createWorkspace, getAuthStatus, listOrgs, listWorkspaces, logout, slugify } from "@/lib/api";
+import type { AuthStatus, Organization, Workspace } from "@/lib/types";
 
 export default function WorkspacesPage() {
   const router = useRouter();
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [orgs, setOrgs] = useState<Organization[]>([]);
   const [auth, setAuth] = useState<AuthStatus | null>(null);
   const [name, setName] = useState("");
   const [creating, setCreating] = useState(false);
 
   useEffect(() => {
     listWorkspaces().then(setWorkspaces).catch(() => toast.error("Failed to load workspaces"));
+    listOrgs().then(setOrgs).catch(() => {});
     getAuthStatus().then(setAuth).catch(() => {});
   }, []);
 
@@ -59,21 +62,40 @@ export default function WorkspacesPage() {
           )}
         </div>
 
-        {workspaces.length > 0 && (
-          <div className="space-y-1">
-            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Workspaces
-            </p>
-            {workspaces.map((ws) => (
-              <Link
-                key={ws.id}
-                href={`/w/${ws.id}`}
-                className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm hover:bg-accent"
-              >
-                <span className="font-medium">{ws.name}</span>
-                <span className="text-xs text-muted-foreground">{ws.slug}</span>
-              </Link>
-            ))}
+        {orgs.length > 0 && (
+          <div className="space-y-4">
+            {orgs.map((org) => {
+              const orgWorkspaces = workspaces.filter((ws) => ws.org_id === org.id);
+              return (
+                <div key={org.id} className="space-y-1">
+                  <div className="flex items-center justify-between group">
+                    <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      {org.name}
+                    </p>
+                    <Link
+                      href={`/orgs/${org.id}/settings`}
+                      className="text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover:opacity-100"
+                      title="Organization settings"
+                    >
+                      <Settings className="h-3.5 w-3.5" />
+                    </Link>
+                  </div>
+                  {orgWorkspaces.map((ws) => (
+                    <Link
+                      key={ws.id}
+                      href={`/w/${ws.id}`}
+                      className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm hover:bg-accent"
+                    >
+                      <span className="font-medium">{ws.name}</span>
+                      <span className="text-xs text-muted-foreground">{ws.slug}</span>
+                    </Link>
+                  ))}
+                  {orgWorkspaces.length === 0 && (
+                    <p className="px-3 py-2 text-xs text-muted-foreground">No workspaces yet</p>
+                  )}
+                </div>
+              );
+            })}
           </div>
         )}
 

--- a/web/app/workspaces/page.tsx
+++ b/web/app/workspaces/page.tsx
@@ -6,17 +6,19 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { createWorkspace, listWorkspaces, slugify } from "@/lib/api";
-import type { Workspace } from "@/lib/types";
+import { createWorkspace, getAuthStatus, listWorkspaces, logout, slugify } from "@/lib/api";
+import type { AuthStatus, Workspace } from "@/lib/types";
 
 export default function WorkspacesPage() {
   const router = useRouter();
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [auth, setAuth] = useState<AuthStatus | null>(null);
   const [name, setName] = useState("");
   const [creating, setCreating] = useState(false);
 
   useEffect(() => {
     listWorkspaces().then(setWorkspaces).catch(() => toast.error("Failed to load workspaces"));
+    getAuthStatus().then(setAuth).catch(() => {});
   }, []);
 
   async function handleCreate(e: React.FormEvent) {
@@ -35,9 +37,26 @@ export default function WorkspacesPage() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-background px-4">
       <div className="w-full max-w-md space-y-6">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Freehold</h1>
-          <p className="text-sm text-muted-foreground">Your knowledge, owned outright.</p>
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">Freehold</h1>
+            <p className="text-sm text-muted-foreground">Your knowledge, owned outright.</p>
+          </div>
+          {auth?.authenticated && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span>{auth.user?.name}</span>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={async () => {
+                  const logoutUrl = await logout();
+                  window.location.href = logoutUrl ?? "/login";
+                }}
+              >
+                Sign out
+              </Button>
+            </div>
+          )}
         </div>
 
         {workspaces.length > 0 && (

--- a/web/components/app-sidebar.tsx
+++ b/web/components/app-sidebar.tsx
@@ -295,8 +295,8 @@ export function AppSidebar({ tree, user }: Props) {
               variant="ghost"
               size="xs"
               onClick={async () => {
-                await logout();
-                window.location.href = "/login";
+                const logoutUrl = await logout();
+                window.location.href = logoutUrl ?? "/login";
               }}
             >
               Sign out

--- a/web/components/app-sidebar.tsx
+++ b/web/components/app-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { ChevronDown, ChevronRight, FilePlus, FolderPlus, Plus } from "lucide-react";
+import { ChevronDown, ChevronRight, FilePlus, FolderPlus, Plus, Settings } from "lucide-react";
 import { toast } from "sonner";
 import {
   Sidebar,
@@ -239,6 +239,14 @@ export function AppSidebar({ tree, user }: Props) {
         </div>
         <div className="flex items-center justify-between px-2 pb-1.5 group">
           <span className="text-xs font-medium text-muted-foreground">{tree.name}</span>
+          <div className="flex items-center gap-1">
+            <a
+              href={`/orgs/${tree.org_id}/settings`}
+              className="hidden group-hover:flex items-center text-muted-foreground hover:text-foreground"
+              title="Organization settings"
+            >
+              <Settings className="h-3.5 w-3.5" />
+            </a>
           <CreateDialog
             trigger={
               <span className="hidden group-hover:flex items-center text-muted-foreground hover:text-foreground cursor-pointer" title="New space">
@@ -252,6 +260,7 @@ export function AppSidebar({ tree, user }: Props) {
               refresh();
             }}
           />
+          </div>
         </div>
         <div className="px-2 pb-2">
           <SearchDialog workspaceId={tree.id} />

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -212,8 +212,11 @@ export function getAuthStatus(): Promise<AuthStatus> {
   return apiFetch("/api/auth/me");
 }
 
-export async function logout(): Promise<void> {
-  await apiFetch("/api/auth/logout", { method: "POST" });
+export async function logout(): Promise<string | null> {
+  const data = await apiFetch<{ status: string; logout_url?: string }>("/api/auth/logout", {
+    method: "POST",
+  });
+  return data.logout_url ?? null;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -9,6 +9,8 @@ import type {
   Attachment,
   AuthStatus,
   Collection,
+  Organization,
+  OrgMembership,
   Page,
   Revision,
   SearchResponse,
@@ -212,6 +214,57 @@ export function getAuthStatus(): Promise<AuthStatus> {
 
 export async function logout(): Promise<void> {
   await apiFetch("/api/auth/logout", { method: "POST" });
+}
+
+// ---------------------------------------------------------------------------
+// Organizations
+// ---------------------------------------------------------------------------
+
+export function listOrgs(): Promise<Organization[]> {
+  return apiFetch("/api/orgs");
+}
+
+export function createOrg(slug: string, name: string): Promise<Organization> {
+  return apiFetch("/api/orgs", {
+    method: "POST",
+    body: JSON.stringify({ slug, name }),
+  });
+}
+
+export function getOrg(orgId: string): Promise<Organization> {
+  return apiFetch(`/api/orgs/${orgId}`);
+}
+
+export function listOrgMembers(orgId: string): Promise<OrgMembership[]> {
+  return apiFetch(`/api/orgs/${orgId}/members`);
+}
+
+export function inviteMember(
+  orgId: string,
+  email: string,
+  role: string
+): Promise<OrgMembership> {
+  return apiFetch(`/api/orgs/${orgId}/members`, {
+    method: "POST",
+    body: JSON.stringify({ email, role }),
+  });
+}
+
+export function updateMemberRole(
+  orgId: string,
+  membershipId: string,
+  role: string
+): Promise<OrgMembership> {
+  return apiFetch(`/api/orgs/${orgId}/members/${membershipId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ role }),
+  });
+}
+
+export function removeMember(orgId: string, membershipId: string): Promise<void> {
+  return apiFetch(`/api/orgs/${orgId}/members/${membershipId}`, {
+    method: "DELETE",
+  });
 }
 
 /** Convert a display name to a URL-safe slug. */

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1,7 +1,24 @@
 // TypeScript types mirroring the Freehold API Pydantic schemas.
 
+export interface Organization {
+  id: string;
+  slug: string;
+  name: string;
+  created_at: string;
+}
+
+export interface OrgMembership {
+  id: string;
+  org_id: string;
+  user_id: string | null;
+  email: string;
+  role: "owner" | "editor" | "viewer";
+  created_at: string;
+}
+
 export interface Workspace {
   id: string;
+  org_id: string;
   slug: string;
   name: string;
   created_at: string;
@@ -91,6 +108,7 @@ export interface SpaceTreeItem {
 
 export interface WorkspaceTree {
   id: string;
+  org_id: string;
   slug: string;
   name: string;
   spaces: SpaceTreeItem[];


### PR DESCRIPTION
## Summary

Closes #39

- Add `organizations` and `org_memberships` tables with three roles (owner, editor, viewer), enforced via RBAC dependency factories on all API endpoints
- Invite flow with pending memberships: admins invite by email, pending records auto-claimed on first OIDC login; personal org auto-created for users with no memberships
- Export/restore upgraded to schema v2 with org metadata (v1 bundles still restorable)
- Org settings UI (member list, role editing, invite form) linked from sidebar
- API key and anonymous auth bypass all role checks for backward compatibility

## Key changes

- **Migration**: `0999ffe7b838` — new tables, `org_id` FK on workspaces, backfill existing data, drop `revisions_no_delete` trigger (was blocking FK CASCADE deletes)
- **RBAC module** (`rbac.py`): dependency factories that resolve resource chains (page → collection → space → workspace → org) via single-query JOINs
- **Auth callback**: claims pending memberships by email, creates personal org if user has none
- **All routers**: injected role checks (viewer for reads, editor for writes, owner for deletes)
- **Export/restore**: schema v2 includes org metadata; v1 backward compat creates a new org on restore

## Test plan

- [x] All 58 backend tests pass (including round-trip regression anchor)
- [x] 10 new RBAC tests covering role matrix, API key bypass, workspace scoping, and cross-role enforcement
- [x] `ruff check` and `ruff format` clean
- [x] Frontend builds successfully
- [x] Manual: OIDC login → personal org created → create workspace → invite member → second user claims pending membership → role enforcement works
- [x] Manual: export workspace → restore → org metadata preserved