### PR TITLE
docs: rebrand Freehold → Marrow in README, CLAUDE, and PRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Freehold
+# Marrow
 
 **Your knowledge, owned outright. No landlords. No lock-in. No surprises.**
 
-Freehold is an open-source, sovereign knowledge base for teams and individuals who are done trusting platforms with their work. It is built around one non-negotiable principle: if you have your data, you can always come back. Export, wipe, restore. Every time. No exceptions.
+Marrow is an open-source, sovereign knowledge base for teams and individuals who are done trusting platforms with their work. It is built around one non-negotiable principle: if you have your data, you can always come back. Export, wipe, restore. Every time. No exceptions.
 
 ---
 
-## Why Freehold exists
+## Why Marrow exists
 
 Most knowledge tools are built on a quiet assumption: that you'll stay. Notion, Confluence, Loop — they're designed to be sticky, which is another word for hard to leave. Your pages, your attachments, your links, your history — they live in someone else's house. You pay rent. They set the rules.
 
-Freehold is built on the opposite assumption. You should be able to leave at any time, take everything with you, and rebuild elsewhere in minutes. That's not a feature. That's the foundation.
+Marrow is built on the opposite assumption. You should be able to leave at any time, take everything with you, and rebuild elsewhere in minutes. That's not a feature. That's the foundation.
 
 ---
 
@@ -19,23 +19,23 @@ Freehold is built on the opposite assumption. You should be able to leave at any
 These are not aspirations. They are constraints that every architectural and product decision must respect.
 
 **1. Restore guarantee**
-If you have a Freehold export bundle, you can restore your entire workspace exactly as it was. Assets, pages, links, revision history, metadata. All of it. If a restore test fails, the export is broken and that is a critical bug.
+If you have a Marrow export bundle, you can restore your entire workspace exactly as it was. Assets, pages, links, revision history, metadata. All of it. If a restore test fails, the export is broken and that is a critical bug.
 
 **2. Transparent data format**
-The export format is documented, human-readable, and boring on purpose. Markdown files, attachments, a JSON manifest, a link graph. No proprietary binary blobs. No surprises. A person with basic technical literacy should be able to read a Freehold export without any tooling.
+The export format is documented, human-readable, and boring on purpose. Markdown files, attachments, a JSON manifest, a link graph. No proprietary binary blobs. No surprises. A person with basic technical literacy should be able to read a Marrow export without any tooling.
 
 **3. Append-only revision history**
 Nothing is ever silently overwritten. Every save creates a revision. You can reconstruct the state of any page at any point in time. Data loss is not a known failure mode.
 
 **4. Pluggable storage**
-Freehold does not care where your data lives. Local disk, S3-compatible object storage, Azure Blob — the storage layer is an interface, not a hard dependency. You bring the storage. Freehold brings the structure.
+Marrow does not care where your data lives. Local disk, S3-compatible object storage, Azure Blob — the storage layer is an interface, not a hard dependency. You bring the storage. Marrow brings the structure.
 
 **5. Self-hosted by default, cloud by choice**
-Freehold can be deployed on your own infrastructure or used as a hosted service. Either way, the data ownership model does not change. The hosted version is a convenience, not a trap.
+Marrow can be deployed on your own infrastructure or used as a hosted service. Either way, the data ownership model does not change. The hosted version is a convenience, not a trap.
 
 ---
 
-## What Freehold is (v0.1 MVP)
+## What Marrow is (v0.1 MVP)
 
 The first version does one thing well: it is a wiki that cannot lose your data.
 
@@ -52,9 +52,9 @@ That's it. No task sync, no approvals workflow, no governance features. Those co
 
 ---
 
-## What Freehold becomes (roadmap direction)
+## What Marrow becomes (roadmap direction)
 
-Freehold is designed to grow toward being the layer where knowledge and execution meet, with the same ownership philosophy running through all of it.
+Marrow is designed to grow toward being the layer where knowledge and execution meet, with the same ownership philosophy running through all of it.
 
 - **Two-way task integration**: tasks as first-class objects, synced bidirectionally with external systems (not just "create task" buttons)
 - **Content lifecycle**: Draft → Reviewed → Approved → Archived, with audit trail
@@ -95,10 +95,10 @@ The revision table is the heart of the restore guarantee. Current page state poi
 
 ## Export bundle format
 
