### PR TITLE
Build multi-arch container images (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -39,6 +40,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./api
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_API }}:${{ steps.meta.outputs.tag }}
@@ -47,6 +49,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./web
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_WEB }}:${{ steps.meta.outputs.tag }}


### PR DESCRIPTION
## Summary
- Adds `linux/arm64` alongside `linux/amd64` to both image builds in `release.yml` via QEMU.
- Unblocks ARM self-hosters (Apple Silicon, Pi, Graviton, Ampere).
- Closes #117.

## Tradeoff
Roughly doubles release.yml runtime — arm64 builds under QEMU on amd64 runners. Fine for v0.1.x. If it becomes annoying, switch to a matrix using native `ubuntu-24.04-arm` runners and merge manifests.

## Test plan
- [ ] After merge, the Release workflow on `main` succeeds and `:latest` becomes a multi-arch manifest.
- [ ] Re-run Release workflow against tag `v0.1.0` to upgrade `:v0.1.0` to multi-arch.
- [ ] `docker buildx imagetools inspect ghcr.io/spmcgraw/marrow-api:v0.1.0` shows both `linux/amd64` and `linux/arm64`.
- [ ] Same for `marrow-web:v0.1.0`.
- [ ] `docker compose -f docker-compose.prod.yml pull` succeeds on an Ampere VM.