### PR TITLE
fix: @ mention suggestion menu — browse mode and title-prefix matching

### DIFF
--- a/api/freehold/routers/workspaces.py
+++ b/api/freehold/routers/workspaces.py
@@ -114,10 +114,7 @@ def search_workspace(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    if not q.strip():
-        return SearchResponse(query=q, results=[])
-
-    results = search.search(workspace_id, q.strip(), db)
+    results = search.search(workspace_id, q, db)
     return SearchResponse(
         query=q,
         results=[SearchResultItem(**vars(r)) for r in results],

--- a/api/freehold/search.py
+++ b/api/freehold/search.py
@@ -49,46 +49,101 @@ class PostgresSearchBackend(SearchBackend):
         *,
         limit: int = 20,
     ) -> list[SearchResult]:
+        if not query.strip():
+            return self._browse(workspace_id, db, limit=limit)
+        return self._ranked_search(workspace_id, query.strip(), db, limit=limit)
+
+    def _browse(
+        self,
+        workspace_id: UUID,
+        db: Session,
+        *,
+        limit: int,
+    ) -> list[SearchResult]:
+        """Return all pages in the workspace ordered by most recently revised."""
         sql = text("""
             SELECT
                 p.id AS page_id,
                 p.title,
-                ts_headline(
-                    'english',
-                    r.content,
-                    plainto_tsquery('english', :query),
-                    'StartSel=**, StopSel=**, MaxWords=35, MinWords=15'
-                ) AS snippet,
+                '' AS snippet,
                 p.collection_id,
                 s.id AS space_id,
                 s.name AS space_name,
                 c.name AS collection_name,
-                ts_rank(p.search_vector, plainto_tsquery('english', :query)) AS rank
+                0.0 AS rank
             FROM pages p
             JOIN revisions r ON r.id = p.current_revision_id
             JOIN collections c ON c.id = p.collection_id
             JOIN spaces s ON s.id = c.space_id
             WHERE s.workspace_id = :workspace_id
-              AND p.search_vector @@ plainto_tsquery('english', :query)
-            ORDER BY rank DESC
+            ORDER BY r.created_at DESC
             LIMIT :limit
         """)
+        rows = db.execute(sql, {"workspace_id": workspace_id, "limit": limit}).fetchall()
+        return [self._row_to_result(row) for row in rows]
 
+    def _ranked_search(
+        self,
+        workspace_id: UUID,
+        query: str,
+        db: Session,
+        *,
+        limit: int,
+    ) -> list[SearchResult]:
+        """Title ILIKE match ranked first, FTS body match as secondary signal."""
+        sql = text("""
+            SELECT
+                p.id AS page_id,
+                p.title,
+                CASE
+                    WHEN p.search_vector @@ plainto_tsquery('english', :query)
+                    THEN ts_headline(
+                        'english',
+                        r.content,
+                        plainto_tsquery('english', :query),
+                        'StartSel=**, StopSel=**, MaxWords=35, MinWords=15'
+                    )
+                    ELSE ''
+                END AS snippet,
+                p.collection_id,
+                s.id AS space_id,
+                s.name AS space_name,
+                c.name AS collection_name,
+                CASE WHEN p.title ILIKE :title_pattern THEN 1 ELSE 0 END
+                    + ts_rank(p.search_vector, plainto_tsquery('english', :query))
+                    AS rank
+            FROM pages p
+            JOIN revisions r ON r.id = p.current_revision_id
+            JOIN collections c ON c.id = p.collection_id
+            JOIN spaces s ON s.id = c.space_id
+            WHERE s.workspace_id = :workspace_id
+              AND (
+                  p.title ILIKE :title_pattern
+                  OR p.search_vector @@ plainto_tsquery('english', :query)
+              )
+            ORDER BY rank DESC, r.created_at DESC
+            LIMIT :limit
+        """)
         rows = db.execute(
             sql,
-            {"workspace_id": workspace_id, "query": query, "limit": limit},
+            {
+                "workspace_id": workspace_id,
+                "query": query,
+                "title_pattern": f"%{query}%",
+                "limit": limit,
+            },
         ).fetchall()
+        return [self._row_to_result(row) for row in rows]
 
-        return [
-            SearchResult(
-                page_id=row.page_id,
-                title=row.title,
-                snippet=row.snippet,
-                collection_id=row.collection_id,
-                space_id=row.space_id,
-                space_name=row.space_name,
-                collection_name=row.collection_name,
-                rank=row.rank,
-            )
-            for row in rows
-        ]
+    @staticmethod
+    def _row_to_result(row) -> "SearchResult":
+        return SearchResult(
+            page_id=row.page_id,
+            title=row.title,
+            snippet=row.snippet,
+            collection_id=row.collection_id,
+            space_id=row.space_id,
+            space_name=row.space_name,
+            collection_name=row.collection_name,
+            rank=row.rank,
+        )

--- a/api/tests/test_search.py
+++ b/api/tests/test_search.py
@@ -261,3 +261,41 @@ def test_title_matches_rank_higher_than_body(db):
 
     assert len(rows) == 2
     assert rows[0].title == "Kubernetes"
+
+
+# ---------------------------------------------------------------------------
+# PostgresSearchBackend class tests (browse + title-ILIKE paths)
+# ---------------------------------------------------------------------------
+
+
+def test_backend_browse_empty_query_returns_all_pages(db):
+    """An empty query should return all pages in the workspace (browse mode)."""
+    from freehold.search import PostgresSearchBackend
+
+    ws, _, col = _seed_workspace(db)
+    _create_page(db, col, "page-a", "Alpha", "First page content")
+    _create_page(db, col, "page-b", "Beta", "Second page content")
+
+    backend = PostgresSearchBackend()
+    results = backend.search(ws.id, "", db, limit=20)
+
+    titles = {r.title for r in results}
+    assert "Alpha" in titles
+    assert "Beta" in titles
+
+
+def test_backend_title_ilike_matches_partial_title(db):
+    """A partial title query should match via ILIKE even if body lacks the word."""
+    from freehold.search import PostgresSearchBackend
+
+    ws, _, col = _seed_workspace(db)
+    _create_page(db, col, "getting-started", "Getting Started Guide", "Welcome to Freehold.")
+    _create_page(db, col, "unrelated", "API Reference", "Lists all endpoints.")
+
+    backend = PostgresSearchBackend()
+    results = backend.search(ws.id, "getting", db, limit=20)
+
+    titles = [r.title for r in results]
+    assert "Getting Started Guide" in titles
+    # The title match should rank first
+    assert titles[0] == "Getting Started Guide"

--- a/web/components/page-editor.tsx
+++ b/web/components/page-editor.tsx
@@ -229,7 +229,7 @@ export function PageEditor({ initialPage }: Props) {
     async (query: string): Promise<DefaultReactSuggestionItem[]> => {
       if (!workspaceId) return [];
       try {
-        const { results } = await searchWorkspace(workspaceId, query || " ");
+        const { results } = await searchWorkspace(workspaceId, query);
         return results.slice(0, 8).map((result) => ({
           title: result.title,
           subtext: `${result.space_name} / ${result.collection_name}`,


### PR DESCRIPTION
## Summary

- Empty `@` query now returns all workspace pages ordered by most-recently-revised (browse mode) instead of early-exiting with zero results
- Non-empty query matches pages by title `ILIKE` first, FTS body content second — so typing a page title works even if the words don't appear in the body
- Removes the `query || " "` frontend hack; raw query is passed to the backend

## Files changed

- `api/freehold/search.py` — split `PostgresSearchBackend.search` into `_browse` (empty query) and `_ranked_search` (title ILIKE + FTS) paths
- `api/freehold/routers/workspaces.py` — removed early-exit guard on blank queries
- `web/components/page-editor.tsx` — removed `query || " "` hack in `getPageMentionItems`
- `api/tests/test_search.py` — two new tests covering browse mode and title-ILIKE matching via the backend class

## Test plan

- [x] Type `@` in the editor — suggestion menu should show recent pages immediately
- [x] Type `@foo` where "foo" is a substring of a page title but not in its body — page should appear in results
- [x] Confirm existing full-text search (Cmd+K) still works as before
- [x] `pytest tests/test_search.py` — all 9 tests pass

Closes #55