### PR TITLE
Web: read browser config at runtime, not build time

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -4,13 +4,15 @@
 # --- Required ---
 SECRET_KEY=replace-with-a-long-random-string
 POSTGRES_PASSWORD=replace-with-a-strong-password
-NEXT_PUBLIC_API_URL=http://localhost:8000
+# Browser-visible API origin. Must be reachable from the user's browser
+# (so http://localhost:8000 only works if the browser is on the same host).
+MARROW_API_URL=http://localhost:8000
 
 # --- Authentication (REQUIRED — set at least one) ---
 # Marrow refuses to start in production without auth configured.
 # Pick one (OIDC is preferred for multi-user; API_KEY is fine for solo / scripts):
-#   1. OIDC — fill in the OIDC_* block below AND set NEXT_PUBLIC_OIDC_ENABLED=true
-#   2. API key — set API_KEY to a long random string
+#   1. OIDC — fill in the OIDC_* block below AND set MARROW_OIDC_ENABLED=true
+#   2. API key — set API_KEY (server) and MARROW_API_KEY (browser, same value)
 # API_KEY=
 
 # --- Optional ---
@@ -21,12 +23,12 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 # WEB_PORT=3000
 # CORS_ORIGINS=http://localhost:3000
 
-# OIDC (set OIDC_ISSUER to enable; mirror with NEXT_PUBLIC_OIDC_ENABLED=true)
+# OIDC (set OIDC_ISSUER to enable; mirror with MARROW_OIDC_ENABLED=true)
 # OIDC_ISSUER=
 # OIDC_CLIENT_ID=
 # OIDC_CLIENT_SECRET=
 # OIDC_REDIRECT_URI=http://localhost:8000/api/auth/callback
 # FRONTEND_URL=http://localhost:3000
 # COOKIE_DOMAIN=localhost
-# NEXT_PUBLIC_OIDC_ENABLED=
-# NEXT_PUBLIC_API_KEY=
+# MARROW_OIDC_ENABLED=
+# MARROW_API_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,6 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run build
-        env:
-          NEXT_PUBLIC_API_URL: http://localhost:8000
 
   docs:
     name: Docs — build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ uvicorn main:app --reload         # starts on http://localhost:8000
 # Frontend
 cd web
 npm install
-cp .env.local.example .env.local  # set NEXT_PUBLIC_API_URL and NEXT_PUBLIC_API_KEY
+cp .env.local.example .env.local  # optionally override MARROW_API_URL / MARROW_API_KEY
 npm run dev                       # starts on http://localhost:3000
 ```
 
@@ -72,10 +72,12 @@ CORS_ORIGINS=http://localhost:3000
 
 **Frontend (`web/.env.local`)**:
 
+Read at runtime (not build time) — the container generates `/public/config.js` from these at startup, so the prebuilt image works for any deployment without rebuilding. In dev (`npm run dev`), defaults work; only set these to override.
+
 ```env
