### PR TITLE
fix: rename session cookie freehold_session → marrow_session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,7 @@ Restore supports v1, v2, and v3 bundles.
 
 Freehold supports three authentication methods, checked in priority order:
 
-1. **OIDC session cookie** (`freehold_session`): A JWT signed with `SECRET_KEY` (HS256), issued after successful OIDC login. Contains `sub` (user UUID), `email`, `name`, with 24h expiry.
+1. **OIDC session cookie** (`marrow_session`): A JWT signed with `SECRET_KEY` (HS256), issued after successful OIDC login. Contains `sub` (user UUID), `email`, `name`, with 24h expiry.
 2. **API key** (`X-API-Key` header): Static key matching `API_KEY` env var. Used by CLI and scripts. **Bypasses all RBAC checks** (superuser equivalent).
 3. **Anonymous**: When neither OIDC nor API key is configured, all requests are allowed (dev mode). **Bypasses all RBAC checks**.
 

--- a/api/marrow/auth.py
+++ b/api/marrow/auth.py
@@ -117,7 +117,7 @@ def decode_session_jwt(token: str) -> dict:
 # Cookie helpers
 # ---------------------------------------------------------------------------
 
-COOKIE_NAME = "freehold_session"
+COOKIE_NAME = "marrow_session"
 
 
 def make_session_cookie_params() -> dict:

--- a/api/marrow/dependencies.py
+++ b/api/marrow/dependencies.py
@@ -88,7 +88,7 @@ def verify_auth(
     """Authenticate the request via session cookie, API key, or anonymous access.
 
     Priority:
-    1. Valid ``freehold_session`` cookie → session auth
+    1. Valid ``marrow_session`` cookie → session auth
     2. Valid ``X-API-Key`` header → API key auth
     3. Neither, but OIDC and API_KEY both unconfigured → anonymous (dev mode)
     4. Otherwise → 401

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -36,9 +36,9 @@ async function apiFetch<T>(
   if (typeof window === "undefined") {
     const { cookies } = await import("next/headers");
     const cookieStore = await cookies();
-    const session = cookieStore.get("freehold_session");
+    const session = cookieStore.get("marrow_session");
     if (session) {
-      headers["Cookie"] = `freehold_session=${session.value}`;
+      headers["Cookie"] = `marrow_session=${session.value}`;
     }
   }
 

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -16,7 +16,7 @@ export function proxy(request: NextRequest) {
   }
 
   // Check for session cookie (set by the backend with Domain=localhost or shared domain)
-  const session = request.cookies.get("freehold_session");
+  const session = request.cookies.get("marrow_session");
   if (!session) {
     return NextResponse.redirect(new URL("/login", request.url));
   }


### PR DESCRIPTION
Closes #68.

## Summary
- Rename `COOKIE_NAME` in `api/marrow/auth.py` from `freehold_session` to `marrow_session`
- Update `web/proxy.ts` and `web/lib/api.ts` (SSR cookie forwarding) to read the new name
- Update docstring in `api/marrow/dependencies.py` and CLAUDE.md reference

No compatibility shim — pre-v0.1.0.

## Test plan
- [x] `pytest tests/test_auth.py` — 16 passed (tests use the `COOKIE_NAME` constant, so they follow the rename automatically)
- [x] Manual OIDC login flow sets a `marrow_session` cookie