### PR TITLE
refactor: finish Freehold → Marrow residuals in api/ and configs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Freehold is a self-hosted, open-source knowledge base (wiki) built around a non-negotiable **restore guarantee**: a Freehold export bundle must always be restorable to an exact replica of the original workspace. This guarantee is the architectural foundation — every decision flows from it.
+Marrow (repo still named `freehold` on disk during the rebrand) is a self-hosted, open-source knowledge base (wiki) built around a non-negotiable **restore guarantee**: a Marrow export bundle must always be restorable to an exact replica of the original workspace. This guarantee is the architectural foundation — every decision flows from it.
 
 Current status: **v0.1 MVP** — core hierarchy, append-only revisions, export/restore, file attachments, and a working Next.js frontend are all implemented and tested.
 
@@ -55,7 +55,7 @@ npm run dev                       # starts on http://localhost:3000
 **Backend (`api/.env`)**:
 
 ```env
-DATABASE_URL=postgresql://freehold:freehold@localhost:5433/freehold
+DATABASE_URL=postgresql://marrow:marrow@localhost:5433/marrow
 SECRET_KEY=changeme
 STORAGE_PATH=./storage       # resolves relative to api/ directory
 API_KEY=                     # optional; if set, enforces X-API-Key header on all routes
@@ -274,8 +274,8 @@ class StorageAdapter(ABC):
 ### Export Bundle Format
 
 ```
-freehold-export-{workspace-slug}-{timestamp}.zip          # full
-freehold-export-{workspace-slug}-slim-{timestamp}.zip     # slim
+marrow-export-{workspace-slug}-{timestamp}.zip          # full
+marrow-export-{workspace-slug}-slim-{timestamp}.zip     # slim
 ├── manifest.json        # workspace + org metadata, all entity IDs, schema version (v3)
 ├── pages/
 │   ├── {page-id}.md     # human-readable Markdown (all pages)
@@ -292,11 +292,11 @@ freehold-export-{workspace-slug}-slim-{timestamp}.zip     # slim
 v1/v2 bundles had only `.md` files. v3 adds `.json` as canonical for JSON-format revisions.
 Restore supports v1, v2, and v3 bundles.
 
-**Slim bundles** omit the `revisions/` directory entirely and set `"slim": true` + `"revisions": []` in `manifest.json`. Restore recreates one revision per page from `pages/` content. CLI: `freehold export --slim`; API: `?slim=true`.
+**Slim bundles** omit the `revisions/` directory entirely and set `"slim": true` + `"revisions": []` in `manifest.json`. Restore recreates one revision per page from `pages/` content. CLI: `marrow export --slim`; API: `?slim=true`.
 
 ### Authentication
 
-Freehold supports three authentication methods, checked in priority order:
+Marrow supports three authentication methods, checked in priority order:
 
 1. **OIDC session cookie** (`marrow_session`): A JWT signed with `SECRET_KEY` (HS256), issued after successful OIDC login. Contains `sub` (user UUID), `email`, `name`, with 24h expiry.
 2. **API key** (`X-API-Key` header): Static key matching `API_KEY` env var. Used by CLI and scripts. **Bypasses all RBAC checks** (superuser equivalent).

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,5 +1,5 @@
 # Database
-DATABASE_URL=postgresql://freehold:freehold@localhost:5433/freehold
+DATABASE_URL=postgresql://marrow:marrow@localhost:5433/marrow
 
 # Security
 SECRET_KEY=changeme

--- a/api/marrow/app.py
+++ b/api/marrow/app.py
@@ -14,7 +14,7 @@ _cors_origins = os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
 
 _secret_key = os.getenv("SECRET_KEY", "changeme")
 
-app = FastAPI(title="Freehold API", version="0.1.0")
+app = FastAPI(title="Marrow API", version="0.1.0")
 
 # SessionMiddleware is required by authlib for OAuth state management.
 app.add_middleware(SessionMiddleware, secret_key=_secret_key)

--- a/api/marrow/cli.py
+++ b/api/marrow/cli.py
@@ -1,11 +1,11 @@
-"""Freehold CLI entry point."""
+"""Marrow CLI entry point."""
 
 from pathlib import Path
 
 import typer
 from dotenv import load_dotenv
 
-app = typer.Typer(help="Freehold — self-hosted knowledge base tools.")
+app = typer.Typer(help="Marrow — self-hosted knowledge base tools.")
 
 
 @app.command()
