### PR TITLE
feat: editor enhancements — JSON storage, code blocks, tables, page mentions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,8 @@ freehold/
 │   │       ├── 69d839126d73_create_core_schema.py
 │   │       ├── d3981f696939_add_full_text_search.py
 │   │       ├── 35eb203afc65_add_users_table.py
-│   │       └── 0999ffe7b838_add_organizations_and_rbac.py
+│   │       ├── 0999ffe7b838_add_organizations_and_rbac.py
+│   │       └── c333d20a46d9_add_content_format_to_revisions.py
 │   ├── freehold/                     # Main package
 │   │   ├── app.py                    # FastAPI app factory, CORS + session middleware
 │   │   ├── auth.py                   # OIDC config, session JWT helpers, cookie params
@@ -212,7 +213,7 @@ organizations → org_memberships (user roles: owner/editor/viewer)
 | spaces | id, workspace_id (FK cascade), slug (unique per workspace), name |
 | collections | id, space_id (FK cascade), slug (unique per space), name |
 | pages | id, collection_id (FK cascade), slug (unique per collection), title, current_revision_id (deferred FK), search_vector (tsvector, GIN-indexed, trigger-managed) |
-| revisions | id, page_id (FK cascade), content (TEXT) — **immutable via PG trigger** |
+| revisions | id, page_id (FK cascade), content (TEXT), content_format (TEXT: 'markdown'\|'json') — **immutable via PG trigger** |
 | attachments | id, page_id (FK cascade), filename, hash (SHA256), size_bytes |
 | users | id, oidc_issuer, oidc_subject (unique together), email, name, last_login_at |
 
@@ -269,16 +270,21 @@ class StorageAdapter(ABC):
 
 ```
 freehold-export-{workspace-slug}-{timestamp}.zip
-├── manifest.json        # workspace + org metadata, all entity IDs, schema version (v2)
+├── manifest.json        # workspace + org metadata, all entity IDs, schema version (v3)
 ├── pages/
-│   └── {page-id}.md     # current content of each page
+│   ├── {page-id}.md     # human-readable Markdown (all pages)
+│   └── {page-id}.json   # canonical BlockNote JSON (JSON-format pages only)
 ├── revisions/
 │   └── {page-id}/
-│       └── {revision-id}.md
+│       ├── {revision-id}.md     # Markdown revisions (legacy) or human-readable export
+│       └── {revision-id}.json   # BlockNote JSON revisions (canonical)
 ├── assets/
 │   └── {attachment-id}{ext}
 └── links.json           # internal links, broken links, orphaned pages
 ```
+
+v1/v2 bundles had only `.md` files. v3 adds `.json` as canonical for JSON-format revisions.
+Restore supports v1, v2, and v3 bundles.
 
 ### Authentication
 
@@ -298,6 +304,8 @@ Freehold supports three authentication methods, checked in priority order:
 
 - **API client** (`lib/api.ts`): all server calls go through `apiFetch<T>()` which injects auth headers and handles errors
 - **Auto-save**: `PageEditor` debounces saves 2 seconds after last keystroke; shows Saving… / Saved / Error status
+- **Content format**: new saves store BlockNote JSON (`content_format='json'`); legacy Markdown revisions are loaded via `tryParseMarkdownToBlocks` for backward compat
+- **Editor features**: code blocks (Shiki syntax highlighting), tables (`TableHandlesController`), `@` page mentions (`SuggestionMenuController` → `searchWorkspace`)
 - **Sidebar create flows**: hover-to-reveal `+` buttons open `CreateDialog` with slug auto-generation via `slugify()`
 - **UI library**: Base UI (`@base-ui/react`) with Tailwind CSS 4 — uses `render` prop pattern, not `asChild`
 - **Theme**: `next-themes` wraps the root layout

--- a/api/alembic/versions/c333d20a46d9_add_content_format_to_revisions.py
+++ b/api/alembic/versions/c333d20a46d9_add_content_format_to_revisions.py
@@ -1,0 +1,35 @@
+"""add_content_format_to_revisions
+
+Revision ID: c333d20a46d9
+Revises: 0999ffe7b838
+Create Date: 2026-04-11 23:04:29.642488
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c333d20a46d9'
+down_revision: Union[str, Sequence[str], None] = '0999ffe7b838'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add content_format column to revisions table.
+
+    New revisions store BlockNote JSON; existing rows default to 'markdown'
+    to maintain backward compatibility.
+    """
+    op.add_column(
+        'revisions',
+        sa.Column('content_format', sa.Text(), nullable=False, server_default='markdown'),
+    )
+
+
+def downgrade() -> None:
+    """Remove content_format column from revisions table."""
+    op.drop_column('revisions', 'content_format')

