### PR TITLE
Editor: @ mentions members; /page slash item for page links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,7 +313,7 @@ Marrow supports three authentication methods, checked in priority order:
 - **API client** (`lib/api.ts`): all server calls go through `apiFetch<T>()` which injects auth headers and handles errors
 - **Auto-save**: `PageEditor` debounces saves 2 seconds after last keystroke; shows Saving… / Saved / Error status
 - **Content format**: new saves store BlockNote JSON (`content_format='json'`); legacy Markdown revisions are loaded via `tryParseMarkdownToBlocks` for backward compat
-- **Editor features**: code blocks (Shiki syntax highlighting), tables (`TableHandlesController`), `@` page mentions (`SuggestionMenuController` → `searchWorkspace`)
+- **Editor features**: code blocks (Shiki syntax highlighting), tables (`TableHandlesController`), `@` member mentions (custom inline-content spec carrying `userId` + `displayName`, fed by `listOrgMembers`), `/page` slash item that opens a page picker and inserts a WikiLink (`searchWorkspace`)
 - **Sidebar create flows**: hover-to-reveal `+` buttons open `CreateDialog` with slug auto-generation via `slugify()`
 - **UI library**: Base UI (`@base-ui/react`) with Tailwind CSS 4 — uses `render` prop pattern, not `asChild`
 - **Theme**: `next-themes` wraps the root layout

--- a/api/marrow/export.py
+++ b/api/marrow/export.py
@@ -77,8 +77,11 @@ def _inline_to_text(inline_content: list) -> str:
             link_text = _inline_to_text(link_content)
             text += f"[{link_text}]({href})"
         elif item_type == "mention":
-            # Page mention: rendered as the mention text
-            text += item.get("props", {}).get("user", "")
+            # Member mention: lossy fallback to "@DisplayName" plaintext.
+            # The canonical userId is preserved in the JSON revision.
+            display_name = item.get("props", {}).get("displayName", "")
+            if display_name:
+                text += f"@{display_name}"
     return text
 
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -175,6 +175,23 @@
   text-decoration-thickness: 1px;
 }
 
+/* Member mentions — non-link styled token. */
+.bn-container .marrow-mention {
+  display: inline-flex;
+  align-items: baseline;
+  padding: 0 0.3em;
+  margin: 0 0.05em;
+  border-radius: 0.25rem;
+  background-color: color-mix(in oklab, var(--primary) 12%, transparent);
+  color: var(--primary);
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  user-select: all;
+  cursor: default;
+}
+
 /* Task list checkboxes — squarer, more prominent, brand-colored. */
 .bn-container [data-content-type="checkListItem"] input[type="checkbox"] {
   appearance: none;

--- a/web/components/editor/mention-inline-content.tsx
+++ b/web/components/editor/mention-inline-content.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { createReactInlineContentSpec } from "@blocknote/react";
+
+export const mentionInlineContentSpec = createReactInlineContentSpec(
+  {
+    type: "mention",
+    propSchema: {
+      userId: { default: "" },
+      displayName: { default: "" },
+    },
+    content: "none",
+  },
+  {
+    render: ({ inlineContent }) => {
+      const props = inlineContent.props as { userId: string; displayName: string };
+      return (
+        <span
+          className="marrow-mention"
+          data-user-id={props.userId}
+          contentEditable={false}
+        >
+          @{props.displayName}
+        </span>
+      );
+    },
+  },
+);

--- a/web/components/editor/page-link-slash-item.tsx
+++ b/web/components/editor/page-link-slash-item.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Link as LinkIcon } from "lucide-react";
+import type { DefaultReactSuggestionItem } from "@blocknote/react";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function pageLinkSlashMenuItem(_editor: any, openPicker: () => void): DefaultReactSuggestionItem {
+  return {
+    title: "Page link",
+    subtext: "Link to another page in this workspace",
+    aliases: ["page", "link", "ref", "wiki"],
+    group: "Custom",
+    icon: <LinkIcon className="h-4 w-4" />,
+    onItemClick: () => {
+      // Defer so the slash-menu finishes closing and the editor selection
+      // is restored before we re-focus into the picker.
+      setTimeout(openPicker, 0);
+    },
+  };
+}