@@ -33,7 +33,7 @@ def export(
     from .export import export_workspace
     from .storage import LocalFilesystemAdapter
 
-    storage_root = storage_path or os.getenv("STORAGE_PATH", "/var/lib/freehold/attachments")
+    storage_root = storage_path or os.getenv("STORAGE_PATH", "/var/lib/marrow/attachments")
     storage = LocalFilesystemAdapter(storage_root)
 
     try:
@@ -73,7 +73,7 @@ def restore(
     from .restore import restore_workspace
     from .storage import LocalFilesystemAdapter
 
-    storage_root = storage_path or os.getenv("STORAGE_PATH", "/var/lib/freehold/attachments")
+    storage_root = storage_path or os.getenv("STORAGE_PATH", "/var/lib/marrow/attachments")
     storage = LocalFilesystemAdapter(storage_root)
 
     try:

--- a/api/marrow/export.py
+++ b/api/marrow/export.py
@@ -1,7 +1,7 @@
 """Export a workspace to a portable zip bundle.
 
 Bundle layout (schema v3):
-    freehold-export-{workspace-slug}-{timestamp}.zip
+    marrow-export-{workspace-slug}-{timestamp}.zip
     ├── manifest.json
     ├── pages/{page-id}.json          # canonical BlockNote JSON (v3 only, format='json')
     ├── pages/{page-id}.md            # human-readable Markdown (all versions)
@@ -362,7 +362,7 @@ def export_workspace(
     export_timestamp = datetime.now(timezone.utc).isoformat()
     timestamp_fmt = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     slim_suffix = "-slim" if slim else ""
-    bundle_name = f"freehold-export-{workspace.slug}{slim_suffix}-{timestamp_fmt}.zip"
+    bundle_name = f"marrow-export-{workspace.slug}{slim_suffix}-{timestamp_fmt}.zip"
 
     if output_path is None:
         output_path = Path.cwd() / bundle_name

--- a/api/marrow/models.py
+++ b/api/marrow/models.py
@@ -1,4 +1,4 @@
-"""SQLAlchemy 2.0 ORM models for the Freehold core schema.
+"""SQLAlchemy 2.0 ORM models for the Marrow core schema.
 
 These models mirror the Alembic migration exactly, including:
 - Server-side UUID primary keys (gen_random_uuid())

--- a/api/marrow/rbac.py
+++ b/api/marrow/rbac.py
@@ -1,4 +1,4 @@
-"""Role-based access control dependencies for Freehold.
+"""Role-based access control dependencies for Marrow.
 
 Provides dependency factories that enforce org membership and role requirements
 on API routes. API key and anonymous auth bypass all role checks for backward

--- a/api/marrow/restore.py
+++ b/api/marrow/restore.py
@@ -1,7 +1,7 @@
 """Restore a workspace from an export bundle.
 
 Usage:
-    freehold restore <bundle.zip>
+    marrow restore <bundle.zip>
 """
 
 import hashlib
@@ -41,7 +41,7 @@ def restore_workspace(
     with zipfile.ZipFile(bundle_path) as zf:
         names = set(zf.namelist())
         if "manifest.json" not in names:
-            raise ValueError(f"Not a valid Freehold bundle: manifest.json missing in {bundle_path}")
+            raise ValueError(f"Not a valid Marrow bundle: manifest.json missing in {bundle_path}")
 
         manifest = json.loads(zf.read("manifest.json"))
 

--- a/api/marrow/routers/auth.py
+++ b/api/marrow/routers/auth.py
@@ -200,7 +200,7 @@ async def logout(request: Request):
         except Exception:
             pass
 
-    # Clear the Freehold session cookie
+    # Clear the Marrow session cookie
     body: dict = {"status": "ok"}
     response = JSONResponse(content=body)
     response.delete_cookie(

--- a/api/marrow/routers/workspaces.py
+++ b/api/marrow/routers/workspaces.py
@@ -94,7 +94,7 @@ async def restore_workspace_endpoint(
     """Restore a workspace from an uploaded export bundle zip."""
     from ..restore import restore_workspace
 
-    storage_root = os.getenv("STORAGE_PATH", "/var/lib/freehold/attachments")
+    storage_root = os.getenv("STORAGE_PATH", "/var/lib/marrow/attachments")
     storage = LocalFilesystemAdapter(storage_root)
 
     # Read one byte over the limit to distinguish "at limit" from "over limit"
@@ -181,7 +181,7 @@ def estimate_workspace_export(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    storage_root = os.getenv("STORAGE_PATH", "/var/lib/freehold/attachments")
+    storage_root = os.getenv("STORAGE_PATH", "/var/lib/marrow/attachments")
     storage = LocalFilesystemAdapter(storage_root)
 
     return estimate_export_sizes(slug=ws.slug, session=db, storage=storage)
@@ -202,7 +202,7 @@ def export_workspace_endpoint(
     if ws is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    storage_root = os.getenv("STORAGE_PATH", "/var/lib/freehold/attachments")
+    storage_root = os.getenv("STORAGE_PATH", "/var/lib/marrow/attachments")
     storage = LocalFilesystemAdapter(storage_root)
 
     import tempfile

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -1,4 +1,4 @@
-"""Pydantic request/response schemas for the Freehold REST API."""
+"""Pydantic request/response schemas for the Marrow REST API."""
 
 from datetime import datetime
 from uuid import UUID

--- a/api/marrow/storage.py
+++ b/api/marrow/storage.py
@@ -36,5 +36,5 @@ class LocalFilesystemAdapter(StorageAdapter):
 
 
 def get_default_adapter() -> StorageAdapter:
-    storage_path = os.getenv("STORAGE_PATH", "/var/lib/freehold/attachments")
+    storage_path = os.getenv("STORAGE_PATH", "/var/lib/marrow/attachments")
     return LocalFilesystemAdapter(storage_path)

--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -17,7 +17,7 @@ from marrow.export import SCHEMA_VERSION, estimate_export_sizes, export_workspac
 from marrow.models import Attachment, Collection, Organization, Page, Revision, Space, Workspace
 from marrow.storage import StorageAdapter
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
 
 
 # ---------------------------------------------------------------------------
@@ -294,7 +294,7 @@ def test_output_filename_default(seeded, session, tmp_path):
         storage=seeded["storage"],
         output_path=tmp_path,
     )
-    assert result.name.startswith("freehold-export-export-test-ws-")
+    assert result.name.startswith("marrow-export-export-test-ws-")
     assert result.name.endswith(".zip")
 
 

--- a/api/tests/test_migration_cycle.py
+++ b/api/tests/test_migration_cycle.py
@@ -16,7 +16,7 @@ from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 from alembic import command
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
 
 
 def _base_dsn() -> str:
@@ -35,7 +35,7 @@ def _alembic_cfg(url: str) -> Config:
 @pytest.fixture(scope="module")
 def db_url():
     """Create a fresh database for the module, yield its URL, then drop it."""
-    db_name = f"freehold_test_{uuid.uuid4().hex[:8]}"
+    db_name = f"marrow_test_{uuid.uuid4().hex[:8]}"
 
     admin = psycopg2.connect(f"{_base_dsn()}/postgres")
     admin.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
@@ -155,7 +155,7 @@ class TestMigrationCycle:
             tables = {row[0] for row in cur.fetchall()}
         conn.close()
 
-        freehold_tables = {
+        marrow_tables = {
             "workspaces",
             "spaces",
             "collections",
@@ -163,4 +163,4 @@ class TestMigrationCycle:
             "revisions",
             "attachments",
         }
-        assert not freehold_tables & tables
+        assert not marrow_tables & tables

--- a/api/tests/test_models_smoke.py
+++ b/api/tests/test_models_smoke.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from marrow.models import Collection, Organization, Page, Revision, Space, Workspace
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
 
 
 @pytest.fixture(scope="module")
@@ -46,7 +46,7 @@ def test_create_workspace_hierarchy(session):
     session.add(page)
     session.flush()
 
-    revision = Revision(page_id=page.id, content="Hello, Freehold.")
+    revision = Revision(page_id=page.id, content="Hello, Marrow.")
     session.add(revision)
     session.flush()
 

--- a/api/tests/test_rbac.py
+++ b/api/tests/test_rbac.py
@@ -19,7 +19,7 @@ from marrow.models import (
     Workspace,
 )
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
 
 
 @pytest.fixture(autouse=True)

--- a/api/tests/test_restore.py
+++ b/api/tests/test_restore.py
@@ -206,6 +206,22 @@ def test_restore_creates_workspace(session, storage, tmp_path):
     assert str(ws.id) == manifest["workspace"]["id"]
 
 
+def test_restore_accepts_legacy_freehold_prefixed_bundle(session, storage, tmp_path):
+    # Restore is manifest-driven, not filename-driven — legacy bundles produced
+    # before the freehold → marrow rename must still restore cleanly.
+    bundle_bytes, manifest = _make_bundle(ws_slug="legacy-prefix-ws")
+    path = _write_bundle(
+        tmp_path, bundle_bytes, name="freehold-export-legacy-prefix-ws-20251231T000000Z.zip"
+    )
+
+    slug = restore_workspace(path, session, storage)
+
+    assert slug == "legacy-prefix-ws"
+    ws = session.query(Workspace).filter_by(slug="legacy-prefix-ws").first()
+    assert ws is not None
+    assert str(ws.id) == manifest["workspace"]["id"]
+
+
 def test_restore_preserves_full_hierarchy(session, storage, tmp_path):
     bundle_bytes, manifest = _make_bundle(ws_slug="restore-hierarchy-ws")
     path = _write_bundle(tmp_path, bundle_bytes)

--- a/api/tests/test_restore.py
+++ b/api/tests/test_restore.py
@@ -22,7 +22,7 @@ from marrow.models import Attachment, Page, Revision, Workspace
 from marrow.restore import restore_workspace
 from marrow.storage import StorageAdapter
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_round_trip.py
+++ b/api/tests/test_round_trip.py
@@ -24,7 +24,7 @@ from marrow.models import Attachment, Collection, Organization, Page, Revision, 
 from marrow.restore import restore_workspace
 from marrow.storage import StorageAdapter
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
 
 
 # ---------------------------------------------------------------------------
@@ -68,7 +68,7 @@ def _alembic_cfg(url: str) -> Config:
 @pytest.fixture(scope="module")
 def db_url():
     """Create a fresh database, run migrations, yield URL, then drop it."""
-    db_name = f"freehold_roundtrip_{uuid.uuid4().hex[:8]}"
+    db_name = f"marrow_roundtrip_{uuid.uuid4().hex[:8]}"
 
     admin = psycopg2.connect(f"{_base_dsn()}/postgres")
     admin.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)

--- a/api/tests/test_search.py
+++ b/api/tests/test_search.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 from alembic import command
 from marrow.models import Collection, Organization, Page, Revision, Space, Workspace
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://freehold:freehold@localhost:5433/freehold")
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
 
 
 # ---------------------------------------------------------------------------
@@ -35,7 +35,7 @@ def _alembic_cfg(url: str) -> Config:
 @pytest.fixture(scope="module")
 def db_url():
     """Create a fresh database, run migrations, yield URL, then drop it."""
-    db_name = f"freehold_search_{uuid.uuid4().hex[:8]}"
+    db_name = f"marrow_search_{uuid.uuid4().hex[:8]}"
 
     admin = psycopg2.connect(f"{_base_dsn()}/postgres")
     admin.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
@@ -289,7 +289,7 @@ def test_backend_title_ilike_matches_partial_title(db):
     from marrow.search import PostgresSearchBackend
 
     ws, _, col = _seed_workspace(db)
-    _create_page(db, col, "getting-started", "Getting Started Guide", "Welcome to Freehold.")
+    _create_page(db, col, "getting-started", "Getting Started Guide", "Welcome to Marrow.")
     _create_page(db, col, "unrelated", "API Reference", "Lists all endpoints.")
 
     backend = PostgresSearchBackend()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,15 @@ services:
   db:
     image: postgres:16
     environment:
-      POSTGRES_USER: freehold
-      POSTGRES_PASSWORD: freehold
-      POSTGRES_DB: freehold
+      POSTGRES_USER: marrow
+      POSTGRES_PASSWORD: marrow
+      POSTGRES_DB: marrow
     ports:
       - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U freehold -d freehold"]
+      test: ["CMD-SHELL", "pg_isready -U marrow -d marrow"]
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Finishes the acceptance criteria that #67, #69, and #70 each left partially done. After this PR, all three close.

## Summary
**Package-side residuals (#67):**
- FastAPI title `"Freehold API"` → `"Marrow API"`
- Typer CLI help + module docstrings (`cli.py`, `models.py`, `schemas.py`, `rbac.py`, `restore.py`, `export.py`)
- Stale cookie-clear comment in `routers/auth.py`
- Test DB name prefixes (`freehold_test_` → `marrow_test_`, etc.), fixture strings, and the filename assertion in `test_export.py`
- CLAUDE.md DB URL example, bundle filename patterns, CLI example, prose

**DB + env samples (#69):**
- `docker-compose.yml` Postgres user/password/db `freehold` → `marrow`
- `api/.env.example` `DATABASE_URL` default updated to match
- `STORAGE_PATH` default `/var/lib/freehold/attachments` → `/var/lib/marrow/attachments` in `cli.py`, `storage.py`, `routers/workspaces.py`
- `web/.env.local.example` reviewed — no changes needed (no `freehold` references)

**Export/restore bundle prefix (#70):**
- Export now emits `marrow-export-*.zip` (prefix changed in `export.py`)
- Legacy `freehold-export-*.zip` bundles restore fine — `restore_workspace` is manifest-driven and ignores the zip filename
- **New test** `test_restore_accepts_legacy_freehold_prefixed_bundle` explicitly verifies legacy-prefix tolerance

Out of scope (intentional): repo directory name on disk, `references/` PRDs, README.md (earns its own doc-rebrand issue).

## Test plan
- [x] `rg 'freehold' api/ --glob '!alembic/versions/*'` returns zero hits
- [x] Full `pytest` suite passes (66/66) against the renamed `marrow` Postgres DB
- [x] New legacy-prefix restore test passes
- [x] Alembic upgrade runs cleanly on a fresh DB
- [x] CLI: `marrow --help` still works (untouched code paths)
- [x] OIDC session login still lands on a `marrow_session` cookie (untouched by this PR; spot-check after merge)

## Local migration steps (for reviewers)
```bash
docker compose down -v
docker compose up -d
# update api/.env DATABASE_URL if you maintain a local copy
cd api && alembic upgrade head
```

Closes #67, #69, #70.