-NEXT_PUBLIC_API_URL=http://localhost:8000
-NEXT_PUBLIC_API_KEY=         # must match API_KEY in backend .env if set
-NEXT_PUBLIC_OIDC_ENABLED=    # set to "true" when OIDC is configured on the backend
+# MARROW_API_URL=http://localhost:8000   # browser-visible API origin
+# MARROW_API_KEY=                        # must match API_KEY in backend .env if set
+# MARROW_OIDC_ENABLED=                   # "true" when OIDC is configured on the backend
 ```
 
 ---

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,8 +24,6 @@ services:
       retries: 5
 
   api:
-    build:
-      context: ./api
     image: ghcr.io/spmcgraw/marrow-api:${MARROW_VERSION:-latest}
     restart: unless-stopped
     depends_on:
@@ -58,19 +56,18 @@ services:
              uvicorn main:app --host 0.0.0.0 --port 8000"
 
   web:
-    build:
-      context: ./web
-      args:
-        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
-        NEXT_PUBLIC_API_KEY: ${NEXT_PUBLIC_API_KEY:-}
-        NEXT_PUBLIC_OIDC_ENABLED: ${NEXT_PUBLIC_OIDC_ENABLED:-}
     image: ghcr.io/spmcgraw/marrow-web:${MARROW_VERSION:-latest}
     restart: unless-stopped
     depends_on:
       - api
     environment:
-      # SSR inside the docker network can't reach NEXT_PUBLIC_API_URL
-      # (which is the public/browser origin). Reach the api by service name.
+      # Browser-visible config — written to /public/config.js at container
+      # startup by docker-entrypoint.sh, then loaded by the layout.
+      MARROW_API_URL: ${MARROW_API_URL:?MARROW_API_URL is required}
+      MARROW_API_KEY: ${MARROW_API_KEY:-}
+      MARROW_OIDC_ENABLED: ${MARROW_OIDC_ENABLED:-false}
+      # SSR inside the docker network can't reach MARROW_API_URL
+      # (the public/browser origin). Reach the api by service name.
       INTERNAL_API_URL: http://api:8000
     ports:
       - "${WEB_PORT:-3000}:3000"

--- a/docs/src/content/docs/configuration/env-vars.md
+++ b/docs/src/content/docs/configuration/env-vars.md
@@ -44,15 +44,16 @@ Set `OIDC_ISSUER` to enable. All other OIDC vars are required when enabled.
 
 See [OIDC](/configuration/oidc/) for setup walkthroughs.
 
-## Frontend (`web/.env.local`)
+## Frontend (`web/.env.local` for dev, container env for prod)
 
-`NEXT_PUBLIC_*` vars are inlined into the JS bundle at build time. Changing them requires a rebuild.
+These are read at **runtime**, not build time. The container generates a small `/config.js` file from these env vars at startup, so the same prebuilt image works in any deployment without rebuilding.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `NEXT_PUBLIC_API_URL` | `http://localhost:8000` | URL the browser uses to reach the API. |
-| `NEXT_PUBLIC_API_KEY` | unset | If `API_KEY` is set on the backend, set this to match. |
-| `NEXT_PUBLIC_OIDC_ENABLED` | unset | Set to `true` when OIDC is configured on the backend. Enables the `/login` route and route-protection middleware. |
+| `MARROW_API_URL` | `http://localhost:8000` | URL the browser uses to reach the API. Must be reachable from end-user browsers. |
+| `MARROW_API_KEY` | unset | If `API_KEY` is set on the backend, set this to match. |
+| `MARROW_OIDC_ENABLED` | unset | Set to `true` when OIDC is configured on the backend. Enables the `/login` route and route-protection middleware. |
+| `INTERNAL_API_URL` | same as `MARROW_API_URL` | URL Next.js uses for SSR fetches inside the Docker network. Set to `http://api:8000` in the prod compose file. |
 
 ## Production compose root `.env`
 

--- a/docs/src/content/docs/configuration/oidc.md
+++ b/docs/src/content/docs/configuration/oidc.md
@@ -27,14 +27,14 @@ SECRET_KEY=<long random string>
 CORS_ORIGINS=https://app.example.com
 ```
 
-And on the frontend (`web/.env.local`):
+And on the frontend (web container env, or `web/.env.local` for dev):
 
 ```env
