### PR TITLE
feat: slim export flag, API download endpoint, and export dialog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,7 @@ freehold/
 │   ├── components/
 │   │   ├── app-sidebar.tsx           # Tree nav: Spaces → Collections → Pages + search
 │   │   ├── search-dialog.tsx         # Cmd+K search dialog
+│   │   ├── export-dialog.tsx         # Export workspace dialog (full / slim, size estimate)
 │   │   ├── page-editor.tsx           # Title + markdown textarea, auto-save, attachments, revisions
 │   │   └── ui/                       # Shadcn/Base UI components
 │   ├── lib/
@@ -242,6 +243,8 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | GET/DELETE | /api/workspaces/{id} | Get / delete workspace | viewer/owner |
 | GET | /api/workspaces/{id}/tree | Full hierarchy (sidebar) | viewer |
 | GET | /api/workspaces/{id}/search?q= | Full-text search across workspace pages | viewer |
+| GET | /api/workspaces/{id}/export?slim=false | Download workspace as zip bundle | viewer |
+| GET | /api/workspaces/{id}/export/estimate | Pre-compression byte estimates for full & slim exports | viewer |
 | GET/POST | /api/workspaces/{id}/spaces/ | List / create spaces | viewer/editor |
 | GET/DELETE | /api/workspaces/{id}/spaces/{sid} | Get / delete space | viewer/owner |
 | GET/POST | /api/spaces/{sid}/collections/ | List / create collections | viewer/editor |
