### PR TITLE
feat(db): PostgreSQL RLS tenant isolation and org-aware db dependency (#41)

### DIFF
--- a/api/alembic/versions/2b5326d2d299_add_rls_tenant_isolation.py
+++ b/api/alembic/versions/2b5326d2d299_add_rls_tenant_isolation.py
@@ -1,0 +1,77 @@
+"""add_rls_tenant_isolation
+
+Revision ID: 2b5326d2d299
+Revises: bd52bac0673f
+Create Date: 2026-05-02 13:42:46.092348
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "2b5326d2d299"
+down_revision: str | None = "bd52bac0673f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_UNSET = (
+    "current_setting('app.current_org', true) IS NULL"
+    " OR current_setting('app.current_org', true) = ''"
+)
+_VIA_ORG = "id = current_setting('app.current_org', true)::uuid"
+_VIA_WORKSPACE = "org_id = current_setting('app.current_org', true)::uuid"
+_VIA_SPACE = (
+    "workspace_id IN ("
+    "SELECT id FROM workspaces"
+    f" WHERE {_VIA_WORKSPACE})"
+)
+_VIA_NODE = (
+    "space_id IN ("
+    "SELECT s.id FROM spaces s"
+    " JOIN workspaces w ON w.id = s.workspace_id"
+    f" WHERE {_VIA_WORKSPACE})"
+)
+_VIA_NODE_INDIRECT = (
+    "node_id IN ("
+    "SELECT n.id FROM nodes n"
+    " JOIN spaces s ON s.id = n.space_id"
+    " JOIN workspaces w ON w.id = s.workspace_id"
+    f" WHERE {_VIA_WORKSPACE})"
+)
+
+
+def _enable_rls(table: str, tenant_expr: str) -> None:
+    op.execute(text(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY"))
+    op.execute(text(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY"))
+    op.execute(
+        text(
+            f"CREATE POLICY tenant_isolation ON {table}"
+            f" USING ({_UNSET} OR {tenant_expr})"
+        )
+    )
+
+
+def upgrade() -> None:
+    _enable_rls("organizations", _VIA_ORG)
+    _enable_rls("org_memberships", _VIA_WORKSPACE)
+    _enable_rls("workspaces", _VIA_WORKSPACE)
+    _enable_rls("spaces", _VIA_SPACE)
+    _enable_rls("nodes", _VIA_NODE)
+    _enable_rls("revisions", _VIA_NODE_INDIRECT)
+    _enable_rls("attachments", _VIA_NODE_INDIRECT)
+
+
+def downgrade() -> None:
+    for table in [
+        "attachments",
+        "revisions",
+        "nodes",
+        "spaces",
+        "workspaces",
+        "org_memberships",
+        "organizations",
+    ]:
+        op.execute(text(f"DROP POLICY IF EXISTS tenant_isolation ON {table}"))
+        op.execute(text(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY"))

--- a/api/marrow/dependencies.py
+++ b/api/marrow/dependencies.py
@@ -11,8 +11,8 @@ from dataclasses import dataclass
 from typing import Generator
 
 from dotenv import load_dotenv
-from fastapi import Header, HTTPException, Request
-from sqlalchemy import create_engine
+from fastapi import Depends, Header, HTTPException, Request
+from sqlalchemy import create_engine, select, text as sa_text
 from sqlalchemy.orm import Session
 
 from .db import _database_url
@@ -117,3 +117,30 @@ def verify_auth(
         return AuthContext(user_id=None, email=None, method="anonymous")
 
     raise HTTPException(status_code=401, detail="Authentication required")
+
+
+def get_db_with_org(
+    auth: AuthContext = Depends(verify_auth),
+    db: Session = Depends(get_db),
+) -> Generator[Session, None, None]:
+    """Yield a session with ``app.current_org`` set for session-authenticated users.
+
+    When the requesting user authenticated via OIDC session, this dependency
+    looks up their first org membership and sets the ``app.current_org``
+    PostgreSQL session variable so RLS policies restrict rows to that org.
+
+    API key and anonymous auth leave ``app.current_org`` unset, which the RLS
+    policies treat as unrestricted access (superuser / dev mode).
+    """
+    if auth.method == "session" and auth.user_id is not None:
+        from .models import OrgMembership
+
+        membership = db.execute(
+            select(OrgMembership).where(OrgMembership.user_id == auth.user_id).limit(1)
+        ).scalar_one_or_none()
+        if membership is not None:
+            db.execute(
+                sa_text("SELECT set_config('app.current_org', :org_id, false)"),
+                {"org_id": str(membership.org_id)},
+            )
+    yield db


### PR DESCRIPTION
Adds database-level multi-tenant isolation:

- New alembic migration enabling RLS on all tenant-scoped tables (organizations, org_memberships, workspaces, spaces, nodes, revisions, attachments) with a bypass clause when `app.current_org` is unset (migrations, CLI, API key auth)
- `get_db_with_org` dependency in `dependencies.py` — sets `app.current_org` per session-authenticated request by looking up the user's first org membership

Upgrade/downgrade cycle verified clean. Part of #41.