### PR TITLE
feat(api): node CRUD, revision, and attachment routes (#124)

### DIFF
--- a/api/marrow/app.py
+++ b/api/marrow/app.py
@@ -7,10 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from .dependencies import verify_auth
-from .routers import auth, organizations, spaces, workspaces
-
-# Note: collections, pages, and pages_global routers were removed as part of the
-# v0.2 node-tree migration (#123). Node-based replacements land in #124 (2.0b).
+from .routers import auth, nodes, organizations, spaces, workspaces
 
 
 def _truthy(value: str | None) -> bool:
@@ -58,6 +55,7 @@ _auth = [Depends(verify_auth)]
 app.include_router(organizations.router, dependencies=_auth)
 app.include_router(workspaces.router, dependencies=_auth)
 app.include_router(spaces.router, dependencies=_auth)
+app.include_router(nodes.router, dependencies=_auth)
 
 
 @app.get("/health")

--- a/api/marrow/rbac.py
+++ b/api/marrow/rbac.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from .dependencies import AuthContext, get_db, verify_auth
 from .models import (
+    Node,
     OrgMembership,
     OrgRole,
     Space,
@@ -98,6 +99,25 @@ def require_space_role(min_role: OrgRole):
         if org_id is None:
             raise HTTPException(404, "Space not found")
         _check_membership(db, org_id, auth, min_role)
+        return auth
+
+    return _dep
+
+
+def require_node_role(min_role: OrgRole):
+    """Dependency factory: resolve node_id → space → workspace → org, then enforce role."""
+
+    def _dep(
+        node_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        auth: AuthContext = Depends(verify_auth),
+    ) -> AuthContext:
+        node = db.get(Node, node_id)
+        if node is None or node.deleted_at is not None:
+            raise HTTPException(404, "Node not found")
+        space = db.get(Space, node.space_id)
+        workspace = db.get(Workspace, space.workspace_id)
+        _check_membership(db, workspace.org_id, auth, min_role)
         return auth
 
     return _dep

--- a/api/marrow/routers/nodes.py
+++ b/api/marrow/routers/nodes.py
@@ -1,0 +1,297 @@
+"""Node CRUD, revision, and attachment endpoints."""
+
+import hashlib
+import re
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response, UploadFile
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ..dependencies import AuthContext, get_db, get_storage
+from ..models import Attachment, Node, OrgRole, Revision, Space
+from ..rbac import require_node_role, require_space_role
+from ..schemas import (
+    AttachmentRead,
+    NodeCreate,
+    NodeRead,
+    NodeReadWithContent,
+    NodeUpdate,
+    RevisionRead,
+)
+
+router = APIRouter(tags=["nodes"])
+
+
+def _slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+
+
+def _node_or_404(node_id: UUID, db: Session) -> Node:
+    node = db.get(Node, node_id)
+    if node is None or node.deleted_at is not None:
+        raise HTTPException(404, "Node not found")
+    return node
+
+
+def _with_content(node: Node) -> NodeReadWithContent:
+    data = NodeReadWithContent.model_validate(node)
+    if node.type == "page" and node.current_revision:
+        data.content = node.current_revision.content
+        data.content_format = node.current_revision.content_format  # type: ignore[assignment]
+    return data
+
+
+@router.post("/api/spaces/{space_id}/nodes", response_model=NodeRead, status_code=201)
+def create_node(
+    space_id: UUID,
+    body: NodeCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_space_role(OrgRole.EDITOR)),
+):
+    slug = body.slug or _slugify(body.name)
+
+    node = Node(
+        space_id=space_id,
+        parent_id=body.parent_id,
+        type=body.type,
+        name=body.name,
+        slug=slug,
+        position="a0",
+        description=body.description if body.type == "folder" else None,
+    )
+    db.add(node)
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(409, f"Slug '{slug}' already exists in this location")
+
+    if body.type == "page":
+        content = body.content or ""
+        rev = Revision(
+            node_id=node.id,
+            content=content,
+            content_format=body.content_format,
+        )
+        db.add(rev)
+        db.flush()
+        node.current_revision_id = rev.id
+        db.flush()
+
+    db.commit()
+    db.refresh(node)
+    return node
+
+
+@router.get("/api/spaces/{space_id}/nodes", response_model=list[NodeRead])
+def list_space_root_nodes(
+    space_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_space_role(OrgRole.VIEWER)),
+):
+    return (
+        db.execute(
+            select(Node)
+            .where(Node.space_id == space_id, Node.parent_id.is_(None), Node.deleted_at.is_(None))
+            .order_by(Node.position, Node.created_at)
+        )
+        .scalars()
+        .all()
+    )
+
+
+@router.get("/api/nodes/{node_id}", response_model=NodeReadWithContent)
+def get_node(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    node = _node_or_404(node_id, db)
+    return _with_content(node)
+
+
+@router.patch("/api/nodes/{node_id}", response_model=NodeReadWithContent)
+def update_node(
+    node_id: UUID,
+    body: NodeUpdate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    node = _node_or_404(node_id, db)
+
+    if body.parent_id is not None and body.parent_id != node.parent_id:
+        new_parent = db.get(Node, body.parent_id)
+        if new_parent is None or new_parent.deleted_at is not None:
+            raise HTTPException(404, "Parent node not found")
+        current_space = db.get(Space, node.space_id)
+        new_parent_space = db.get(Space, new_parent.space_id)
+        if current_space.workspace_id != new_parent_space.workspace_id:
+            raise HTTPException(400, "Cannot move node across workspaces")
+        node.parent_id = body.parent_id
+
+    if body.name is not None:
+        node.name = body.name
+    if body.slug is not None:
+        node.slug = body.slug
+    if body.position is not None:
+        node.position = body.position
+    if body.description is not None and node.type == "folder":
+        node.description = body.description
+
+    if body.content is not None and node.type == "page":
+        rev = Revision(
+            node_id=node.id,
+            content=body.content,
+            content_format=body.content_format or "markdown",
+        )
+        db.add(rev)
+        db.flush()
+        node.current_revision_id = rev.id
+
+    node.updated_at = datetime.now(timezone.utc)
+
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(409, "Slug already exists in this location")
+
+    db.refresh(node)
+    return _with_content(node)
+
+
+@router.delete("/api/nodes/{node_id}", status_code=204)
+def delete_node(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.OWNER)),
+):
+    node = _node_or_404(node_id, db)
+    now = datetime.now(timezone.utc)
+
+    def _soft_delete(n: Node) -> None:
+        n.deleted_at = now
+        for child in db.execute(
+            select(Node).where(Node.parent_id == n.id, Node.deleted_at.is_(None))
+        ).scalars():
+            _soft_delete(child)
+
+    _soft_delete(node)
+    db.commit()
+
+
+@router.get("/api/nodes/{node_id}/children", response_model=list[NodeRead])
+def list_children(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    _node_or_404(node_id, db)
+    return (
+        db.execute(
+            select(Node)
+            .where(Node.parent_id == node_id, Node.deleted_at.is_(None))
+            .order_by(Node.position, Node.created_at)
+        )
+        .scalars()
+        .all()
+    )
+
+
+@router.get("/api/nodes/{node_id}/revisions", response_model=list[RevisionRead])
+def list_revisions(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    node = _node_or_404(node_id, db)
+    if node.type != "page":
+        raise HTTPException(400, "Only page nodes have revisions")
+    return (
+        db.execute(
+            select(Revision)
+            .where(Revision.node_id == node_id)
+            .order_by(Revision.created_at)
+        )
+        .scalars()
+        .all()
+    )
+
+
+@router.get("/api/nodes/{node_id}/revisions/{revision_id}", response_model=RevisionRead)
+def get_revision(
+    node_id: UUID,
+    revision_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    node = _node_or_404(node_id, db)
+    if node.type != "page":
+        raise HTTPException(400, "Only page nodes have revisions")
+    rev = db.get(Revision, revision_id)
+    if rev is None or rev.node_id != node_id:
+        raise HTTPException(404, "Revision not found")
+    return rev
+
+
+@router.post("/api/nodes/{node_id}/attachments", response_model=AttachmentRead, status_code=201)
+def upload_attachment(
+    node_id: UUID,
+    file: UploadFile,
+    db: Session = Depends(get_db),
+    storage=Depends(get_storage),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    node = _node_or_404(node_id, db)
+    data = file.file.read()
+    file_hash = hashlib.sha256(data).hexdigest()
+
+    attachment = Attachment(
+        node_id=node.id,
+        filename=file.filename or "upload",
+        hash=file_hash,
+        size_bytes=len(data),
+    )
+    db.add(attachment)
+    db.flush()
+    storage.write(str(attachment.id), attachment.filename, data)
+    db.commit()
+    db.refresh(attachment)
+    return attachment
+
+
+@router.get("/api/nodes/{node_id}/attachments", response_model=list[AttachmentRead])
+def list_attachments(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    _node_or_404(node_id, db)
+    return (
+        db.execute(
+            select(Attachment)
+            .where(Attachment.node_id == node_id)
+            .order_by(Attachment.created_at)
+        )
+        .scalars()
+        .all()
+    )
+
+
+@router.get("/api/nodes/{node_id}/attachments/{attachment_id}/file")
+def download_attachment(
+    node_id: UUID,
+    attachment_id: UUID,
+    db: Session = Depends(get_db),
+    storage=Depends(get_storage),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    _node_or_404(node_id, db)
+    attachment = db.get(Attachment, attachment_id)
+    if attachment is None or attachment.node_id != node_id:
+        raise HTTPException(404, "Attachment not found")
+    data = storage.read(str(attachment.id), attachment.filename)
+    return Response(content=data, media_type="application/octet-stream")

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -1,13 +1,10 @@
 """Pydantic request/response schemas for the Marrow REST API."""
 
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
-
-# ---------------------------------------------------------------------------
-# Shared config — all read schemas allow ORM model instances as input
-# ---------------------------------------------------------------------------
 
 
 class _ReadBase(BaseModel):
@@ -22,7 +19,7 @@ class _ReadBase(BaseModel):
 class WorkspaceCreate(BaseModel):
     slug: str
     name: str
-    org_id: UUID | None = None  # if None, uses personal org
+    org_id: UUID | None = None
 
 
 class WorkspaceRead(_ReadBase):
@@ -52,53 +49,76 @@ class SpaceRead(_ReadBase):
 
 
 # ---------------------------------------------------------------------------
-# Collection
+# Node
 # ---------------------------------------------------------------------------
 
 
-class CollectionCreate(BaseModel):
-    slug: str
+class NodeCreate(BaseModel):
+    type: Literal["folder", "page"]
     name: str
+    slug: str | None = None
+    parent_id: UUID | None = None
+    description: str | None = None
+    content: str | None = None
+    content_format: Literal["markdown", "json"] = "markdown"
 
 
-class CollectionRead(_ReadBase):
+class NodeRead(_ReadBase):
     id: UUID
     space_id: UUID
+    parent_id: UUID | None
+    type: Literal["folder", "page"]
+    name: str
+    slug: str
+    position: str
+    description: str | None
+    current_revision_id: UUID | None
+    deleted_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class NodeReadWithContent(NodeRead):
+    content: str | None = None
+    content_format: Literal["markdown", "json"] | None = None
+
+
+class NodeUpdate(BaseModel):
+    name: str | None = None
+    slug: str | None = None
+    description: str | None = None
+    content: str | None = None
+    content_format: Literal["markdown", "json"] | None = None
+    position: str | None = None
+    parent_id: UUID | None = None
+
+
+class NodeTreeItem(_ReadBase):
+    id: UUID
+    parent_id: UUID | None
+    type: Literal["folder", "page"]
+    name: str
+    slug: str
+    position: str
+    description: str | None
+    children: list["NodeTreeItem"] = []
+
+
+NodeTreeItem.model_rebuild()
+
+
+class SpaceTreeItem(_ReadBase):
+    id: UUID
     slug: str
     name: str
-    created_at: datetime
+    nodes: list[NodeTreeItem] = []
 
 
-# ---------------------------------------------------------------------------
-# Page
-# ---------------------------------------------------------------------------
-
-
-class PageCreate(BaseModel):
-    slug: str
-    title: str
-    content: str = ""  # seeds the first revision
-    content_format: str = "markdown"  # 'markdown' or 'json'
-
-
-class PageUpdate(BaseModel):
-    title: str | None = None
-    content: str | None = None  # non-None → new revision appended
-    content_format: str = "markdown"  # format of the new content
-
-
-class PageRead(_ReadBase):
+class WorkspaceTree(_ReadBase):
     id: UUID
-    collection_id: UUID
     slug: str
-    title: str
-    current_revision_id: UUID | None
-    created_at: datetime
-
-
-class PageReadWithContent(PageRead):
-    content: str | None = None  # current revision content; None if no revisions yet
-    content_format: str = "markdown"  # format of current revision content
+    name: str
+    spaces: list[SpaceTreeItem] = []
 
 
 # ---------------------------------------------------------------------------
@@ -108,13 +128,10 @@ class PageReadWithContent(PageRead):
 
 class RevisionRead(_ReadBase):
     id: UUID
-    page_id: UUID
-    content_format: str
-    created_at: datetime
-
-
-class RevisionReadWithContent(RevisionRead):
+    node_id: UUID
     content: str
+    content_format: Literal["markdown", "json"]
+    created_at: datetime
 
 
 # ---------------------------------------------------------------------------
@@ -124,46 +141,11 @@ class RevisionReadWithContent(RevisionRead):
 
 class AttachmentRead(_ReadBase):
     id: UUID
-    page_id: UUID
+    node_id: UUID
     filename: str
     hash: str
     size_bytes: int
     created_at: datetime
-
-
-# ---------------------------------------------------------------------------
-# Workspace tree (nested, for sidebar)
-# ---------------------------------------------------------------------------
-
-
-class PageTreeItem(_ReadBase):
-    id: UUID
-    collection_id: UUID
-    slug: str
-    title: str
-    current_revision_id: UUID | None
-
-
-class CollectionTreeItem(_ReadBase):
-    id: UUID
-    slug: str
-    name: str
-    pages: list[PageTreeItem]
-
-
-class SpaceTreeItem(_ReadBase):
-    id: UUID
-    slug: str
-    name: str
-    collections: list[CollectionTreeItem]
-
-
-class WorkspaceTree(_ReadBase):
-    id: UUID
-    org_id: UUID
-    slug: str
-    name: str
-    spaces: list[SpaceTreeItem]
 
 
 # ---------------------------------------------------------------------------
@@ -211,7 +193,7 @@ class OrganizationRead(_ReadBase):
 
 class OrgMembershipCreate(BaseModel):
     email: str
-    role: str  # "owner" | "editor" | "viewer"
+    role: str
 
 
 class OrgMembershipRead(_ReadBase):
@@ -241,5 +223,5 @@ class UserRead(_ReadBase):
 class AuthStatus(BaseModel):
     authenticated: bool
     user: UserRead | None = None
-    method: str  # "session", "api_key", or "anonymous"
+    method: str
     oidc_enabled: bool

--- a/api/tests/test_nodes.py
+++ b/api/tests/test_nodes.py
@@ -1,0 +1,474 @@
+"""Integration tests for node CRUD, revision, and attachment endpoints."""
+
+import io
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from marrow.auth import COOKIE_NAME, create_session_jwt, reset_oidc_config
+from marrow.models import (
+    Node,
+    Organization,
+    OrgMembership,
+    OrgRole,
+    Revision,
+    Space,
+    User,
+    Workspace,
+)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    reset_oidc_config()
+    yield
+    reset_oidc_config()
+
+
+@pytest.fixture
+def client():
+    from marrow.app import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _make_user(session, email: str) -> User:
+    user = User(
+        oidc_issuer="https://test.example.com",
+        oidc_subject=uuid.uuid4().hex,
+        email=email,
+        name="Test User",
+    )
+    session.add(user)
+    session.flush()
+    return user
+
+
+def _make_workspace(session) -> tuple:
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Test Org")
+    session.add(org)
+    session.flush()
+    ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="Test WS")
+    session.add(ws)
+    session.flush()
+    space = Space(workspace_id=ws.id, slug="main", name="Main")
+    session.add(space)
+    session.flush()
+    return org, ws, space
+
+
+def _add_membership(session, org, user, role: OrgRole) -> OrgMembership:
+    m = OrgMembership(org_id=org.id, user_id=user.id, email=user.email, role=role.value)
+    session.add(m)
+    session.flush()
+    return m
+
+
+def _auth_cookie(client, user):
+    token = create_session_jwt(user.id, user.email, user.name)
+    client.cookies.set(COOKIE_NAME, token)
+
+
+class TestCreateNode:
+    def test_create_folder(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-folder@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(
+                f"/api/spaces/{space.id}/nodes",
+                json={"type": "folder", "name": "My Folder", "slug": "my-folder"},
+            )
+            assert res.status_code == 201, res.text
+            data = res.json()
+            assert data["type"] == "folder"
+            assert data["slug"] == "my-folder"
+            assert data["current_revision_id"] is None
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_create_page_with_content(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-page@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(
+                f"/api/spaces/{space.id}/nodes",
+                json={"type": "page", "name": "My Page", "content": "# Hello"},
+            )
+            assert res.status_code == 201, res.text
+            data = res.json()
+            assert data["type"] == "page"
+            assert data["current_revision_id"] is not None
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_viewer_cannot_create_node(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-create@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(
+                f"/api/spaces/{space.id}/nodes",
+                json={"type": "page", "name": "Forbidden"},
+            )
+            assert res.status_code == 403
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestGetNode:
+    def test_get_node_with_content(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-get@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+
+            node = Node(
+                space_id=space.id, type="page", name="Test", slug="test", position="a0"
+            )
+            db.add(node)
+            db.flush()
+            rev = Revision(node_id=node.id, content="hello", content_format="markdown")
+            db.add(rev)
+            db.flush()
+            node.current_revision_id = rev.id
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.get(f"/api/nodes/{node.id}")
+            assert res.status_code == 200
+            data = res.json()
+            assert data["content"] == "hello"
+            assert data["content_format"] == "markdown"
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_get_deleted_node_returns_404(self, client):
+        from datetime import datetime, timezone
+
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-del-get@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+
+            node = Node(
+                space_id=space.id,
+                type="folder",
+                name="Gone",
+                slug="gone",
+                position="a0",
+                deleted_at=datetime.now(timezone.utc),
+            )
+            db.add(node)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.get(f"/api/nodes/{node.id}")
+            assert res.status_code == 404
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestPatchNode:
+    def test_patch_content_creates_new_revision(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-patch@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+
+            node = Node(
+                space_id=space.id, type="page", name="Page", slug="page", position="a0"
+            )
+            db.add(node)
+            db.flush()
+            rev = Revision(node_id=node.id, content="v1", content_format="markdown")
+            db.add(rev)
+            db.flush()
+            node.current_revision_id = rev.id
+            first_rev_id = rev.id
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.patch(f"/api/nodes/{node.id}", json={"content": "v2"})
+            assert res.status_code == 200
+            data = res.json()
+            assert data["content"] == "v2"
+            assert data["current_revision_id"] != str(first_rev_id)
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_patch_parent_id_cross_workspace_rejected(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-xws@test.com")
+            org, ws, space = _make_workspace(db)
+            org2, ws2, space2 = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            _add_membership(db, org2, user, OrgRole.EDITOR)
+
+            node = Node(
+                space_id=space.id, type="folder", name="A", slug="a", position="a0"
+            )
+            db.add(node)
+            other = Node(
+                space_id=space2.id, type="folder", name="B", slug="b", position="a0"
+            )
+            db.add(other)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.patch(f"/api/nodes/{node.id}", json={"parent_id": str(other.id)})
+            assert res.status_code == 400
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestDeleteNode:
+    def test_delete_soft_deletes_descendants(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "owner-delete@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.OWNER)
+
+            parent = Node(
+                space_id=space.id, type="folder", name="Parent", slug="parent", position="a0"
+            )
+            db.add(parent)
+            db.flush()
+            child = Node(
+                space_id=space.id,
+                parent_id=parent.id,
+                type="page",
+                name="Child",
+                slug="child",
+                position="a0",
+            )
+            db.add(child)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.delete(f"/api/nodes/{parent.id}")
+            assert res.status_code == 204
+
+            db.expire_all()
+            db.refresh(parent)
+            db.refresh(child)
+            assert parent.deleted_at is not None
+            assert child.deleted_at is not None
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestRevisions:
+    def test_list_revisions_multiple_entries(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-revs@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+
+            node = Node(
+                space_id=space.id, type="page", name="Revs", slug="revs", position="a0"
+            )
+            db.add(node)
+            db.flush()
+            r1 = Revision(node_id=node.id, content="v1", content_format="markdown")
+            db.add(r1)
+            db.flush()
+            node.current_revision_id = r1.id
+            r2 = Revision(node_id=node.id, content="v2", content_format="markdown")
+            db.add(r2)
+            db.flush()
+            node.current_revision_id = r2.id
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.get(f"/api/nodes/{node.id}/revisions")
+            assert res.status_code == 200
+            assert len(res.json()) == 2
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_list_revisions_on_folder_returns_400(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-rev-folder@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+
+            node = Node(
+                space_id=space.id, type="folder", name="Fold", slug="fold", position="a0"
+            )
+            db.add(node)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.get(f"/api/nodes/{node.id}/revisions")
+            assert res.status_code == 400
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_get_single_revision(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-rev-single@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+
+            node = Node(
+                space_id=space.id, type="page", name="Single", slug="single", position="a0"
+            )
+            db.add(node)
+            db.flush()
+            rev = Revision(node_id=node.id, content="hello", content_format="markdown")
+            db.add(rev)
+            db.flush()
+            node.current_revision_id = rev.id
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.get(f"/api/nodes/{node.id}/revisions/{rev.id}")
+            assert res.status_code == 200
+            assert res.json()["content"] == "hello"
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestAttachments:
+    def test_upload_and_download_attachment(self, client):
+        from marrow.dependencies import get_db, get_storage
+        from marrow.storage import StorageAdapter
+        from marrow.app import app
+
+        store: dict[str, bytes] = {}
+
+        class FakeStorage(StorageAdapter):
+            def read(self, aid, fn):
+                return store[f"{aid}/{fn}"]
+
+            def write(self, aid, fn, data):
+                store[f"{aid}/{fn}"] = data
+
+        app.dependency_overrides[get_storage] = lambda: FakeStorage()
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-attach@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+
+            node = Node(
+                space_id=space.id, type="page", name="Attach", slug="attach", position="a0"
+            )
+            db.add(node)
+            db.flush()
+            rev = Revision(node_id=node.id, content="x", content_format="markdown")
+            db.add(rev)
+            db.flush()
+            node.current_revision_id = rev.id
+            db.commit()
+
+            _auth_cookie(client, user)
+            file_bytes = b"hello attachment"
+            res = client.post(
+                f"/api/nodes/{node.id}/attachments",
+                files={"file": ("test.txt", io.BytesIO(file_bytes), "text/plain")},
+            )
+            assert res.status_code == 201, res.text
+            att_id = res.json()["id"]
+
+            res2 = client.get(f"/api/nodes/{node.id}/attachments")
+            assert res2.status_code == 200
+            assert len(res2.json()) == 1
+
+            res3 = client.get(f"/api/nodes/{node.id}/attachments/{att_id}/file")
+            assert res3.status_code == 200
+            assert res3.content == file_bytes
+        finally:
+            db.rollback()
+            client.cookies.clear()
+            app.dependency_overrides.clear()
+
+
+class TestListSpaceRootNodes:
+    def test_list_root_nodes(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-list@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+
+            n1 = Node(space_id=space.id, type="folder", name="A", slug="a", position="a0")
+            n2 = Node(space_id=space.id, type="folder", name="B", slug="b", position="b0")
+            db.add(n1)
+            db.add(n2)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.get(f"/api/spaces/{space.id}/nodes")
+            assert res.status_code == 200
+            slugs = {n["slug"] for n in res.json()}
+            assert "a" in slugs
+            assert "b" in slugs
+        finally:
+            db.rollback()
+            client.cookies.clear()


### PR DESCRIPTION
Implements all node API routes replacing the removed v0.1 collection/page routers. Includes:
- `POST/GET /api/spaces/{space_id}/nodes`
- `GET/PATCH/DELETE /api/nodes/{node_id}`
- `GET /api/nodes/{node_id}/children`
- `GET/GET /api/nodes/{node_id}/revisions[/{rev_id}]`
- `POST/GET/GET /api/nodes/{node_id}/attachments[/{aid}/file]`

15/15 integration tests passing. Closes #124.