@@ -269,7 +272,8 @@ class StorageAdapter(ABC):
 ### Export Bundle Format
 
 ```
-freehold-export-{workspace-slug}-{timestamp}.zip
+freehold-export-{workspace-slug}-{timestamp}.zip          # full
+freehold-export-{workspace-slug}-slim-{timestamp}.zip     # slim
 ├── manifest.json        # workspace + org metadata, all entity IDs, schema version (v3)
 ├── pages/
 │   ├── {page-id}.md     # human-readable Markdown (all pages)
@@ -285,6 +289,8 @@ freehold-export-{workspace-slug}-{timestamp}.zip
 
 v1/v2 bundles had only `.md` files. v3 adds `.json` as canonical for JSON-format revisions.
 Restore supports v1, v2, and v3 bundles.
+
+**Slim bundles** omit the `revisions/` directory entirely and set `"slim": true` + `"revisions": []` in `manifest.json`. Restore recreates one revision per page from `pages/` content. CLI: `freehold export --slim`; API: `?slim=true`.
 
 ### Authentication
 

--- a/api/freehold/cli.py
+++ b/api/freehold/cli.py
@@ -14,6 +14,9 @@ def export(
     output: Path | None = typer.Option(
         None, "--output", "-o", help="Output path (file or directory; defaults to cwd)"
     ),
+    slim: bool = typer.Option(
+        False, "--slim", help="Skip revision history; export current content only"
+    ),
     database_url: str | None = typer.Option(
         None, "--database-url", envvar="DATABASE_URL", help="PostgreSQL connection URL"
     ),
@@ -40,6 +43,7 @@ def export(
                 session=session,
                 storage=storage,
                 output_path=output,
+                slim=slim,
             )
         typer.echo(f"Exported to {result}")
     except ValueError as exc:

--- a/api/freehold/export.py
+++ b/api/freehold/export.py
@@ -291,13 +291,61 @@ def _build_manifest(
     }
 
 
+def estimate_export_sizes(
+    slug: str,
+    session: Session,
+    storage: StorageAdapter,
+) -> dict:
+    """Return estimated byte sizes for full and slim exports of *slug*.
+
+    Sizes are raw (pre-compression) byte counts. Actual zip files will be
+    smaller due to DEFLATE compression, but the ratio between full and slim
+    is accurate.
+    """
+    workspace = session.query(Workspace).filter_by(slug=slug).first()
+    if workspace is None:
+        raise ValueError(f"Workspace '{slug}' not found")
+
+    pages = _collect_pages(workspace)
+    for page in pages:
+        _ = page.current_revision
+        _ = page.revisions
+        _ = page.attachments
+
+    attachment_bytes = 0
+    for page in pages:
+        for att in page.attachments:
+            attachment_bytes += att.size_bytes
+
+    current_content_bytes = sum(
+        len((page.current_revision.content or "").encode())
+        for page in pages
+        if page.current_revision
+    )
+    revision_bytes = sum(
+        len((rev.content or "").encode())
+        for page in pages
+        for rev in page.revisions
+    )
+
+    slim_bytes = current_content_bytes + attachment_bytes
+    full_bytes = slim_bytes + revision_bytes
+
+    return {"full_bytes": full_bytes, "slim_bytes": slim_bytes}
+
+
 def export_workspace(
     slug: str,
     session: Session,
     storage: StorageAdapter,
     output_path: Path | None = None,
+    slim: bool = False,
 ) -> Path:
-    """Export *slug* to a zip bundle and return the path of the written file."""
+    """Export *slug* to a zip bundle and return the path of the written file.
+
+    When *slim* is True the revisions/ directory is omitted, producing a
+    current-content-only bundle that is smaller but cannot restore full history.
+    """
     workspace = session.query(Workspace).filter_by(slug=slug).first()
     if workspace is None:
         raise ValueError(f"Workspace '{slug}' not found")
@@ -313,7 +361,8 @@ def export_workspace(
 
     export_timestamp = datetime.now(timezone.utc).isoformat()
     timestamp_fmt = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    bundle_name = f"freehold-export-{workspace.slug}-{timestamp_fmt}.zip"
+    slim_suffix = "-slim" if slim else ""
+    bundle_name = f"freehold-export-{workspace.slug}{slim_suffix}-{timestamp_fmt}.zip"
 
     if output_path is None:
         output_path = Path.cwd() / bundle_name
@@ -341,17 +390,18 @@ def export_workspace(
             else:
                 zf.writestr(f"pages/{page_id}.md", content)
 
-            # Every revision (append-only history).
-            for rev in page.revisions:
-                rev_id = str(rev.id)
-                if rev.content_format == "json":
-                    zf.writestr(f"revisions/{page_id}/{rev_id}.json", rev.content)
-                    zf.writestr(
-                        f"revisions/{page_id}/{rev_id}.md",
-                        blocks_to_markdown(rev.content),
-                    )
-                else:
-                    zf.writestr(f"revisions/{page_id}/{rev_id}.md", rev.content)
+            if not slim:
+                # Every revision (append-only history).
+                for rev in page.revisions:
+                    rev_id = str(rev.id)
+                    if rev.content_format == "json":
+                        zf.writestr(f"revisions/{page_id}/{rev_id}.json", rev.content)
+                        zf.writestr(
+                            f"revisions/{page_id}/{rev_id}.md",
+                            blocks_to_markdown(rev.content),
+                        )
+                    else:
+                        zf.writestr(f"revisions/{page_id}/{rev_id}.md", rev.content)
 
         # Attachments — verify hash before including.
         all_attachments: list[Attachment] = []
@@ -381,12 +431,13 @@ def export_workspace(
             )
 
         zf.writestr("links.json", json.dumps(_build_links(pages, page_id_set), indent=2))
-        zf.writestr(
-            "manifest.json",
-            json.dumps(
-                _build_manifest(workspace, pages, attachment_records, export_timestamp), indent=2
-            ),
-        )
+
+        manifest = _build_manifest(workspace, pages, attachment_records, export_timestamp)
+        if slim:
+            manifest["slim"] = True
+            manifest["revisions"] = []
+
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2))
 
     output_path.write_bytes(buf.getvalue())
     return output_path

--- a/api/freehold/restore.py
+++ b/api/freehold/restore.py
@@ -51,6 +51,8 @@ def restore_workspace(
                 f"Unsupported bundle schema version '{schema_version}' (expected '1', '2', or '3')"
             )
 
+        is_slim = manifest.get("slim", False)
+
         ws_meta = manifest["workspace"]
         ws_id = uuid.UUID(ws_meta["id"])
 
@@ -157,25 +159,53 @@ def restore_workspace(
         session.flush()
 
         # --- Revisions ---
-        for r in manifest["revisions"]:
-            content_format = r.get("content_format", "markdown")
-            if content_format == "json":
-                # v3 bundle: canonical content is the .json file
-                rev_file = f"revisions/{r['page_id']}/{r['id']}.json"
-            else:
-                rev_file = f"revisions/{r['page_id']}/{r['id']}.md"
-            if rev_file not in names:
-                raise ValueError(f"Bundle is missing revision file: {rev_file}")
-            content = zf.read(rev_file).decode()
-            session.add(
-                Revision(
-                    id=uuid.UUID(r["id"]),
-                    page_id=uuid.UUID(r["page_id"]),
-                    content=content,
-                    content_format=content_format,
-                    created_at=_dt(r["created_at"]),
+        if is_slim:
+            # Slim bundles omit revision history. Recreate one revision per page
+            # from the current page content stored in pages/.
+            for p in manifest["pages"]:
+                page_id = uuid.UUID(p["id"])
+                # Detect JSON vs Markdown from available files
+                json_file = f"pages/{p['id']}.json"
+                md_file = f"pages/{p['id']}.md"
+                if json_file in names:
+                    content = zf.read(json_file).decode()
+                    content_format = "json"
+                elif md_file in names:
+                    content = zf.read(md_file).decode()
+                    content_format = "markdown"
+                else:
+                    content = ""
+                    content_format = "markdown"
+                new_rev_id = uuid.uuid4()
+                session.add(
+                    Revision(
+                        id=new_rev_id,
+                        page_id=page_id,
+                        content=content,
+                        content_format=content_format,
+                    )
                 )
-            )
+                page_current_revisions[page_id] = new_rev_id
+        else:
+            for r in manifest["revisions"]:
+                content_format = r.get("content_format", "markdown")
+                if content_format == "json":
+                    # v3 bundle: canonical content is the .json file
+                    rev_file = f"revisions/{r['page_id']}/{r['id']}.json"
+                else:
+                    rev_file = f"revisions/{r['page_id']}/{r['id']}.md"
+                if rev_file not in names:
+                    raise ValueError(f"Bundle is missing revision file: {rev_file}")
+                content = zf.read(rev_file).decode()
+                session.add(
+                    Revision(
+                        id=uuid.UUID(r["id"]),
+                        page_id=uuid.UUID(r["page_id"]),
+                        content=content,
+                        content_format=content_format,
+                        created_at=_dt(r["created_at"]),
+                    )
+                )
         session.flush()
 
         # --- Wire up current_revision_id now that revisions exist ---

--- a/api/freehold/routers/workspaces.py
+++ b/api/freehold/routers/workspaces.py
@@ -1,8 +1,11 @@
 """Workspace CRUD endpoints."""
 
+import os
+from io import BytesIO
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -18,6 +21,7 @@ from ..schemas import (
     WorkspaceTree,
 )
 from ..search import SearchBackend
+from ..storage import LocalFilesystemAdapter
 
 router = APIRouter(prefix="/api/workspaces", tags=["workspaces"])
 
@@ -118,6 +122,62 @@ def search_workspace(
     return SearchResponse(
         query=q,
         results=[SearchResultItem(**vars(r)) for r in results],
+    )
+
+
+@router.get("/{workspace_id}/export/estimate")
+def estimate_workspace_export(
+    workspace_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_workspace_role(OrgRole.VIEWER)),
+):
+    """Return pre-compression byte estimates for full and slim export bundles."""
+    from ..export import estimate_export_sizes
+
+    ws = db.get(Workspace, workspace_id)
+    if ws is None:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    storage_root = os.getenv("STORAGE_PATH", "/var/lib/freehold/attachments")
+    storage = LocalFilesystemAdapter(storage_root)
+
+    return estimate_export_sizes(slug=ws.slug, session=db, storage=storage)
+
+
+@router.get("/{workspace_id}/export")
+def export_workspace_endpoint(
+    workspace_id: UUID,
+    slim: bool = False,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_workspace_role(OrgRole.VIEWER)),
+):
+    """Download a workspace export bundle as a zip file."""
+    from pathlib import Path
+    from ..export import export_workspace
+
+    ws = db.get(Workspace, workspace_id)
+    if ws is None:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    storage_root = os.getenv("STORAGE_PATH", "/var/lib/freehold/attachments")
+    storage = LocalFilesystemAdapter(storage_root)
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        bundle_path = export_workspace(
+            slug=ws.slug,
+            session=db,
+            storage=storage,
+            output_path=Path(tmp),
+            slim=slim,
+        )
+        data = bundle_path.read_bytes()
+
+    return StreamingResponse(
+        BytesIO(data),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{bundle_path.name}"'},
     )
 
 

--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -13,7 +13,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
-from freehold.export import SCHEMA_VERSION, export_workspace
+from freehold.export import SCHEMA_VERSION, estimate_export_sizes, export_workspace
 from freehold.models import Attachment, Collection, Organization, Page, Revision, Space, Workspace
 from freehold.storage import StorageAdapter
 
@@ -296,3 +296,126 @@ def test_output_filename_default(seeded, session, tmp_path):
     )
     assert result.name.startswith("freehold-export-export-test-ws-")
     assert result.name.endswith(".zip")
+
+
+# ---------------------------------------------------------------------------
+# Slim export tests
+# ---------------------------------------------------------------------------
+
+
+def test_slim_export_omits_revisions(seeded, session, tmp_path):
+    result = export_workspace(
+        slug="export-test-ws",
+        session=session,
+        storage=seeded["storage"],
+        output_path=tmp_path,
+        slim=True,
+    )
+
+    with zipfile.ZipFile(result) as zf:
+        names = zf.namelist()
+
+    assert not any(n.startswith("revisions/") for n in names)
+    assert any(n.startswith("pages/") for n in names)
+    assert "manifest.json" in names
+
+
+def test_slim_export_filename_contains_slim(seeded, session, tmp_path):
+    result = export_workspace(
+        slug="export-test-ws",
+        session=session,
+        storage=seeded["storage"],
+        output_path=tmp_path,
+        slim=True,
+    )
+    assert "-slim-" in result.name
+
+
+def test_slim_manifest_has_slim_flag_and_empty_revisions(seeded, session, tmp_path):
+    result = export_workspace(
+        slug="export-test-ws",
+        session=session,
+        storage=seeded["storage"],
+        output_path=tmp_path,
+        slim=True,
+    )
+
+    with zipfile.ZipFile(result) as zf:
+        manifest = json.loads(zf.read("manifest.json"))
+
+    assert manifest.get("slim") is True
+    assert manifest["revisions"] == []
+
+
+def test_slim_bundle_is_restorable(session, tmp_path):
+    """A slim bundle restores cleanly — one revision per page from pages/ content."""
+    import uuid as _uuid
+    from datetime import datetime, timezone
+    from freehold.restore import restore_workspace
+
+    now = datetime.now(timezone.utc).isoformat()
+    ws_id = _uuid.uuid4()
+    org_id = _uuid.uuid4()
+    space_id = _uuid.uuid4()
+    col_id = _uuid.uuid4()
+    page_id = _uuid.uuid4()
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "slim": True,
+        "export_timestamp": now,
+        "organization": {
+            "id": str(org_id),
+            "slug": "slim-restore-org",
+            "name": "Slim Restore Org",
+            "created_at": now,
+        },
+        "workspace": {
+            "id": str(ws_id),
+            "org_id": str(org_id),
+            "slug": "slim-restore-ws",
+            "name": "Slim Restore WS",
+            "created_at": now,
+        },
+        "spaces": [{"id": str(space_id), "workspace_id": str(ws_id), "slug": "sp", "name": "Space", "created_at": now}],
+        "collections": [{"id": str(col_id), "space_id": str(space_id), "slug": "col", "name": "Col", "created_at": now}],
+        "pages": [{"id": str(page_id), "collection_id": str(col_id), "slug": "pg", "title": "Page", "current_revision_id": None, "created_at": now}],
+        "revisions": [],
+        "attachments": [],
+    }
+
+    import io as _io
+    buf = _io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+        zf.writestr(f"pages/{page_id}.md", "# Page\nCurrent content.")
+        zf.writestr("links.json", json.dumps({"internal_links": [], "broken_links": [], "orphaned_pages": []}))
+
+    bundle_path = tmp_path / "slim-bundle.zip"
+    bundle_path.write_bytes(buf.getvalue())
+
+    storage = FakeStorageAdapter()
+    slug = restore_workspace(bundle_path, session, storage)
+    assert slug == "slim-restore-ws"
+
+    from freehold.models import Workspace
+    restored_ws = session.query(Workspace).filter_by(slug="slim-restore-ws").one()
+    pages_list = [p for s in restored_ws.spaces for c in s.collections for p in c.pages]
+    assert len(pages_list) == 1
+    p = pages_list[0]
+    assert p.current_revision is not None
+    assert p.current_revision.content == "# Page\nCurrent content."
+    assert len(p.revisions) == 1
+
+
+def test_estimate_export_sizes(seeded, session):
+    sizes = estimate_export_sizes(
+        slug="export-test-ws",
+        session=session,
+        storage=seeded["storage"],
+    )
+
+    assert "full_bytes" in sizes
+    assert "slim_bytes" in sizes
+    assert sizes["full_bytes"] >= sizes["slim_bytes"]
+    assert sizes["slim_bytes"] >= 0

--- a/web/components/app-sidebar.tsx
+++ b/web/components/app-sidebar.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { ChevronDown, ChevronRight, FilePlus, FolderPlus, Plus, Settings } from "lucide-react";
+import { ExportDialog } from "@/components/export-dialog";
 import { toast } from "sonner";
 import {
   Sidebar,
@@ -240,6 +241,7 @@ export function AppSidebar({ tree, user }: Props) {
         <div className="flex items-center justify-between px-2 pb-1.5 group">
           <span className="text-xs font-medium text-muted-foreground">{tree.name}</span>
           <div className="flex items-center gap-1">
+            <ExportDialog workspaceId={tree.id} workspaceName={tree.name} />
             <a
               href={`/orgs/${tree.org_id}/settings`}
               className="hidden group-hover:flex items-center text-muted-foreground hover:text-foreground"

--- a/web/components/export-dialog.tsx
+++ b/web/components/export-dialog.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { Download } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { getExportSizeEstimate, exportWorkspaceUrl } from "@/lib/api";
+
+interface Props {
+  workspaceId: string;
+  workspaceName: string;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function ExportDialog({ workspaceId, workspaceName }: Props) {
+  const [open, setOpen] = useState(false);
+  const [slim, setSlim] = useState(false);
+  const [estimate, setEstimate] = useState<{ full_bytes: number; slim_bytes: number } | null>(null);
+  const [loadingEstimate, setLoadingEstimate] = useState(false);
+
+  async function handleOpen(isOpen: boolean) {
+    setOpen(isOpen);
+    if (isOpen && !estimate) {
+      setLoadingEstimate(true);
+      try {
+        const sizes = await getExportSizeEstimate(workspaceId);
+        setEstimate(sizes);
+      } catch {
+        // Estimate is non-critical — continue without it
+      } finally {
+        setLoadingEstimate(false);
+      }
+    }
+  }
+
+  function handleDownload() {
+    const url = exportWorkspaceUrl(workspaceId, slim);
+    window.location.href = url;
+    setOpen(false);
+  }
+
+  const estimatedBytes = estimate ? (slim ? estimate.slim_bytes : estimate.full_bytes) : null;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpen}>
+      <DialogTrigger render={<button type="button" className="contents" />}>
+        <span
+          className="hidden group-hover:flex items-center text-muted-foreground hover:text-foreground cursor-pointer"
+          title="Export workspace"
+        >
+          <Download className="h-3.5 w-3.5" />
+        </span>
+      </DialogTrigger>
+
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Export &ldquo;{workspaceName}&rdquo;</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-1">
+          <div className="space-y-2">
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="radio"
+                name="export-mode"
+                value="full"
+                checked={!slim}
+                onChange={() => setSlim(false)}
+                className="mt-0.5"
+              />
+              <div>
+                <p className="text-sm font-medium">Full export</p>
+                <p className="text-xs text-muted-foreground">
+                  Includes complete revision history. Use this to fully migrate or back up your
+                  workspace.
+                </p>
+                {estimate && !loadingEstimate && (
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    ~{formatBytes(estimate.full_bytes)} uncompressed
+                  </p>
+                )}
+              </div>
+            </label>
+
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="radio"
+                name="export-mode"
+                value="slim"
+                checked={slim}
+                onChange={() => setSlim(true)}
+                className="mt-0.5"
+              />
+              <div>
+                <p className="text-sm font-medium">Slim export</p>
+                <p className="text-xs text-muted-foreground">
+                  Current content only — no revision history. Smaller file, but history cannot be
+                  restored.
+                </p>
+                {estimate && !loadingEstimate && (
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    ~{formatBytes(estimate.slim_bytes)} uncompressed
+                  </p>
+                )}
+              </div>
+            </label>
+          </div>
+
+          {slim && (
+            <p className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded px-2 py-1.5">
+              Slim exports cannot restore revision history. Use full export if you need a complete
+              backup.
+            </p>
+          )}
+
+          {loadingEstimate && (
+            <p className="text-xs text-muted-foreground">Calculating size estimate…</p>
+          )}
+
+          {estimatedBytes !== null && !loadingEstimate && (
+            <p className="text-xs text-muted-foreground">
+              Estimated size: ~{formatBytes(estimatedBytes)} uncompressed (actual zip will be
+              smaller)
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={handleDownload}>
+            <Download className="h-3.5 w-3.5 mr-1.5" />
+            Download
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -88,6 +88,18 @@ export function getWorkspaceTree(id: string): Promise<WorkspaceTree> {
   return apiFetch(`/api/workspaces/${id}/tree`);
 }
 
+export function getExportSizeEstimate(
+  workspaceId: string
+): Promise<{ full_bytes: number; slim_bytes: number }> {
+  return apiFetch(`/api/workspaces/${workspaceId}/export/estimate`);
+}
+
+export function exportWorkspaceUrl(workspaceId: string, slim: boolean): string {
+  const base = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+  const params = slim ? "?slim=true" : "";
+  return `${base}/api/workspaces/${workspaceId}/export${params}`;
+}
+
 // ---------------------------------------------------------------------------
 // Search
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #38

## Summary

- **`--slim` CLI flag** — `freehold export --slim` skips the `revisions/` directory, producing a current-content-only bundle with a `-slim-` filename infix
- **API export endpoint** — `GET /api/workspaces/{id}/export?slim=false` streams the zip bundle as a download; `GET /api/workspaces/{id}/export/estimate` returns pre-compression byte counts for both modes
- **Slim restore support** — `restore_workspace` detects `manifest["slim"]: true` and recreates one revision per page from `pages/` content instead of the (absent) `revisions/` directory
- **Frontend export dialog** — hover-reveal download icon in the sidebar workspace header opens a dialog with full/slim radio toggle, per-mode size estimates fetched on open, and an amber warning when slim is selected

## Test plan

- [x] `test_slim_export_omits_revisions` — no `revisions/` entries in slim zip
- [x] `test_slim_export_filename_contains_slim` — filename includes `-slim-`
- [x] `test_slim_manifest_has_slim_flag_and_empty_revisions` — manifest flags are correct
- [x] `test_slim_bundle_is_restorable` — restore recreates one revision per page with correct content
- [x] `test_estimate_export_sizes` — full_bytes ≥ slim_bytes ≥ 0
- [x] All 65 existing tests still pass
- [x] Manual: open export dialog in browser, verify size estimates load, download both full and slim bundles, confirm slim restores cleanly