-NEXT_PUBLIC_API_URL=https://api.example.com
-NEXT_PUBLIC_OIDC_ENABLED=true
+MARROW_API_URL=https://api.example.com
+MARROW_OIDC_ENABLED=true
 ```
 
-`NEXT_PUBLIC_OIDC_ENABLED` enables the `/login` page and route-protection middleware. Without it the frontend assumes anonymous mode.
+`MARROW_OIDC_ENABLED` enables the `/login` page and route-protection middleware. Without it the frontend assumes anonymous mode.
 
 ## Cookie domain
 

--- a/docs/src/content/docs/deployment/docker-compose.md
+++ b/docs/src/content/docs/deployment/docker-compose.md
@@ -20,7 +20,7 @@ Edit `.env`. The required values:
 | --- | --- |
 | `SECRET_KEY` | Signs the session JWT. Use a long random string. |
 | `POSTGRES_PASSWORD` | Postgres user password. |
-| `NEXT_PUBLIC_API_URL` | The URL the browser will call to reach the API (e.g. `https://api.example.com`). |
+| `MARROW_API_URL` | The URL the browser will call to reach the API (e.g. `https://api.example.com`). |
 
 See [Environment variables](/configuration/env-vars/) for the full reference, including OIDC and CORS.
 
@@ -37,17 +37,17 @@ docker compose -f docker-compose.prod.yml up -d
 `-v` removes the volume — only safe before you have real data.
 :::
 
-## 2. Build and start
+## 2. Pull and start
 
 ```bash
-docker compose -f docker-compose.prod.yml up -d --build
+docker compose -f docker-compose.prod.yml up -d
 ```
 
 This:
 
 1. Brings up PostgreSQL with a persistent volume (`postgres_data`).
-2. Builds the API image and runs `alembic upgrade head` then `uvicorn`.
-3. Builds the web image with the right `NEXT_PUBLIC_*` values baked in (Next.js inlines these at build time).
+2. Pulls the API image from GHCR and runs `alembic upgrade head` then `uvicorn`.
+3. Pulls the web image from GHCR. The browser-visible config (`MARROW_API_URL`, `MARROW_API_KEY`, `MARROW_OIDC_ENABLED`) is read from container env at startup and written into `/config.js` — no rebuild needed when these change.
 
 The API exposes port 8000 and the web exposes port 3000 by default. Override with `API_PORT` / `WEB_PORT`.
 
@@ -70,7 +70,7 @@ Back up both for a complete restore. Or use `marrow export` for portable bundles
 
 ## Reverse proxy
 
-The Compose file does not include a reverse proxy. In production, terminate TLS in front of the web container with Caddy, Traefik, or nginx, and point `NEXT_PUBLIC_API_URL` at the public API hostname.
+The Compose file does not include a reverse proxy. In production, terminate TLS in front of the web container with Caddy, Traefik, or nginx, and point `MARROW_API_URL` at the public API hostname.
 
 If the API and web are on different subdomains, set `CORS_ORIGINS` to the web origin and `COOKIE_DOMAIN` to the parent domain (e.g. `.example.com`) so the session cookie is shared.
 

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -1,5 +1,8 @@
-NEXT_PUBLIC_API_URL=http://localhost:8000
-# Set this if you configured API_KEY on the backend
-NEXT_PUBLIC_API_KEY=
-# Set to "true" when OIDC is configured on the backend
-NEXT_PUBLIC_OIDC_ENABLED=
+# Local dev (`npm run dev`). Only needed if you want to override the defaults.
+# In production (Docker), set these on the web container instead — see
+# .env.prod.example.
+
+# Browser-visible config. Defaults to http://localhost:8000 when unset.
+# MARROW_API_URL=http://localhost:8000
+# MARROW_API_KEY=
+# MARROW_OIDC_ENABLED=

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -15,13 +15,8 @@ COPY . .
 
 ENV NEXT_TELEMETRY_DISABLED=1
 
-ARG NEXT_PUBLIC_API_URL
-ARG NEXT_PUBLIC_API_KEY
-ARG NEXT_PUBLIC_OIDC_ENABLED
-ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL \
-    NEXT_PUBLIC_API_KEY=$NEXT_PUBLIC_API_KEY \
-    NEXT_PUBLIC_OIDC_ENABLED=$NEXT_PUBLIC_OIDC_ENABLED
-
+# Public env vars are injected at runtime via /public/config.js (see
+# docker-entrypoint.sh), so nothing about them is baked into the bundle.
 RUN npm run build
 
 
