### PR TITLE
feat(web): rename user-facing Freehold → Marrow

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -8,7 +8,7 @@ import "./globals.css";
 const inter = Inter({ variable: "--font-inter", subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Freehold",
+  title: "Marrow",
   description: "Your knowledge, owned outright.",
 };
 

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -12,7 +12,7 @@ export default function LoginPage() {
     <div className="flex min-h-screen items-center justify-center">
       <div className="w-full max-w-sm space-y-6 text-center">
         <div className="space-y-2">
-          <h1 className="text-2xl font-bold tracking-tight">Freehold</h1>
+          <h1 className="text-2xl font-bold tracking-tight">Marrow</h1>
           <p className="text-muted-foreground text-sm">
             Sign in to access your workspace
           </p>

--- a/web/app/workspaces/page.tsx
+++ b/web/app/workspaces/page.tsx
@@ -44,7 +44,7 @@ export default function WorkspacesPage() {
         {/* Header */}
         <div className="flex items-start justify-between">
           <div>
-            <h1 className="font-heading text-3xl font-bold tracking-tight">Freehold</h1>
+            <h1 className="font-heading text-3xl font-bold tracking-tight">Marrow</h1>
             <p className="mt-1 text-sm text-muted-foreground">Your knowledge, owned outright.</p>
           </div>
           {auth?.authenticated && (

--- a/web/components/app-sidebar.tsx
+++ b/web/components/app-sidebar.tsx
@@ -238,7 +238,7 @@ export function AppSidebar({ tree, user }: Props) {
       <SidebarHeader className="border-b border-sidebar-border">
         <div className="flex items-center justify-between px-2 py-1.5">
           <a href="/workspaces" className="text-sm font-semibold tracking-tight hover:opacity-70">
-            Freehold
+            Marrow
           </a>
           <SidebarTrigger className="-mr-1" />
         </div>

--- a/web/components/restore-dialog.tsx
+++ b/web/components/restore-dialog.tsx
@@ -83,7 +83,7 @@ export function RestoreDialog() {
 
         <div className="space-y-4 py-1">
           <p className="text-sm text-muted-foreground">
-            Upload a Freehold export bundle (.zip) to restore a workspace. Full and slim bundles are
+            Upload a Marrow export bundle (.zip) to restore a workspace. Full and slim bundles are
             both supported.
           </p>
 

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,5 +1,5 @@
 /**
- * Freehold API client.
+ * Marrow API client.
  *
  * All requests go through `apiFetch`, which attaches the API key header
  * and throws a descriptive error on non-2xx responses.

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1,4 +1,4 @@
-// TypeScript types mirroring the Freehold API Pydantic schemas.
+// TypeScript types mirroring the Marrow API Pydantic schemas.
 
 export interface Organization {
   id: string;


### PR DESCRIPTION
## Summary
- Rename user-visible "Freehold" strings to "Marrow" across the web app (login page, workspaces landing, sidebar header, layout `<title>`, restore dialog copy, and source file comments in `lib/api.ts` and `lib/types.ts`).
- Leaves the `freehold_session` cookie name in `web/lib/api.ts` and `web/proxy.ts` unchanged — that rename is handled on a separate branch.

Closes #71

## Test plan
- [x] `npm run build` succeeds
- [x] `rg -i freehold web/ --glob '!node_modules'` only shows the `freehold_session` cookie references (intentional, out-of-scope)
- [x] Visually verify login page, workspaces landing, sidebar header, browser tab title, and restore dialog copy all say "Marrow"
- Note: `npm run lint` fails with a pre-existing ESLint tooling error (`react/display-name` rule incompatibility) unrelated to this change.