--- a/api/freehold/export.py
+++ b/api/freehold/export.py
@@ -1,12 +1,17 @@
 """Export a workspace to a portable zip bundle.
 
-Bundle layout:
+Bundle layout (schema v3):
     freehold-export-{workspace-slug}-{timestamp}.zip
     ├── manifest.json
-    ├── pages/{page-id}.md
+    ├── pages/{page-id}.json          # canonical BlockNote JSON (v3 only, format='json')
+    ├── pages/{page-id}.md            # human-readable Markdown (all versions)
     ├── assets/{asset-id}{ext}
-    ├── revisions/{page-id}/{revision-id}.md
+    ├── revisions/{page-id}/{revision-id}.json   # for JSON-format revisions
+    ├── revisions/{page-id}/{revision-id}.md     # for all revisions
     └── links.json
+
+v1/v2 bundles only had .md files. v3 adds .json as the canonical format for
+revisions stored as BlockNote JSON.
 """
 
 import hashlib
@@ -22,7 +27,7 @@ from sqlalchemy.orm import Session
 from .models import Attachment, Page, Workspace
 from .storage import StorageAdapter
 
-SCHEMA_VERSION = "2"
+SCHEMA_VERSION = "3"
 
 
 def _sha256(data: bytes) -> str:
@@ -42,6 +47,141 @@ def _collect_pages(workspace: Workspace) -> list[Page]:
     return pages
 
 
+# ---------------------------------------------------------------------------
+# BlockNote JSON → Markdown converter (for human-readable export)
+# ---------------------------------------------------------------------------
+
+
+def _inline_to_text(inline_content: list) -> str:
+    """Convert BlockNote inline content array to Markdown text."""
+    text = ""
+    for item in inline_content:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type", "text")
+        if item_type == "text":
+            t = item.get("text", "")
+            styles = item.get("styles", {})
+            if styles.get("code"):
+                t = f"`{t}`"
+            if styles.get("bold"):
+                t = f"**{t}**"
+            if styles.get("italic"):
+                t = f"*{t}*"
+            if styles.get("strike"):
+                t = f"~~{t}~~"
+            text += t
+        elif item_type == "link":
+            href = item.get("href", "")
+            link_content = item.get("content", [])
+            link_text = _inline_to_text(link_content)
+            text += f"[{link_text}]({href})"
+        elif item_type == "mention":
+            # Page mention: rendered as the mention text
+            text += item.get("props", {}).get("user", "")
+    return text
+
+
+def _blocks_to_markdown(blocks: list, indent: int = 0) -> list[str]:
+    """Recursively convert BlockNote block array to Markdown lines."""
+    lines: list[str] = []
+    prefix = "  " * indent
+
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type", "paragraph")
+        content = block.get("content", [])
+        props = block.get("props", {})
+        children = block.get("children", [])
+
+        # Table blocks store content as a 2D grid, not inline content
+        if btype == "table":
+            rows = content if isinstance(content, list) else []
+            if rows:
+                md_rows = []
+                for i, row in enumerate(rows):
+                    cells = row.get("cells", []) if isinstance(row, dict) else []
+                    cell_texts = [
+                        _inline_to_text(cell) if isinstance(cell, list) else str(cell)
+                        for cell in cells
+                    ]
+                    md_rows.append(f"{prefix}| {' | '.join(cell_texts)} |")
+                    if i == 0:
+                        separator = f"{prefix}|" + "|".join(
+                            [" --- " for _ in cells]
+                        ) + "|"
+                        md_rows.append(separator)
+                lines.extend(md_rows)
+            continue
+
+        text = _inline_to_text(content) if isinstance(content, list) else str(content)
+
+        if btype == "paragraph":
+            if text.strip():
+                lines.append(f"{prefix}{text}")
+            else:
+                lines.append("")
+        elif btype == "heading":
+            level = int(props.get("level", 1))
+            lines.append(f"{prefix}{'#' * level} {text}")
+        elif btype == "bulletListItem":
+            lines.append(f"{prefix}- {text}")
+        elif btype == "numberedListItem":
+            lines.append(f"{prefix}1. {text}")
+        elif btype == "checkListItem":
+            checked = "x" if props.get("checked") else " "
+            lines.append(f"{prefix}- [{checked}] {text}")
+        elif btype == "codeBlock":
+            language = props.get("language", "")
+            lines.append(f"{prefix}```{language}")
+            lines.append(text)
+            lines.append(f"{prefix}```")
+        elif btype == "quote":
+            lines.append(f"{prefix}> {text}")
+        elif btype == "divider":
+            lines.append(f"{prefix}---")
+        elif btype == "image":
+            url = props.get("url", "")
+            caption = props.get("caption", "") or props.get("name", "image")
+            lines.append(f"{prefix}![{caption}]({url})")
+        elif btype == "file":
+            url = props.get("url", "")
+            name = props.get("name", "file")
+            lines.append(f"{prefix}[{name}]({url})")
+        elif btype == "toggleListItem":
+            lines.append(f"{prefix}> {text}")
+        else:
+            if text.strip():
+                lines.append(f"{prefix}{text}")
+
+        if children:
+            lines.extend(_blocks_to_markdown(children, indent + 1))
+
+    return lines
+
+
+def blocks_to_markdown(content_json: str) -> str:
+    """Convert a BlockNote JSON string to human-readable Markdown.
+
+    Used during export to generate the .md companion file for JSON revisions.
+    Returns the original string unchanged if parsing fails.
+    """
+    try:
+        blocks = json.loads(content_json)
+        if not isinstance(blocks, list):
+            return content_json
+        lines = _blocks_to_markdown(blocks)
+        return "\n".join(lines)
+    except (json.JSONDecodeError, TypeError, KeyError):
+        return content_json
+
+
+# ---------------------------------------------------------------------------
+# Link analysis (Markdown only — best-effort for JSON revisions)
+# ---------------------------------------------------------------------------
+
+
 def _build_links(pages: list[Page], page_id_set: set[str]) -> dict:
     internal_links: list[dict] = []
     broken_links: list[dict] = []