@@ -37,12 +32,16 @@ ENV NODE_ENV=production \
 RUN addgroup --system --gid 1001 nodejs \
     && adduser --system --uid 1001 nextjs
 
-COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+COPY --chown=nextjs:nodejs docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 USER nextjs
 
 EXPOSE 3000
 
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import localFont from "next/font/local";
+import Script from "next/script";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -23,6 +24,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <Script src="/config.js" strategy="beforeInteractive" />
+      </head>
       <body className={`${inter.variable} ${fraunces.variable} antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
           <TooltipProvider>

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,12 +1,12 @@
 import { redirect } from "next/navigation";
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
-const OIDC_ENABLED = process.env.NEXT_PUBLIC_OIDC_ENABLED === "true";
+import { getApiUrl, getOidcEnabled } from "@/lib/runtime-config";
 
 export default function LoginPage() {
-  if (!OIDC_ENABLED) {
+  if (!getOidcEnabled()) {
     redirect("/workspaces");
   }
+
+  const apiUrl = getApiUrl();
 
   return (
     <div className="flex min-h-screen items-center justify-center">
@@ -18,7 +18,7 @@ export default function LoginPage() {
           </p>
         </div>
         <a
-          href={`${API_URL}/api/auth/login`}
+          href={`${apiUrl}/api/auth/login`}
           className="inline-flex h-9 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
         >
           Sign in with SSO

--- a/web/docker-entrypoint.sh
+++ b/web/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# Generate /app/public/config.js from runtime env vars so the browser bundle
+# can read NEXT_PUBLIC_*-style values without rebuilding the image.
+# Loaded by app/layout.tsx via <Script src="/config.js" strategy="beforeInteractive" />.
+
+CONFIG_FILE="/app/public/config.js"
+
+API_URL="${MARROW_API_URL:-http://localhost:8000}"
+API_KEY="${MARROW_API_KEY:-}"
+OIDC_ENABLED="${MARROW_OIDC_ENABLED:-false}"
+
+# Escape backslash, double-quote, and newline for safe JSON-ish embedding.
+escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e ':a;N;$!ba;s/\n/\\n/g'
+}
+
+cat > "$CONFIG_FILE" <<EOF
+window.__MARROW_CONFIG__ = {
+  apiUrl: "$(escape "$API_URL")",
+  apiKey: "$(escape "$API_KEY")",
+  oidcEnabled: $([ "$OIDC_ENABLED" = "true" ] && echo "true" || echo "false")
+};
+EOF
+
+exec "$@"

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -5,6 +5,7 @@
  * and throws a descriptive error on non-2xx responses.
  */
 
+import { getApiKey, getApiUrl, getInternalApiUrl } from "./runtime-config";
 import type {
   Attachment,
   AuthStatus,
@@ -19,21 +20,20 @@ import type {
   WorkspaceTree,
 } from "./types";
 
-// Browser uses NEXT_PUBLIC_API_URL (the user-facing origin).
-// SSR inside Docker can't reach that origin from within the container, so
-// it uses INTERNAL_API_URL (the docker-network service name) when set.
-const BROWSER_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
-const SERVER_BASE_URL = process.env.INTERNAL_API_URL ?? BROWSER_BASE_URL;
-const BASE_URL = typeof window === "undefined" ? SERVER_BASE_URL : BROWSER_BASE_URL;
-const API_KEY = process.env.NEXT_PUBLIC_API_KEY ?? "";
+// Resolve URLs per-call so runtime config changes (e.g. operator updates env
+// then restarts the container) take effect without rebuilding.
+function baseUrl(): string {
+  return typeof window === "undefined" ? getInternalApiUrl() : getApiUrl();
+}
 
 async function apiFetch<T>(
   path: string,
   options: RequestInit = {}
 ): Promise<T> {
+  const apiKey = getApiKey();
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    ...(API_KEY ? { "X-API-Key": API_KEY } : {}),
+    ...(apiKey ? { "X-API-Key": apiKey } : {}),
     ...(options.headers as Record<string, string>),
   };
 
@@ -47,7 +47,7 @@ async function apiFetch<T>(
     }
   }
 
-  const res = await fetch(`${BASE_URL}${path}`, {
+  const res = await fetch(`${baseUrl()}${path}`, {
     ...options,
     headers,
     credentials: "include", // send cookies for cross-origin OIDC auth
@@ -57,7 +57,7 @@ async function apiFetch<T>(
   if (!res.ok) {
     // Client-side 401: redirect to OIDC login
     if (res.status === 401 && typeof window !== "undefined") {
-      window.location.href = `${BASE_URL}/api/auth/login`;
+      window.location.href = `${baseUrl()}/api/auth/login`;
       return new Promise(() => {}); // page is navigating away
     }
     const text = await res.text().catch(() => res.statusText);
@@ -100,18 +100,18 @@ export function getExportSizeEstimate(
 }
 
 export function exportWorkspaceUrl(workspaceId: string, slim: boolean): string {
-  const base = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
   const params = slim ? "?slim=true" : "";
-  return `${base}/api/workspaces/${workspaceId}/export${params}`;
+  return `${getApiUrl()}/api/workspaces/${workspaceId}/export${params}`;
 }
 
 export async function restoreWorkspace(file: File): Promise<Workspace> {
   const form = new FormData();
   form.append("bundle", file);
 
-  const headers: Record<string, string> = API_KEY ? { "X-API-Key": API_KEY } : {};
+  const apiKey = getApiKey();
+  const headers: Record<string, string> = apiKey ? { "X-API-Key": apiKey } : {};
 
-  const res = await fetch(`${BASE_URL}/api/workspaces/restore`, {
+  const res = await fetch(`${baseUrl()}/api/workspaces/restore`, {
     method: "POST",
     body: form,
     headers,
@@ -224,10 +224,11 @@ export async function uploadAttachment(
   const form = new FormData();
   form.append("file", file);
 
-  const headers: Record<string, string> = API_KEY ? { "X-API-Key": API_KEY } : {};
+  const apiKey = getApiKey();
+  const headers: Record<string, string> = apiKey ? { "X-API-Key": apiKey } : {};
 
   const res = await fetch(
-    `${BASE_URL}/api/collections/${collectionId}/pages/${pageId}/attachments`,
+    `${baseUrl()}/api/collections/${collectionId}/pages/${pageId}/attachments`,
     { method: "POST", body: form, headers, credentials: "include" }
   );
 
@@ -239,7 +240,7 @@ export async function uploadAttachment(
 }
 
 export function attachmentFileUrl(collectionId: string, pageId: string, attachmentId: string): string {
-  return `${BASE_URL}/api/collections/${collectionId}/pages/${pageId}/attachments/${attachmentId}/file`;
+  return `${baseUrl()}/api/collections/${collectionId}/pages/${pageId}/attachments/${attachmentId}/file`;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/lib/runtime-config.ts
+++ b/web/lib/runtime-config.ts
@@ -1,0 +1,49 @@
+// Runtime config — read on every request so self-hosters can change env vars
+// without rebuilding the web image.
+//
+// Server-side (SSR, server components, route handlers, middleware): values
+// are read from process.env at request time. Standalone Next.js does not
+// inline non-NEXT_PUBLIC_ env vars, so this works at runtime.
+//
+// Browser-side: values come from window.__MARROW_CONFIG__, which is populated
+// by /config.js — a small script generated at container startup by
+// docker-entrypoint.sh and loaded by app/layout.tsx before any client code.
+
+export interface RuntimeConfig {
+  apiUrl: string;
+  apiKey: string;
+  oidcEnabled: boolean;
+}
+
+declare global {
+  interface Window {
+    __MARROW_CONFIG__?: Partial<RuntimeConfig>;
+  }
+}
+
+const DEFAULT_API_URL = "http://localhost:8000";
+
+export function getApiUrl(): string {
+  if (typeof window === "undefined") {
+    return process.env.MARROW_API_URL || DEFAULT_API_URL;
+  }
+  return window.__MARROW_CONFIG__?.apiUrl || DEFAULT_API_URL;
+}
+
+export function getApiKey(): string {
+  if (typeof window === "undefined") {
+    return process.env.MARROW_API_KEY || "";
+  }
+  return window.__MARROW_CONFIG__?.apiKey || "";
+}
+
+export function getOidcEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return process.env.MARROW_OIDC_ENABLED === "true";
+  }
+  return window.__MARROW_CONFIG__?.oidcEnabled === true;
+}
+
+export function getInternalApiUrl(): string {
+  return process.env.INTERNAL_API_URL || getApiUrl();
+}

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -10,8 +10,9 @@ export function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // If OIDC is not enabled, skip auth checks
-  if (process.env.NEXT_PUBLIC_OIDC_ENABLED !== "true") {
+  // If OIDC is not enabled, skip auth checks. Read at runtime — middleware
+  // runs server-side, so non-NEXT_PUBLIC_ env vars are available.
+  if (process.env.MARROW_OIDC_ENABLED !== "true") {
     return NextResponse.next();
   }
 

--- a/web/public/config.js
+++ b/web/public/config.js
@@ -1,0 +1,5 @@
+// Placeholder for dev mode. The Docker container overwrites this file at
+// startup with values from MARROW_API_URL / MARROW_API_KEY / MARROW_OIDC_ENABLED.
+// In `npm run dev`, leave this empty — runtime-config.ts falls back to the
+// process.env path on the server and the localhost default in the browser.
+window.__MARROW_CONFIG__ = {};


### PR DESCRIPTION
## Summary
NEXT_PUBLIC_* are baked into the Next.js bundle at build time. The CI release build passed no build args, so `ghcr.io/spmcgraw/marrow-web:v0.1.0` shipped with empty values — only working for the laptop-localhost case. Self-hosters cannot override these at runtime without a rebuild.

This PR switches the web container to runtime config injection:

- `lib/runtime-config.ts` — single source of truth. Server-side reads `process.env` at request time. Browser-side reads `window.__MARROW_CONFIG__`.
- `docker-entrypoint.sh` — writes `/app/public/config.js` from container env at startup, then execs CMD.
- `app/layout.tsx` — loads `/config.js` with `strategy="beforeInteractive"` so values are ready before client code runs.
- `Dockerfile` — drops the NEXT_PUBLIC_* build args; chowns `/app/public` so the entrypoint can write as the `nextjs` user.
- `docker-compose.prod.yml` — drops `build:` from api and web (now pull-only); web uses `MARROW_API_URL` / `MARROW_API_KEY` / `MARROW_OIDC_ENABLED` runtime env.
- `.env.prod.example` / `.env.local.example` / docs / CLAUDE.md updated for the renamed vars.

Closes #119.

## Why MARROW_* and not keep NEXT_PUBLIC_*
The new vars are **runtime** config, not Next.js build-time vars. Keeping the `NEXT_PUBLIC_` prefix would falsely imply the old semantics. Renaming is safe — v0.1.0 has zero installs.

## Test plan
- [x] `npm run build` succeeds with no NEXT_PUBLIC_* in the produced bundle (verified — grepped chunks, no hits).
- [x] `npm run lint` clean.
- [x] `tsc --noEmit` clean.
- [x] Entrypoint script handles env vars with embedded quotes (smoke-tested locally).
- [ ] Docker build: tested in CI by the release workflow.
- [ ] Multi-arch publish: confirmed by GHCR manifest inspect after merge + tag.
- [ ] End-to-end on a fresh Oracle Ampere VM with `MARROW_API_URL` set to a non-localhost host — page loads, browser network tab shows requests to the configured URL.