### PR TITLE
Fix react-hooks/set-state-in-effect lint errors

### DIFF
--- a/web/app/orgs/[orgId]/settings/page.tsx
+++ b/web/app/orgs/[orgId]/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
@@ -26,7 +26,7 @@ export default function OrgSettingsPage() {
   const [inviteRole, setInviteRole] = useState<string>("editor");
   const [busy, setBusy] = useState(false);
 
-  async function load() {
+  const load = useCallback(async () => {
     try {
       const [o, m] = await Promise.all([getOrg(orgId), listOrgMembers(orgId)]);
       setOrg(o);
@@ -34,11 +34,24 @@ export default function OrgSettingsPage() {
     } catch (err) {
       toast.error(String(err));
     }
-  }
+  }, [orgId]);
 
   useEffect(() => {
-    load();
-  }, [orgId]); // eslint-disable-line react-hooks/exhaustive-deps
+    let cancelled = false;
+    (async () => {
+      try {
+        const [o, m] = await Promise.all([getOrg(orgId), listOrgMembers(orgId)]);
+        if (cancelled) return;
+        setOrg(o);
+        setMembers(m);
+      } catch (err) {
+        if (!cancelled) toast.error(String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId]);
 
   async function handleInvite(e: React.FormEvent) {
     e.preventDefault();

--- a/web/components/theme-toggle.tsx
+++ b/web/components/theme-toggle.tsx
@@ -1,15 +1,19 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { useTheme } from "next-themes";
 import { Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
+const subscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
 export function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => setMounted(true), []);
+  // Avoid SSR hydration mismatch on the icon: render a placeholder on the
+  // server snapshot, the real toggle on the client snapshot.
+  const mounted = useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
 
   if (!mounted) return <div className="h-7 w-7" />;
 

--- a/web/hooks/use-mobile.ts
+++ b/web/hooks/use-mobile.ts
@@ -1,19 +1,21 @@
-import * as React from "react"
+import { useSyncExternalStore } from "react"
 
 const MOBILE_BREAKPOINT = 768
 
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+  mql.addEventListener("change", callback)
+  return () => mql.removeEventListener("change", callback)
+}
+
+function getSnapshot() {
+  return window.innerWidth < MOBILE_BREAKPOINT
+}
+
+function getServerSnapshot() {
+  return false
+}
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }


### PR DESCRIPTION
## Summary
Three pre-existing lint errors in `web/` were all flavors of `react-hooks/set-state-in-effect` (calling setState directly in an effect body). This PR resolves them properly rather than silencing the rule.

- **`web/components/theme-toggle.tsx`** — replaced the `useEffect(() => setMounted(true), [])` mounted-detection pattern with `useSyncExternalStore`. Server snapshot returns `false`, client snapshot returns `true`. No setState involved.
- **`web/hooks/use-mobile.ts`** — converted to `useSyncExternalStore` subscribed to the matchMedia `change` event. This is the textbook React 18+ pattern for media-query subscriptions.
- **`web/app/orgs/[orgId]/settings/page.tsx`** — the initial-load `useEffect` called a `load()` helper which the rule flagged. Inlined an async IIFE with a cancellation flag inside the effect; action handlers (invite / role change / remove) keep a memoized `load()` callback for post-action refresh.

## Verification
- `cd web && npm run lint` — exits clean, zero errors (was 3).
- `cd web && npm run build` — passes.

## Test plan
- [x] Toggle the theme button — no flicker, no hydration mismatch warnings in the console.
- [x] Resize the window through 768px — anything driven by `useIsMobile` updates correctly.
- [x] Visit `/orgs/{orgId}/settings` — members + org load on first paint; invite / change role / remove all refresh the list as before.