### PR TITLE
feat(storage): R2StorageAdapter and STORAGE_BACKEND env var gate (#41)

### DIFF
--- a/api/marrow/storage.py
+++ b/api/marrow/storage.py
@@ -35,6 +35,52 @@ class LocalFilesystemAdapter(StorageAdapter):
         path.write_bytes(data)
 
 
+class R2StorageAdapter(StorageAdapter):
+    """Reads/writes attachments in a Cloudflare R2 bucket (S3-compatible API).
+
+    Set STORAGE_BACKEND=r2 plus R2_ENDPOINT_URL, R2_ACCESS_KEY_ID,
+    R2_SECRET_ACCESS_KEY, and R2_BUCKET to use this adapter.
+    """
+
+    def __init__(
+        self,
+        endpoint_url: str | None,
+        access_key_id: str,
+        secret_access_key: str,
+        bucket: str,
+    ) -> None:
+        import boto3
+
+        self._bucket = bucket
+        self._client = boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,  # None falls back to standard AWS S3 (useful in tests)
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            region_name="auto",  # R2 requires "auto"; harmless against real AWS
+        )
+
+    def _key(self, attachment_id: str, filename: str) -> str:
+        return f"{attachment_id}/{filename}"
+
+    def read(self, attachment_id: str, filename: str) -> bytes:
+        key = self._key(attachment_id, filename)
+        response = self._client.get_object(Bucket=self._bucket, Key=key)
+        return response["Body"].read()
+
+    def write(self, attachment_id: str, filename: str, data: bytes) -> None:
+        key = self._key(attachment_id, filename)
+        self._client.put_object(Bucket=self._bucket, Key=key, Body=data)
+
+
 def get_default_adapter() -> StorageAdapter:
+    backend = os.getenv("STORAGE_BACKEND", "local").lower()
+    if backend == "r2":
+        return R2StorageAdapter(
+            endpoint_url=os.environ["R2_ENDPOINT_URL"],
+            access_key_id=os.environ["R2_ACCESS_KEY_ID"],
+            secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
+            bucket=os.environ["R2_BUCKET"],
+        )
     storage_path = os.getenv("STORAGE_PATH", "/var/lib/marrow/attachments")
     return LocalFilesystemAdapter(storage_path)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "PyJWT>=2.8",
     "httpx>=0.28",
     "itsdangerous>=2.1",
+    "boto3>=1.34",
 ]
 
 [project.scripts]
@@ -26,6 +27,7 @@ dev = [
     "pytest-asyncio>=0.25",
     "httpx>=0.28",
     "ruff>=0.9",
+    "moto[s3]>=4.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/api/tests/test_storage.py
+++ b/api/tests/test_storage.py
@@ -1,0 +1,80 @@
+"""Tests for storage adapters (local filesystem and R2/S3-compatible)."""
+
+import boto3
+import pytest
+
+from marrow.storage import LocalFilesystemAdapter, R2StorageAdapter
+
+# moto v4+ uses mock_aws; fall back to mock_s3 for older installs
+try:
+    from moto import mock_aws as _mock
+except ImportError:
+    from moto import mock_s3 as _mock
+
+
+# ---------------------------------------------------------------------------
+# LocalFilesystemAdapter
+# ---------------------------------------------------------------------------
+
+
+def test_local_write_and_read(tmp_path):
+    adapter = LocalFilesystemAdapter(tmp_path)
+    adapter.write("attach-1", "file.txt", b"hello world")
+    assert adapter.read("attach-1", "file.txt") == b"hello world"
+
+
+def test_local_creates_subdirectory(tmp_path):
+    adapter = LocalFilesystemAdapter(tmp_path)
+    adapter.write("attach-nested", "deep/path.bin", b"data")
+    assert (tmp_path / "attach-nested" / "deep" / "path.bin").read_bytes() == b"data"
+
+
+def test_local_file_not_found(tmp_path):
+    adapter = LocalFilesystemAdapter(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        adapter.read("nonexistent", "file.txt")
+
+
+# ---------------------------------------------------------------------------
+# R2StorageAdapter (moto-mocked S3)
+# ---------------------------------------------------------------------------
+
+
+def _make_r2_adapter(bucket: str = "test-bucket") -> R2StorageAdapter:
+    """Return an R2StorageAdapter whose boto3 client uses standard AWS endpoints.
+
+    moto intercepts calls to the standard AWS S3 endpoint (s3.amazonaws.com).
+    Custom endpoint_url values (e.g. real R2 URLs) bypass moto and hit the
+    network, so tests must omit endpoint_url and let moto intercept.
+    The production adapter still accepts endpoint_url; this helper is test-only.
+    """
+    boto3.client(
+        "s3",
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    ).create_bucket(Bucket=bucket)
+
+    return R2StorageAdapter(
+        endpoint_url=None,  # let moto intercept via standard AWS endpoint
+        access_key_id="test",
+        secret_access_key="test",
+        bucket=bucket,
+    )
+
+
+@_mock
+def test_r2_write_and_read():
+    adapter = _make_r2_adapter()
+    adapter.write("attach-2", "photo.png", b"image bytes")
+    assert adapter.read("attach-2", "photo.png") == b"image bytes"
+
+
+@_mock
+def test_r2_multiple_attachments():
+    adapter = _make_r2_adapter()
+    adapter.write("attach-a", "doc.pdf", b"pdf bytes")
+    adapter.write("attach-b", "doc.pdf", b"other pdf bytes")
+
+    assert adapter.read("attach-a", "doc.pdf") == b"pdf bytes"
+    assert adapter.read("attach-b", "doc.pdf") == b"other pdf bytes"


### PR DESCRIPTION
## Summary

- Adds `R2StorageAdapter` to `api/marrow/storage.py` — a Cloudflare R2 (S3-compatible) attachment backend using `boto3`
- `get_default_adapter()` now checks `STORAGE_BACKEND` env var (`"r2"` or default `"local"`) to select the adapter at startup; R2 requires `R2_ENDPOINT_URL`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`
- Adds `boto3>=1.34` as a runtime dep and `moto[s3]>=4.0` as a dev dep in `pyproject.toml`
- New `api/tests/test_storage.py` with 5 passing tests covering both adapters (moto v5 `mock_aws` for R2 tests)

Closes #59.

## Test plan

- [x] `pytest api/tests/test_storage.py -v` — all 5 pass
- [x] `STORAGE_BACKEND=local` (default) — `LocalFilesystemAdapter` is returned, no boto3 imported
- [x] `STORAGE_BACKEND=r2` with valid R2 credentials — attachments round-trip through R2 bucket