--- a/web/components/page-editor.tsx
+++ b/web/components/page-editor.tsx
@@ -25,6 +25,7 @@ import {
   BlockNoteSchema,
   createCodeBlockSpec,
   defaultBlockSpecs,
+  defaultInlineContentSpecs,
 } from "@blocknote/core";
 import { filterSuggestionItems } from "@blocknote/core/extensions";
 import {
@@ -35,6 +36,16 @@ import {
   type DefaultReactSuggestionItem,
 } from "@blocknote/react";
 import { calloutBlockSpec, calloutSlashMenuItem } from "@/components/editor/callout-block";
+import { mentionInlineContentSpec } from "@/components/editor/mention-inline-content";
+import { pageLinkSlashMenuItem } from "@/components/editor/page-link-slash-item";
+import { useWorkspaceTree } from "@/components/workspace-tree-context";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { BlockNoteView } from "@blocknote/mantine";
 import { createHighlighter } from "shiki";
 import { Upload } from "lucide-react";
@@ -55,11 +66,12 @@ import { CommentBubbleFab } from "@/components/comment-bubble-fab";
 import {
   attachmentFileUrl,
   listAttachments,
+  listOrgMembers,
   searchWorkspace,
   updatePage,
   uploadAttachment,
 } from "@/lib/api";
-import type { Attachment, Page } from "@/lib/types";
+import type { Attachment, OrgMembership, Page, SearchResultItem } from "@/lib/types";
 
 type SaveStatus = "idle" | "saving" | "saved" | "error";
 
@@ -96,6 +108,10 @@ const schema = BlockNoteSchema.create({
       defaultLanguage: "text",
     }),
     callout: calloutBlockSpec(),
+  },
+  inlineContentSpecs: {
+    ...defaultInlineContentSpecs,
+    mention: mentionInlineContentSpec,
   },
 });
 
@@ -249,27 +265,107 @@ export function PageEditor({ initialPage }: Props) {
   );
 
   // ---------------------------------------------------------------------------
-  // @-mention suggestion menu — queries workspace pages
+  // @-mention suggestion menu — queries workspace members
   // ---------------------------------------------------------------------------
 
-  const getPageMentionItems = useCallback(
+  const tree = useWorkspaceTree();
+  const orgId = tree?.org_id ?? null;
+  const membersCacheRef = useRef<{ orgId: string; members: OrgMembership[] } | null>(null);
+
+  const getMemberItems = useCallback(
     async (query: string): Promise<DefaultReactSuggestionItem[]> => {
-      if (!workspaceId) return [];
-      try {
-        const { results } = await searchWorkspace(workspaceId, query);
-        return results.slice(0, 8).map((result) => ({
-          title: result.title,
-          subtext: `${result.space_name} / ${result.collection_name}`,
-          onItemClick: () => {
-            editor.createLink(`/w/${workspaceId}/pages/${result.page_id}`, result.title);
-          },
-        }));
-      } catch {
-        return [];
+      if (!orgId) return [];
+      let members: OrgMembership[];
+      if (membersCacheRef.current?.orgId === orgId) {
+        members = membersCacheRef.current.members;
+      } else {
+        try {
+          members = await listOrgMembers(orgId);
+          membersCacheRef.current = { orgId, members };
+        } catch {
+          return [];
+        }
       }
+
+      const q = query.trim().toLowerCase();
+      const filtered = q
+        ? members.filter(
+            (m) => m.email.toLowerCase().includes(q),
+          )
+        : members;
+
+      return filtered.slice(0, 8).map((member) => {
+        const displayName = member.email.split("@")[0] || member.email;
+        return {
+          title: displayName,
+          subtext: member.email,
+          onItemClick: () => {
+            editor.insertInlineContent([
+              {
+                type: "mention",
+                props: { userId: member.user_id ?? "", displayName },
+              },
+              " ",
+            ]);
+          },
+        };
+      });
+    },
+    [editor, orgId],
+  );
+
+  // ---------------------------------------------------------------------------
+  // /page slash item — opens a page picker that inserts a WikiLink
+  // ---------------------------------------------------------------------------
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerQuery, setPickerQuery] = useState("");
+  const [pickerResults, setPickerResults] = useState<SearchResultItem[]>([]);
+  const [pickerLoading, setPickerLoading] = useState(false);
+  const [pickerActiveIndex, setPickerActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (!pickerOpen || !workspaceId) return;
+    const q = pickerQuery.trim();
+    if (!q) return;
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      setPickerLoading(true);
+      try {
+        const res = await searchWorkspace(workspaceId, q);
+        if (!cancelled) {
+          setPickerResults(res.results.slice(0, 12));
+          setPickerActiveIndex(0);
+        }
+      } catch {
+        if (!cancelled) setPickerResults([]);
+      } finally {
+        if (!cancelled) setPickerLoading(false);
+      }
+    }, 200);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [pickerOpen, pickerQuery, workspaceId]);
+
+  const insertPageLink = useCallback(
+    (result: SearchResultItem) => {
+      if (!workspaceId) return;
+      editor.createLink(`/w/${workspaceId}/pages/${result.page_id}`, result.title);
+      setPickerOpen(false);
+      setPickerQuery("");
+      setPickerResults([]);
     },
     [editor, workspaceId],
   );