@@ -49,9 +189,15 @@ def _build_links(pages: list[Page], page_id_set: set[str]) -> dict:
     for page in pages:
         if page.current_revision is None:
             continue
-        for href in _extract_hrefs(page.current_revision.content or ""):
+        content = page.current_revision.content or ""
+        content_format = page.current_revision.content_format
+
+        # For JSON revisions, convert to markdown first for link extraction
+        if content_format == "json":
+            content = blocks_to_markdown(content)
+
+        for href in _extract_hrefs(content):
             source = str(page.id)
-            # Treat /pages/<id> paths and bare UUIDs that match known pages as internal.
             candidate = href.removeprefix("/pages/").rstrip("/")
             if candidate in page_id_set:
                 internal_links.append(
@@ -80,7 +226,12 @@ def _build_manifest(
     collections = [c for s in spaces for c in s.collections]
 
     revision_records = [
-        {"id": str(rev.id), "page_id": str(rev.page_id), "created_at": rev.created_at.isoformat()}
+        {
+            "id": str(rev.id),
+            "page_id": str(rev.page_id),
+            "content_format": rev.content_format,
+            "created_at": rev.created_at.isoformat(),
+        }
         for page in pages
         for rev in page.revisions
     ]
@@ -176,13 +327,31 @@ def export_workspace(
         for page in pages:
             page_id = str(page.id)
 
-            # Current page content.
-            content = page.current_revision.content if page.current_revision else ""
-            zf.writestr(f"pages/{page_id}.md", content)
+            # Current page content — always write .md; also write .json for JSON format.
+            if page.current_revision:
+                content = page.current_revision.content
+                fmt = page.current_revision.content_format
+            else:
+                content = ""
+                fmt = "markdown"
+
+            if fmt == "json":
+                zf.writestr(f"pages/{page_id}.json", content)
+                zf.writestr(f"pages/{page_id}.md", blocks_to_markdown(content))
+            else:
+                zf.writestr(f"pages/{page_id}.md", content)
 
             # Every revision (append-only history).
             for rev in page.revisions:
-                zf.writestr(f"revisions/{page_id}/{rev.id}.md", rev.content)
+                rev_id = str(rev.id)
+                if rev.content_format == "json":
+                    zf.writestr(f"revisions/{page_id}/{rev_id}.json", rev.content)
+                    zf.writestr(
+                        f"revisions/{page_id}/{rev_id}.md",
+                        blocks_to_markdown(rev.content),
+                    )
+                else:
+                    zf.writestr(f"revisions/{page_id}/{rev_id}.md", rev.content)
 
         # Attachments — verify hash before including.
         all_attachments: list[Attachment] = []

--- a/api/freehold/models.py
+++ b/api/freehold/models.py
@@ -202,6 +202,8 @@ class Revision(Base):
     )
     page_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
+    # 'markdown' for legacy plain-text revisions; 'json' for BlockNote JSON revisions.
+    content_format: Mapped[str] = mapped_column(Text, nullable=False, server_default="markdown")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/api/freehold/restore.py
+++ b/api/freehold/restore.py
@@ -46,9 +46,9 @@ def restore_workspace(
         manifest = json.loads(zf.read("manifest.json"))
 
         schema_version = manifest.get("schema_version")
-        if schema_version not in ("1", "2"):
+        if schema_version not in ("1", "2", "3"):
             raise ValueError(
-                f"Unsupported bundle schema version '{schema_version}' (expected '1' or '2')"
+                f"Unsupported bundle schema version '{schema_version}' (expected '1', '2', or '3')"
             )
 
         ws_meta = manifest["workspace"]
@@ -66,8 +66,8 @@ def restore_workspace(
             )
 
         # --- Organization ---
-        # v2 bundles include org metadata; v1 bundles create a new org from workspace name.
-        if schema_version == "2" and "organization" in manifest:
+        # v2/v3 bundles include org metadata; v1 bundles create a new org from workspace name.
+        if schema_version in ("2", "3") and "organization" in manifest:
             org_meta = manifest["organization"]
             org_id = uuid.UUID(org_meta["id"])
             existing_org = session.get(Organization, org_id)
@@ -158,7 +158,12 @@ def restore_workspace(
 
         # --- Revisions ---
         for r in manifest["revisions"]:
-            rev_file = f"revisions/{r['page_id']}/{r['id']}.md"
+            content_format = r.get("content_format", "markdown")
+            if content_format == "json":
+                # v3 bundle: canonical content is the .json file
+                rev_file = f"revisions/{r['page_id']}/{r['id']}.json"
+            else:
+                rev_file = f"revisions/{r['page_id']}/{r['id']}.md"
             if rev_file not in names:
                 raise ValueError(f"Bundle is missing revision file: {rev_file}")
             content = zf.read(rev_file).decode()
@@ -167,6 +172,7 @@ def restore_workspace(
                     id=uuid.UUID(r["id"]),
                     page_id=uuid.UUID(r["page_id"]),
                     content=content,
+                    content_format=content_format,
                     created_at=_dt(r["created_at"]),
                 )
             )

--- a/api/freehold/routers/pages.py
+++ b/api/freehold/routers/pages.py
@@ -41,6 +41,7 @@ def _get_page_or_404(collection_id: UUID, page_id: UUID, db: Session) -> Page:
 def _page_with_content(page: Page) -> PageReadWithContent:
     """Build the response schema, pulling content from the current revision."""
     content = page.current_revision.content if page.current_revision else None
+    content_format = page.current_revision.content_format if page.current_revision else "markdown"
     return PageReadWithContent(
         id=page.id,
         collection_id=page.collection_id,
@@ -49,6 +50,7 @@ def _page_with_content(page: Page) -> PageReadWithContent:
         current_revision_id=page.current_revision_id,
         created_at=page.created_at,
         content=content,
+        content_format=content_format,
     )
 
 
@@ -87,7 +89,7 @@ def create_page(
     db.add(page)
     db.flush()
 
-    rev = Revision(page_id=page.id, content=body.content)
+    rev = Revision(page_id=page.id, content=body.content, content_format=body.content_format)
     db.add(rev)
     db.flush()
 
@@ -135,7 +137,7 @@ def update_page(
         page.title = body.title
 
     if body.content is not None:
-        rev = Revision(page_id=page.id, content=body.content)
+        rev = Revision(page_id=page.id, content=body.content, content_format=body.content_format)
         db.add(rev)
         db.flush()
         page.current_revision_id = rev.id

--- a/api/freehold/routers/pages_global.py
+++ b/api/freehold/routers/pages_global.py
@@ -32,6 +32,7 @@ def _get_page_or_404(page_id: UUID, db: Session) -> Page:
 
 def _page_with_content(page: Page) -> PageReadWithContent:
     content = page.current_revision.content if page.current_revision else None
+    content_format = page.current_revision.content_format if page.current_revision else "markdown"
     return PageReadWithContent(
         id=page.id,
         collection_id=page.collection_id,
@@ -40,6 +41,7 @@ def _page_with_content(page: Page) -> PageReadWithContent:
         current_revision_id=page.current_revision_id,
         created_at=page.created_at,
         content=content,
+        content_format=content_format,
     )
 
 
@@ -66,7 +68,7 @@ def update_page(
         page.title = body.title
 
     if body.content is not None:
-        rev = Revision(page_id=page.id, content=body.content)
+        rev = Revision(page_id=page.id, content=body.content, content_format=body.content_format)
         db.add(rev)
         db.flush()
         page.current_revision_id = rev.id

--- a/api/freehold/schemas.py
+++ b/api/freehold/schemas.py
@@ -78,11 +78,13 @@ class PageCreate(BaseModel):
     slug: str
     title: str
     content: str = ""  # seeds the first revision
+    content_format: str = "markdown"  # 'markdown' or 'json'
 
 
 class PageUpdate(BaseModel):
     title: str | None = None
     content: str | None = None  # non-None → new revision appended
+    content_format: str = "markdown"  # format of the new content
 
 
 class PageRead(_ReadBase):
@@ -96,6 +98,7 @@ class PageRead(_ReadBase):
 
 class PageReadWithContent(PageRead):
     content: str | None = None  # current revision content; None if no revisions yet
+    content_format: str = "markdown"  # format of current revision content
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +109,7 @@ class PageReadWithContent(PageRead):
 class RevisionRead(_ReadBase):
     id: UUID
     page_id: UUID
+    content_format: str
     created_at: datetime
 
 

--- a/api/tests/test_round_trip.py
+++ b/api/tests/test_round_trip.py
@@ -126,13 +126,60 @@ def test_export_restore_round_trip(db_url, tmp_path):
         session.add_all([page1, page2])
         session.flush()
 
-        rev1a = Revision(page_id=page1.id, content="# Page One\nFirst draft.")
-        rev1b = Revision(page_id=page1.id, content="# Page One\nSecond draft.")
+        rev1a = Revision(
+            page_id=page1.id,
+            content="# Page One\nFirst draft.",
+            content_format="markdown",
+        )
+        rev1b = Revision(
+            page_id=page1.id,
+            content="# Page One\nSecond draft.",
+            content_format="markdown",
+        )
+        # Simulate a JSON revision (BlockNote format) for the current revision
+        import json as _json
+
+        _h1_block = {
+            "id": "a1",
+            "type": "heading",
+            "props": {
+                "level": 1,
+                "textColor": "default",
+                "backgroundColor": "default",
+                "textAlignment": "left",
+            },
+            "content": [{"type": "text", "text": "Page One", "styles": {}}],
+            "children": [],
+        }
+        _p_block = {
+            "id": "a2",
+            "type": "paragraph",
+            "props": {
+                "textColor": "default",
+                "backgroundColor": "default",
+                "textAlignment": "left",
+            },
+            "content": [
+                {"type": "text", "text": "See also ", "styles": {}},
+                {
+                    "type": "link",
+                    "href": f"/pages/{page2.id}",
+                    "content": [{"type": "text", "text": "Page Two", "styles": {}}],
+                },
+            ],
+            "children": [],
+        }
+        rev1c_content = _json.dumps([_h1_block, _p_block])
         rev1c = Revision(
             page_id=page1.id,
-            content=f"# Page One\nSee also [Page Two](/pages/{page2.id}).",
+            content=rev1c_content,
+            content_format="json",
         )
-        rev2a = Revision(page_id=page2.id, content="# Page Two\nOnly revision.")
+        rev2a = Revision(
+            page_id=page2.id,
+            content="# Page Two\nOnly revision.",
+            content_format="markdown",
+        )
         session.add_all([rev1a, rev1b, rev1c, rev2a])
         session.flush()
 
@@ -173,9 +220,18 @@ def test_export_restore_round_trip(db_url, tmp_path):
                 "title": page1.title,
                 "current_revision_id": str(page1.current_revision_id),
                 "revisions": {
-                    str(rev1a.id): rev1a.content,
-                    str(rev1b.id): rev1b.content,
-                    str(rev1c.id): rev1c.content,
+                    str(rev1a.id): {
+                        "content": rev1a.content,
+                        "content_format": rev1a.content_format,
+                    },
+                    str(rev1b.id): {
+                        "content": rev1b.content,
+                        "content_format": rev1b.content_format,
+                    },
+                    str(rev1c.id): {
+                        "content": rev1c.content,
+                        "content_format": rev1c.content_format,
+                    },
                 },
             },
             str(page2.id): {
@@ -183,7 +239,10 @@ def test_export_restore_round_trip(db_url, tmp_path):
                 "title": page2.title,
                 "current_revision_id": str(page2.current_revision_id),
                 "revisions": {
-                    str(rev2a.id): rev2a.content,
+                    str(rev2a.id): {
+                        "content": rev2a.content,
+                        "content_format": rev2a.content_format,
+                    },
                 },
             },
         }
@@ -279,9 +338,12 @@ def test_export_restore_round_trip(db_url, tmp_path):
                 f"Revision IDs differ for page {page_id}. "
                 f"Got: {set(restored_revs.keys())} Expected: {set(expected['revisions'].keys())}"
             )
-            for rev_id, content in expected["revisions"].items():
-                assert restored_revs[rev_id].content == content, (
+            for rev_id, rev_data in expected["revisions"].items():
+                assert restored_revs[rev_id].content == rev_data["content"], (
                     f"Content mismatch for revision {rev_id}"
+                )
+                assert restored_revs[rev_id].content_format == rev_data["content_format"], (
+                    f"content_format mismatch for revision {rev_id}"
                 )
 
         # Attachment metadata

--- a/web/components/page-editor.tsx
+++ b/web/components/page-editor.tsx
@@ -3,21 +3,37 @@
 /**
  * PageEditor — the main editing surface.
  *
- * Uses BlockNote for a Notion-style block editor.
- * Content is serialized to/from Markdown for storage so the export bundle
- * remains human-readable. BlockNote's internal JSON is never persisted.
+ * Uses BlockNote for a Notion-style block editor. Content is stored as
+ * BlockNote JSON (content_format='json') for new saves. Legacy Markdown
+ * revisions (content_format='markdown') are read-only-parsed on load for
+ * backward compatibility.
  *
- * Save behavior: auto-saves 2 seconds after the user stops typing.
- * Each save creates a new revision via PATCH /api/pages/{id}.
+ * Features:
+ * - Code blocks with Shiki syntax highlighting
+ * - Tables with drag handles (TableHandlesController)
+ * - @-mention page links via suggestion menu (SuggestionMenuController)
+ * - Auto-save 2 seconds after last keystroke
  */
 
 import "@blocknote/core/fonts/inter.css";
 import "@blocknote/mantine/style.css";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useParams } from "next/navigation";
 import { useTheme } from "next-themes";
-import { useCreateBlockNote } from "@blocknote/react";
+import {
+  BlockNoteSchema,
+  createCodeBlockSpec,
+  defaultBlockSpecs,
+} from "@blocknote/core";
+import {
+  SuggestionMenuController,
+  TableHandlesController,
+  useCreateBlockNote,
+  type DefaultReactSuggestionItem,
+} from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
+import { createHighlighter } from "shiki";
 import { Clock, Upload } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -34,6 +50,7 @@ import {
   getRevision,
   listAttachments,
   listRevisions,
+  searchWorkspace,
   updatePage,
   uploadAttachment,
 } from "@/lib/api";
@@ -45,16 +62,56 @@ interface Props {
   initialPage: Page;
 }
 
+// ---------------------------------------------------------------------------
+// BlockNote schema with Shiki syntax highlighting for code blocks
+// ---------------------------------------------------------------------------
+
+const schema = BlockNoteSchema.create({
+  blockSpecs: {
+    ...defaultBlockSpecs,
+    codeBlock: createCodeBlockSpec({
+      createHighlighter: () =>
+        createHighlighter({
+          themes: ["github-light", "github-dark"],
+          langs: [
+            "javascript",
+            "typescript",
+            "python",
+            "bash",
+            "json",
+            "html",
+            "css",
+            "sql",
+            "go",
+            "rust",
+            "yaml",
+            "markdown",
+          ],
+        }),
+      defaultLanguage: "text",
+    }),
+  },
+});
+
+// ---------------------------------------------------------------------------
+// PageEditor component
+// ---------------------------------------------------------------------------
+
 export function PageEditor({ initialPage }: Props) {
   const [title, setTitle] = useState(initialPage.title);
   const [status, setStatus] = useState<SaveStatus>("idle");
   const { resolvedTheme } = useTheme();
 
+  // Extract workspaceId from the URL for page mention search
+  const params = useParams<{ workspaceId?: string }>();
+  const workspaceId = params?.workspaceId;
+
   // Refs for save logic — avoids stale closures in debounce callbacks
   const titleRef = useRef(title);
   const savedTitleRef = useRef(initialPage.title);
   const savedContentRef = useRef(initialPage.content ?? "");
-  const pendingMarkdownRef = useRef(initialPage.content ?? "");
+  // pendingContentRef holds the current JSON string to save
+  const pendingContentRef = useRef(initialPage.content ?? "");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isInitializingRef = useRef(false);
 
@@ -62,23 +119,39 @@ export function PageEditor({ initialPage }: Props) {
     titleRef.current = title;
   }, [title]);
 
-  const editor = useCreateBlockNote();
+  const editor = useCreateBlockNote({ schema });
 
-  // Parse initial Markdown content into BlockNote blocks on mount
+  // Load initial content — JSON (new format) or Markdown (legacy)
   useEffect(() => {
     const content = initialPage.content;
     if (!content) return;
 
     isInitializingRef.current = true;
-    const blocks = editor.tryParseMarkdownToBlocks(content);
-    editor.replaceBlocks(editor.document, blocks);
+
+    const fmt = initialPage.content_format ?? "markdown";
+    if (fmt === "json") {
+      try {
+        const blocks = JSON.parse(content);
+        editor.replaceBlocks(editor.document, blocks);
+        pendingContentRef.current = content;
+      } catch {
+        // Malformed JSON: fall back to showing raw text
+        pendingContentRef.current = content;
+      }
+    } else {
+      // Legacy Markdown: parse into blocks
+      const blocks = editor.tryParseMarkdownToBlocks(content);
+      editor.replaceBlocks(editor.document, blocks);
+      // On first save this will be re-serialized as JSON
+      pendingContentRef.current = content;
+    }
+
     isInitializingRef.current = false;
-    pendingMarkdownRef.current = content;
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const saveNow = useCallback(async () => {
     const currentTitle = titleRef.current;
-    const currentContent = pendingMarkdownRef.current;
+    const currentContent = pendingContentRef.current;
 
     const newTitle = currentTitle !== savedTitleRef.current ? currentTitle : undefined;
     const newContent =
@@ -88,7 +161,11 @@ export function PageEditor({ initialPage }: Props) {
 
     setStatus("saving");
     try {
-      await updatePage(initialPage.id, { title: newTitle, content: newContent });
+      await updatePage(initialPage.id, {
+        title: newTitle,
+        content: newContent,
+        content_format: "json",
+      });
       savedTitleRef.current = currentTitle;
       savedContentRef.current = currentContent;
       setStatus("saved");
@@ -112,23 +189,59 @@ export function PageEditor({ initialPage }: Props) {
     };
   }, [title, scheduleSave]);
 
-  // Serialize editor blocks to Markdown and schedule a save
+  // Serialize editor document to JSON and schedule a save
   const handleEditorChange = useCallback(() => {
     if (isInitializingRef.current) return;
-    const markdown = editor.blocksToMarkdownLossy(editor.document);
-    pendingMarkdownRef.current = markdown;
+    const json = JSON.stringify(editor.document);
+    pendingContentRef.current = json;
     scheduleSave();
   }, [editor, scheduleSave]);
 
-  // Restore a revision: parse its Markdown into blocks and update editor
+  // Restore a revision into the editor
   const handleRestore = useCallback(
-    async (markdownContent: string) => {
-      const blocks = editor.tryParseMarkdownToBlocks(markdownContent);
-      editor.replaceBlocks(editor.document, blocks);
-      pendingMarkdownRef.current = markdownContent;
+    async (content: string, contentFormat: string) => {
+      if (contentFormat === "json") {
+        try {
+          const blocks = JSON.parse(content);
+          editor.replaceBlocks(editor.document, blocks);
+          pendingContentRef.current = content;
+        } catch {
+          toast.error("Could not parse revision content");
+          return;
+        }
+      } else {
+        // Legacy markdown revision
+        const blocks = editor.tryParseMarkdownToBlocks(content);
+        editor.replaceBlocks(editor.document, blocks);
+        // Re-serialize as JSON for the next save
+        pendingContentRef.current = JSON.stringify(editor.document);
+      }
       scheduleSave();
     },
     [editor, scheduleSave],
+  );
+
+  // ---------------------------------------------------------------------------
+  // @-mention suggestion menu — queries workspace pages
+  // ---------------------------------------------------------------------------
+
+  const getPageMentionItems = useCallback(
+    async (query: string): Promise<DefaultReactSuggestionItem[]> => {
+      if (!workspaceId) return [];
+      try {
+        const { results } = await searchWorkspace(workspaceId, query || " ");
+        return results.slice(0, 8).map((result) => ({
+          title: result.title,
+          subtext: `${result.space_name} / ${result.collection_name}`,
+          onItemClick: () => {
+            editor.createLink(`/w/${workspaceId}/pages/${result.page_id}`, result.title);
+          },
+        }));
+      } catch {
+        return [];
+      }
+    },
+    [editor, workspaceId],
   );
 
   const statusLabel = {
@@ -167,7 +280,16 @@ export function PageEditor({ initialPage }: Props) {
           onChange={handleEditorChange}
           theme={resolvedTheme === "dark" ? "dark" : "light"}
           style={{ minHeight: "100%" }}
-        />
+        >
+          {/* Table drag handles */}
+          <TableHandlesController />
+
+          {/* @-mention suggestion menu for page links */}
+          <SuggestionMenuController
+            triggerCharacter="@"
+            getItems={getPageMentionItems}
+          />
+        </BlockNoteView>
       </div>
     </div>
   );
@@ -182,7 +304,7 @@ function RevisionSheet({
   onRestore,
 }: {
   pageId: string;
-  onRestore: (content: string) => Promise<void>;
+  onRestore: (content: string, contentFormat: string) => Promise<void>;
 }) {
   const [revisions, setRevisions] = useState<Revision[]>([]);
   const [selected, setSelected] = useState<Revision | null>(null);
@@ -209,9 +331,21 @@ function RevisionSheet({
     }
   }
 
+  /** Display content for the preview pane — JSON is pretty-printed. */
+  function previewText(rev: Revision): string {
+    if (!rev.content) return "";
+    if (rev.content_format === "json") {
+      try {
+        return JSON.stringify(JSON.parse(rev.content), null, 2);
+      } catch {
+        return rev.content;
+      }
+    }
+    return rev.content;
+  }
+
   return (
     <Sheet onOpenChange={(open) => open && load()}>
-      {/* Base UI uses render prop instead of asChild */}
       <SheetTrigger render={<Button variant="ghost" size="sm" />}>
         <Clock className="mr-1 h-4 w-4" />
         History
@@ -236,17 +370,20 @@ function RevisionSheet({
                 <p className="text-muted-foreground">
                   {new Date(rev.created_at).toLocaleString()}
                 </p>
+                <p className="text-muted-foreground uppercase tracking-wide" style={{ fontSize: "10px" }}>
+                  {rev.content_format}
+                </p>
               </button>
             ))}
           </ScrollArea>
 
-          {/* Preview — raw Markdown for readability */}
+          {/* Preview */}
           <div className="flex flex-1 flex-col overflow-hidden">
             {selected ? (
               <>
                 <ScrollArea className="flex-1 p-3">
                   <pre className="whitespace-pre-wrap font-mono text-xs leading-relaxed">
-                    {selected.content}
+                    {previewText(selected)}
                   </pre>
                 </ScrollArea>
                 <div className="border-t p-3">
@@ -254,7 +391,7 @@ function RevisionSheet({
                     size="sm"
                     className="w-full"
                     onClick={async () => {
-                      await onRestore(selected.content!);
+                      await onRestore(selected.content!, selected.content_format);
                       toast.success("Revision restored — save to confirm");
                     }}
                   >

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -126,11 +126,12 @@ export function createPage(
   collectionId: string,
   slug: string,
   title: string,
-  content = ""
+  content = "",
+  content_format = "markdown"
 ): Promise<Page> {
   return apiFetch(`/api/collections/${collectionId}/pages`, {
     method: "POST",
-    body: JSON.stringify({ slug, title, content }),
+    body: JSON.stringify({ slug, title, content, content_format }),
   });
 }
 
@@ -140,7 +141,7 @@ export function getPage(pageId: string): Promise<Page> {
 
 export function updatePage(
   pageId: string,
-  patch: { title?: string; content?: string }
+  patch: { title?: string; content?: string; content_format?: string }
 ): Promise<Page> {
   return apiFetch(`/api/pages/${pageId}`, {
     method: "PATCH",

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -48,11 +48,13 @@ export interface Page {
   current_revision_id: string | null;
   created_at: string;
   content?: string | null;
+  content_format?: string; // 'markdown' | 'json'
 }
 
 export interface Revision {
   id: string;
   page_id: string;
+  content_format: string; // 'markdown' | 'json'
   created_at: string;
   content?: string;
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,6 +20,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "shadcn": "^4.0.8",
+        "shiki": "^4.0.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
@@ -2130,6 +2131,165 @@
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/core/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@shikijs/types": {
       "version": "3.23.0",
@@ -7089,6 +7249,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
+      "integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/open": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
@@ -7935,6 +8112,30 @@
         "node": ">= 4"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/rehype-format": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
@@ -8453,6 +8654,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/shiki/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/side-channel": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.0.8",
+    "shiki": "^4.0.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"


### PR DESCRIPTION
Closes #37.

## Summary

- **JSON revision storage**: saves now store BlockNote JSON (`content_format='json'`) instead of lossy Markdown serialization; legacy Markdown revisions load transparently via `tryParseMarkdownToBlocks`
- **Code blocks with syntax highlighting**: Shiki configured with 12 common languages and light/dark themes
- **Tables**: `TableHandlesController` added for drag-handle UI (tables were already in the default BlockNote schema)
- **Page mentions**: `@`-triggered suggestion menu (`SuggestionMenuController`) searches workspace pages and inserts a link to the selected page
- **Export v3**: JSON-format revisions produce both `.json` (canonical) and `.md` (human-readable, generated by a new Python `blocks_to_markdown()` converter); manifest includes `content_format` per revision entry
- **Restore**: supports v1/v2/v3 bundles; reads `.json` as canonical for JSON revisions
- **Migration**: `content_format TEXT NOT NULL DEFAULT 'markdown'` added to `revisions` table

## Test plan

- [x] All 58 backend tests pass (`pytest` from `api/`)
- [x] Round-trip test covers mixed markdown + JSON revisions and verifies `content_format` survives export → wipe → restore
- [x] Frontend builds clean (`npm run build` from `web/`)
- [x] Open a page — type `/` to verify code block and table appear in the slash menu
- [x] Insert a code block, select a language — verify syntax highlighting applies
- [x] Insert a table — verify drag handles appear on hover
- [x] Type `@` in editor — verify page suggestion menu appears and selecting a page inserts a link
- [x] Save a page, reload — verify content round-trips correctly as JSON
- [x] Open History panel — verify `json` / `markdown` badge shows on each revision; verify restore works for both formats
- [x] Export a workspace with JSON revisions; inspect bundle for `.json` + `.md` pairs and `content_format` in manifest
- [x] Restore that bundle; verify content and format are preserved exactly