-A Freehold export bundle is a `.zip` file with the following structure:
+A Marrow export bundle is a `.zip` file with the following structure:
 
 ```text
-freehold-export-{workspace-slug}-{timestamp}.zip
+marrow-export-{workspace-slug}-{timestamp}.zip
 ├── manifest.json          # workspace metadata, export timestamp, schema version
 ├── pages/
 │   └── {page-id}.md       # page content in Markdown
@@ -110,7 +110,7 @@ freehold-export-{workspace-slug}-{timestamp}.zip
 └── links.json             # full link graph: internal links, broken links, orphans
 ```
 
-The restore guarantee means: given this bundle and a fresh Freehold installation, `freehold restore --bundle <file>` reproduces the workspace exactly. Asset hashes are verified on restore. If they do not match, the restore fails loudly.
+The restore guarantee means: given this bundle and a fresh Marrow installation, `marrow restore --bundle <file>` reproduces the workspace exactly. Asset hashes are verified on restore. If they do not match, the restore fails loudly.
 
 ---
 
@@ -176,7 +176,7 @@ pytest tests/test_round_trip.py  # export/restore round-trip only
 
 ## Contributing
 
-Freehold is open source because the philosophy demands it. A sovereign knowledge base built behind closed doors would be a contradiction.
+Marrow is open source because the philosophy demands it. A sovereign knowledge base built behind closed doors would be a contradiction.
 
 If you want to contribute, start with the issues labeled `good first issue`. Before writing code, read the restore guarantee section above. Any contribution that compromises the export/restore round-trip will not be merged.
 
@@ -188,4 +188,4 @@ Apache 2.0. Use it, fork it, deploy it, build on it. Just don't tell people thei
 
 ---
 
-*Freehold: property owned outright, with no landlord, no lease, and no one who can take it back.*
+*Marrow: the core that holds everything together — portable, durable, yours.*

--- a/references/PR-50-instructions.md
+++ b/references/PR-50-instructions.md
@@ -7,7 +7,7 @@ This verifies the app works exactly as before when OIDC is not configured.
 ### Setup
 
 1. Make sure your api/.env has no OIDC settings (they should be commented out or absent):
-   DATABASE_URL=postgresql://freehold:freehold@localhost:5433/freehold
+   DATABASE_URL=postgresql://marrow:marrow@localhost:5433/marrow
    SECRET_KEY=changeme
    STORAGE_PATH=./storage
    /# API_KEY=            ← leave commented out
@@ -57,11 +57,11 @@ This is the most involved test. We'll spin up a local Keycloak instance as your 
 3. Click Administration Console and log in with `admin` / `admin`
 4. Create a realm (a realm is like a tenant in Keycloak):
     - In the top-left dropdown (it says "Keycloak" or "master"), click it and then click Create realm
-    - Set the Realm name to `freehold`
+    - Set the Realm name to `marrow`
     - Click Create
-5. Create a client (this represents your Freehold app):
+5. Create a client (this represents your Marrow app):
     - In the left sidebar, click Clients → Create client
-    - Client ID: `freehold-app`
+    - Client ID: `marrow-app`
     - Click Next
     - Turn ON Client authentication (this makes it a confidential client, which gives you a client secret)
     - Click Next
@@ -81,14 +81,14 @@ This is the most involved test. We'll spin up a local Keycloak instance as your 
     - Go to the Credentials tab on that user
     - Click Set password, enter `password`, turn OFF Temporary, click Save
 
-### Part B: Configure Freehold
+### Part B: Configure Marrow
 
 1. Update `api/.env`:
-  DATABASE_URL=`postgresql://freehold:freehold@localhost:5433/freehold`
+  DATABASE_URL=`postgresql://marrow:marrow@localhost:5433/marrow`
   SECRET_KEY=changeme
   STORAGE_PATH=./storage
-  OIDC_ISSUER=`http://localhost:8080/realms/freehold`
-  OIDC_CLIENT_ID=freehold-app
+  OIDC_ISSUER=`http://localhost:8080/realms/marrow`
+  OIDC_CLIENT_ID=marrow-app
   OIDC_CLIENT_SECRET=<paste the secret from step 6>
   OIDC_REDIRECT_URI=`http://localhost:8000/api/auth/callback`
   FRONTEND_URL=`http://localhost:3000`
@@ -141,7 +141,7 @@ This verifies that header-based API key auth works alongside OIDC.
 
 ### First create a workspace via the API or browser, then:
 
-API_KEY=test-secret-key freehold export --workspace <your-workspace-slug> --output /tmp/test-export.zip
+API_KEY=test-secret-key marrow export --workspace <your-workspace-slug> --output /tmp/test-export.zip
 11. This should succeed, proving CLI export works with API key auth even when OIDC is enabled.
 
 If all of that works, this test passes.