+
+  const openPagePicker = useCallback(() => {
+    setPickerQuery("");
+    setPickerResults([]);
+    setPickerActiveIndex(0);
+    setPickerOpen(true);
+  }, []);
 
   const statusLabel = {
     idle: "",
@@ -334,24 +430,94 @@ export function PageEditor({ initialPage }: Props) {
           {/* Table drag handles */}
           <TableHandlesController />
 
-          {/* Slash menu — default items + callout */}
+          {/* Slash menu — default items + callout + page link */}
           <SuggestionMenuController
             triggerCharacter="/"
             getItems={async (query) =>
               filterSuggestionItems(
-                [...getDefaultReactSlashMenuItems(editor), calloutSlashMenuItem(editor)],
+                [
+                  ...getDefaultReactSlashMenuItems(editor),
+                  calloutSlashMenuItem(editor),
+                  pageLinkSlashMenuItem(editor, openPagePicker),
+                ],
                 query,
               )
             }
           />
 
-          {/* @-mention suggestion menu for page links */}
+          {/* @-mention suggestion menu for workspace members */}
           <SuggestionMenuController
             triggerCharacter="@"
-            getItems={getPageMentionItems}
+            getItems={getMemberItems}
           />
         </BlockNoteView>
       </div>
+
+      {/* Page picker (opened via /page slash item) */}
+      <Dialog open={pickerOpen} onOpenChange={setPickerOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Link to a page</DialogTitle>
+          </DialogHeader>
+          <Input
+            autoFocus
+            value={pickerQuery}
+            placeholder="Search pages…"
+            onChange={(e) => {
+              const v = e.target.value;
+              setPickerQuery(v);
+              if (!v.trim()) {
+                setPickerResults([]);
+                setPickerActiveIndex(0);
+              }
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setPickerActiveIndex((i) => Math.min(i + 1, pickerResults.length - 1));
+              } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setPickerActiveIndex((i) => Math.max(i - 1, 0));
+              } else if (e.key === "Enter" && pickerResults[pickerActiveIndex]) {
+                e.preventDefault();
+                insertPageLink(pickerResults[pickerActiveIndex]);
+              }
+            }}
+          />
+          <div className="max-h-72 overflow-y-auto">
+            {pickerLoading && (
+              <p className="px-1 py-2 text-xs text-muted-foreground">Searching…</p>
+            )}
+            {!pickerLoading && pickerQuery.trim() && pickerResults.length === 0 && (
+              <p className="px-1 py-2 text-xs text-muted-foreground">No pages match.</p>
+            )}
+            {!pickerQuery.trim() && (
+              <p className="px-1 py-2 text-xs text-muted-foreground">
+                Start typing to search pages in this workspace.
+              </p>
+            )}
+            <ul className="flex flex-col gap-1">
+              {pickerResults.map((r, i) => (
+                <li key={r.page_id}>
+                  <button
+                    type="button"
+                    onClick={() => insertPageLink(r)}
+                    onMouseEnter={() => setPickerActiveIndex(i)}
+                    className={`w-full rounded-md px-3 py-2 text-left transition-colors ${
+                      i === pickerActiveIndex ? "bg-accent" : "hover:bg-accent/60"
+                    }`}
+                  >
+                    <div className="text-sm font-medium text-foreground">{r.title}</div>
+                    <div className="mt-0.5 font-mono text-[11px] text-muted-foreground">
+                      {r.space_name} / {r.collection_name}
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       {!commentsOpen && (
         <CommentBubbleFab onClick={() => { setSideDrawer(null); setCommentsOpen(true); }} />


### PR DESCRIPTION
## Summary
- Splits the `@` trigger from page-search to member-mention so `@` matches the universal collaboration convention (Slack/Notion/Linear/GitHub).
- New `/page` slash item opens a workspace page picker and inserts a `WikiLink` (picks up the dashed-underline accent CSS from #93).
- New mention inline-content spec carries `{ userId, displayName }`; renders as a non-link styled `@Name` token (`.marrow-mention`).
- JSON revisions preserve the full mention object (userId survives reload). Markdown export falls back to `@Name` plaintext per the issue spec.

Closes #108.

## Notes / follow-ups
- `OrgMembership` doesn't carry a display name yet, so the mention's `displayName` is derived from the email local-part. Worth a follow-up to join `users.name` into the membership response so the styled token shows the human-readable name.
- `[[` as a top-level trigger was discussed and dropped — not in the issue's acceptance criteria, and BlockNote's slash-item `aliases` only filter slash items.

## Test plan

`cd web && npm run dev`. Open a workspace, open a page.

### `@` member mentions
- [x] Type `@` in the editor body → suggestion menu opens with workspace members.
- [x] Filter by typing characters that appear in member emails — list narrows.
- [x] Select a member → a styled `@name` token is inserted (accent color, tinted background, mono uppercase). Cursor advances past the token (trailing space).
- [x] Click the token → nothing happens (it's not a link).
- [x] Save (auto-save fires after 2s) and reload the page → mention persists and re-renders styled.
- [x] Confirm: typing `@` no longer surfaces page-search results.

### `/page` slash item
- [x] Type `/` → "Page link" appears in the slash menu (with a link icon, "Custom" group).
- [x] Type `/page` → list filters to the new item.
- [x] Select it → a "Link to a page" dialog opens with a focused search input.
- [x] Type a query → matching pages appear after a short debounce.
- [x] ArrowUp/ArrowDown changes the highlighted result; Enter inserts a link to the highlighted page.
- [x] Click a result with the mouse → same effect.
- [x] Inserted link is a `WikiLink` (`/w/{wsid}/pages/{pid}`) and renders with the dashed-underline accent style from #93.
- [x] Closing the dialog without selecting (Esc / clicking the backdrop) inserts nothing.

### Markdown export
- [x] Export the workspace (full bundle).
- [x] Open the page's `.md` file: mentions appear as plaintext `@Name` (acceptable lossy fallback).
- [x] Open the page's `.json` file (v3 bundle): mention nodes preserve `userId` and `displayName` in their props (canonical for restore).

### Regression
- [x] Existing editor features unchanged: code blocks, callout, tables, attachments, comments drawer, revisions, auto-save.
- [ ] `cd web && npm run lint` — no new errors (3 pre-existing remain).
- [x] `cd web && npm run build` — passes locally.