--- a/references/prd-marrow-roadmap.md
+++ b/references/prd-marrow-roadmap.md
@@ -1,10 +1,10 @@
-# Freehold Product Roadmap — PRD
+# Marrow Product Roadmap — PRD
 
 ## Overview
 
-Freehold is an open-source, self-hostable knowledge base built around a non-negotiable restore guarantee: any export bundle can be restored to an exact replica of the original workspace. The v0.1 MVP proves this technically — append-only revisions, zip-based export/restore, and a round-trip integration test that validates the cycle.
+Marrow is an open-source, self-hostable knowledge base built around a non-negotiable restore guarantee: any export bundle can be restored to an exact replica of the original workspace. The v0.1 MVP proves this technically — append-only revisions, zip-based export/restore, and a round-trip integration test that validates the cycle.
 
-This PRD defines the phased roadmap to turn Freehold from a working proof-of-concept into a product that solo contractors and small teams use daily. Each phase is a shippable milestone with its own "done" criteria. Phases can overlap in development but ship sequentially.
+This PRD defines the phased roadmap to turn Marrow from a working proof-of-concept into a product that solo contractors and small teams use daily. Each phase is a shippable milestone with its own "done" criteria. Phases can overlap in development but ship sequentially.
 
 **Target user (day one):** Solo contractors and freelancers managing multiple client engagements. One workspace per client. Export when the engagement ends. Restore when they come back.
 
@@ -15,12 +15,12 @@ This PRD defines the phased roadmap to turn Freehold from a working proof-of-con
 
 ## Phase 1 — Usable Knowledge Base
 
-**Goal:** Make Freehold usable enough that a solo contractor replaces their current wiki/notes tool with it.
+**Goal:** Make Marrow usable enough that a solo contractor replaces their current wiki/notes tool with it.
 
 ### 1.1 Search
 
 **Decision:** PostgreSQL full-text search. No new infrastructure.
-**Why:** Freehold already requires Postgres. A `tsvector` column on pages with a GIN index gets ranked full-text search with zero new services. Handles 10k+ pages comfortably.
+**Why:** Marrow already requires Postgres. A `tsvector` column on pages with a GIN index gets ranked full-text search with zero new services. Handles 10k+ pages comfortably.
 **Rejected:** Meilisearch (adds a service dependency, overkill for launch), application-level search (too slow past 1k pages).
 
 **Implementation:**
@@ -38,7 +38,7 @@ This PRD defines the phased roadmap to turn Freehold from a working proof-of-con
 
 ### 1.2 Authentication
 
-**Decision:** OIDC-first. Freehold validates JWT tokens from a configured OIDC provider.
+**Decision:** OIDC-first. Marrow validates JWT tokens from a configured OIDC provider.
 **Why:** Avoids building password hashing, reset flows, email verification, brute-force protection. Self-hosters point at their own IdP (Keycloak, Okta, Azure AD). SaaS tier uses a managed provider (Clerk/Auth0). SSO is a natural consequence, not a separate feature.
 **Rejected:** Built-in email/password (massive security surface area for a small team), OAuth-only without OIDC (less standardized, harder for self-hosters).
 
@@ -132,7 +132,7 @@ This PRD defines the phased roadmap to turn Freehold from a working proof-of-con
 **Blocked by:** 1.4 (#37), 1.5 (#38)
 
 **Done when:**
-- A stranger can self-host Freehold in under 30 minutes following the README
+- A stranger can self-host Marrow in under 30 minutes following the README
 - Cloudflare deployment path documented (Pages + Containers + Neon + R2)
 - `v0.1.0` GitHub release created and tagged
 


### PR DESCRIPTION
## Summary
- Rebrand Freehold → Marrow in `README.md`, `CLAUDE.md` (where not intentionally referring to on-disk repo name), and `references/PR-50-instructions.md`
- Rename `references/prd-freehold-roadmap.md` → `references/prd-marrow-roadmap.md` (94% similarity, history preserved)
- Remove Weald Labs references; keep legacy-tolerance notes (e.g. `freehold-export-*` bundle restore) intact

Closes #72

## Test plan
- [x] `rg -i 'freehold|weald' README.md CLAUDE.md references/` returns only intentional hits (on-disk repo name, rebrand PRD archival refs, legacy-prefix tolerance)
- [x] PRD file renamed via `git mv` (history preserved)
- [x] Reviewed by `review` subagent — verdict: ship it