### PR TITLE
feat(search): migrate FTS from pages to nodes (#125)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,10 @@ marrow/
 │   │       ├── d3981f696939_add_full_text_search.py
 │   │       ├── 35eb203afc65_add_users_table.py
 │   │       ├── 0999ffe7b838_add_organizations_and_rbac.py
-│   │       └── c333d20a46d9_add_content_format_to_revisions.py
+│   │       ├── c333d20a46d9_add_content_format_to_revisions.py
+│   │       ├── bd52bac0673f_node_tree_schema_collapse_collections_.py
+│   │       ├── 2b5326d2d299_add_rls_tenant_isolation.py
+│   │       └── fdf65c08ffa8_add_node_fts_triggers_and_gin_index.py
 │   ├── marrow/                       # Main package
 │   │   ├── app.py                    # FastAPI app factory, CORS + session middleware
 │   │   ├── auth.py                   # OIDC config, session JWT helpers, cookie params
@@ -272,7 +275,9 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | GET/POST | /api/workspaces/{id}/spaces/ | List / create spaces | viewer/editor |
 | GET/DELETE | /api/workspaces/{id}/spaces/{sid} | Get / delete space | viewer/owner |
 
-> **Note (#123 → #124):** v0.1's collection-scoped and global page routes were removed by the schema migration. Node CRUD/tree/attachment/revision routes land in #124 (2.0b) under `/api/nodes/...` and `/api/spaces/{sid}/nodes`. The workspace `/tree`, `/search`, `/export`, and `/restore` endpoints are still wired but their handlers will NameError at runtime until the node-aware rewrites land in #124, #125, #132, and #133.
+> **Note (#123 → #125):** v0.1's collection-scoped and global page routes were removed by the schema migration. Node CRUD/tree/attachment/revision routes land in #124 (2.0b) under `/api/nodes/...` and `/api/spaces/{sid}/nodes`. The workspace `/search` endpoint is node-aware as of #125 (2.0c). The `/tree`, `/export`, and `/restore` endpoints are still wired but their handlers will NameError at runtime until the node-aware rewrites land in #124, #132, and #133.
+>
+> **Search response shape (v0.2):** `SearchResultItem` fields are `node_id`, `name`, `snippet`, `space_id`, `space_name`, `node_path` (list of ancestor folder names, root→leaf), `rank`. The old `page_id`, `title`, `collection_id`, `collection_name` fields are gone.
 
 ### Storage Adapter Interface
 
@@ -286,7 +291,7 @@ class StorageAdapter(ABC):
 
 ### Export Bundle Format
 
-```
+```text
 marrow-export-{workspace-slug}-{timestamp}.zip          # full
 marrow-export-{workspace-slug}-slim-{timestamp}.zip     # slim
 ├── manifest.json        # workspace + org metadata, all entity IDs, schema version (v3)

--- a/api/alembic/versions/fdf65c08ffa8_add_node_fts_triggers_and_gin_index.py
+++ b/api/alembic/versions/fdf65c08ffa8_add_node_fts_triggers_and_gin_index.py
@@ -1,0 +1,78 @@
+"""add node FTS triggers and GIN index
+
+Revision ID: fdf65c08ffa8
+Revises: bd52bac0673f
+Create Date: 2026-05-02 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "fdf65c08ffa8"
+down_revision: Union[str, Sequence[str], None] = "2b5326d2d299"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # GIN index on search_vector, limited to live page nodes.
+    op.execute(
+        "CREATE INDEX idx_nodes_search ON nodes USING gin(search_vector)"
+        " WHERE type = 'page' AND deleted_at IS NULL"
+    )
+
+    # Fires AFTER INSERT on revisions — updates parent node's search_vector.
+    # Weighted: name → A (title-match ranks higher), content → B.
+    op.execute("""
+        CREATE OR REPLACE FUNCTION update_node_search_vector()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            UPDATE nodes
+            SET search_vector =
+                setweight(to_tsvector('english', COALESCE(nodes.name, '')), 'A') ||
+                setweight(to_tsvector('english', COALESCE(NEW.content, '')), 'B')
+            WHERE id = NEW.node_id
+              AND type = 'page';
+            RETURN NEW;
+        END;
+        $$;
+    """)
+    op.execute("""
+        CREATE TRIGGER trg_revision_update_node_search_vector
+        AFTER INSERT ON revisions
+        FOR EACH ROW EXECUTE FUNCTION update_node_search_vector();
+    """)
+
+    # Fires BEFORE UPDATE OF name, slug on nodes — refreshes search_vector when
+    # a page's display name or slug changes without a new revision being inserted.
+    op.execute("""
+        CREATE OR REPLACE FUNCTION update_node_search_vector_on_name_change()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            IF NEW.type = 'page' THEN
+                NEW.search_vector :=
+                    setweight(to_tsvector('english', COALESCE(NEW.name, '')), 'A') ||
+                    setweight(to_tsvector('english', COALESCE(
+                        (SELECT content FROM revisions WHERE id = NEW.current_revision_id),
+                        ''
+                    )), 'B');
+            END IF;
+            RETURN NEW;
+        END;
+        $$;
+    """)
+    op.execute("""
+        CREATE TRIGGER trg_node_name_update_search_vector
+        BEFORE UPDATE OF name, slug ON nodes
+        FOR EACH ROW EXECUTE FUNCTION update_node_search_vector_on_name_change();
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS trg_node_name_update_search_vector ON nodes")
+    op.execute("DROP FUNCTION IF EXISTS update_node_search_vector_on_name_change()")
+    op.execute("DROP TRIGGER IF EXISTS trg_revision_update_node_search_vector ON revisions")
+    op.execute("DROP FUNCTION IF EXISTS update_node_search_vector()")
+    op.execute("DROP INDEX IF EXISTS idx_nodes_search")

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -154,13 +154,12 @@ class AttachmentRead(_ReadBase):
 
 
 class SearchResultItem(BaseModel):
-    page_id: UUID
-    title: str
+    node_id: UUID
+    name: str
     snippet: str
-    collection_id: UUID
     space_id: UUID
     space_name: str
-    collection_name: str
+    node_path: list[str]
     rank: float
 
 

--- a/api/marrow/search.py
+++ b/api/marrow/search.py
@@ -5,7 +5,7 @@ engine) without touching routers or frontend code.
 """
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from uuid import UUID
 
 from sqlalchemy import text
@@ -14,13 +14,12 @@ from sqlalchemy.orm import Session
 
 @dataclass
 class SearchResult:
-    page_id: UUID
-    title: str
+    node_id: UUID
+    name: str
     snippet: str
-    collection_id: UUID
     space_id: UUID
     space_name: str
-    collection_name: str
+    node_path: list[str]
     rank: float
 
 
@@ -36,6 +35,22 @@ class SearchBackend(ABC):
     ) -> list[SearchResult]:
         """Search pages within a workspace. Returns ranked results."""
         ...
+
+
+# Recursive CTE fragment that resolves the ordered ancestor folder names for a
+# given node. Yields one row with an `ancestors` text[] column (root → leaf).
+_ANCESTOR_PATH_CTE = """
+    WITH RECURSIVE anc(nm, parent_id, depth) AS (
+        SELECT p.name, p.parent_id, 1
+        FROM nodes p
+        WHERE p.id = n.parent_id
+        UNION ALL
+        SELECT p2.name, p2.parent_id, a.depth + 1
+        FROM nodes p2
+        JOIN anc a ON p2.id = a.parent_id
+    )
+    SELECT ARRAY(SELECT nm FROM anc ORDER BY depth DESC)
+"""
 
 
 class PostgresSearchBackend(SearchBackend):
@@ -61,21 +76,24 @@ class PostgresSearchBackend(SearchBackend):
         limit: int,
     ) -> list[SearchResult]:
         """Return all pages in the workspace ordered by most recently revised."""
-        sql = text("""
+        sql = text(f"""
             SELECT
-                p.id AS page_id,
-                p.title,
+                n.id AS node_id,
+                n.name,
                 '' AS snippet,
-                p.collection_id,
                 s.id AS space_id,
                 s.name AS space_name,
-                c.name AS collection_name,
+                COALESCE(
+                    ({_ANCESTOR_PATH_CTE}),
+                    ARRAY[]::text[]
+                ) AS node_path,
                 0.0 AS rank
-            FROM pages p
-            JOIN revisions r ON r.id = p.current_revision_id
-            JOIN collections c ON c.id = p.collection_id
-            JOIN spaces s ON s.id = c.space_id
+            FROM nodes n
+            JOIN revisions r ON r.id = n.current_revision_id
+            JOIN spaces s ON s.id = n.space_id
             WHERE s.workspace_id = :workspace_id
+              AND n.type = 'page'
+              AND n.deleted_at IS NULL
             ORDER BY r.created_at DESC
             LIMIT :limit
         """)
@@ -90,13 +108,13 @@ class PostgresSearchBackend(SearchBackend):
         *,
         limit: int,
     ) -> list[SearchResult]:
-        """Title ILIKE match ranked first, FTS body match as secondary signal."""
-        sql = text("""
+        """Name ILIKE match ranked first, FTS body match as secondary signal."""
+        sql = text(f"""
             SELECT
-                p.id AS page_id,
-                p.title,
+                n.id AS node_id,
+                n.name,
                 CASE
-                    WHEN p.search_vector @@ plainto_tsquery('english', :query)
+                    WHEN n.search_vector @@ plainto_tsquery('english', :query)
                     THEN ts_headline(
                         'english',
                         r.content,
@@ -105,21 +123,24 @@ class PostgresSearchBackend(SearchBackend):
                     )
                     ELSE ''
                 END AS snippet,
-                p.collection_id,
                 s.id AS space_id,
                 s.name AS space_name,
-                c.name AS collection_name,
-                CASE WHEN p.title ILIKE :title_pattern THEN 1 ELSE 0 END
-                    + ts_rank(p.search_vector, plainto_tsquery('english', :query))
+                COALESCE(
+                    ({_ANCESTOR_PATH_CTE}),
+                    ARRAY[]::text[]
+                ) AS node_path,
+                CASE WHEN n.name ILIKE :name_pattern THEN 1 ELSE 0 END
+                    + ts_rank(n.search_vector, plainto_tsquery('english', :query))
                     AS rank
-            FROM pages p
-            JOIN revisions r ON r.id = p.current_revision_id
-            JOIN collections c ON c.id = p.collection_id
-            JOIN spaces s ON s.id = c.space_id
+            FROM nodes n
+            JOIN revisions r ON r.id = n.current_revision_id
+            JOIN spaces s ON s.id = n.space_id
             WHERE s.workspace_id = :workspace_id
+              AND n.type = 'page'
+              AND n.deleted_at IS NULL
               AND (
-                  p.title ILIKE :title_pattern
-                  OR p.search_vector @@ plainto_tsquery('english', :query)
+                  n.name ILIKE :name_pattern
+                  OR n.search_vector @@ plainto_tsquery('english', :query)
               )
             ORDER BY rank DESC, r.created_at DESC
             LIMIT :limit
@@ -129,7 +150,7 @@ class PostgresSearchBackend(SearchBackend):
             {
                 "workspace_id": workspace_id,
                 "query": query,
-                "title_pattern": f"%{query}%",
+                "name_pattern": f"%{query}%",
                 "limit": limit,
             },
         ).fetchall()
@@ -138,12 +159,11 @@ class PostgresSearchBackend(SearchBackend):
     @staticmethod
     def _row_to_result(row) -> "SearchResult":
         return SearchResult(
-            page_id=row.page_id,
-            title=row.title,
+            node_id=row.node_id,
+            name=row.name,
             snippet=row.snippet,
-            collection_id=row.collection_id,
             space_id=row.space_id,
             space_name=row.space_name,
-            collection_name=row.collection_name,
+            node_path=list(row.node_path) if row.node_path else [],
             rank=row.rank,
         )

--- a/api/tests/test_search.py
+++ b/api/tests/test_search.py
@@ -11,7 +11,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
 from alembic import command
-from marrow.models import Collection, Organization, Page, Revision, Space, Workspace
+from marrow.models import Node, Organization, Revision, Space, Workspace
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
 
@@ -74,7 +74,7 @@ def db(engine):
     conn.close()
 
 
-def _seed_workspace(db: Session) -> tuple[Workspace, Space, Collection]:
+def _seed_workspace(db: Session) -> tuple[Workspace, Space]:
     org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Test Org")
     db.add(org)
     db.flush()
@@ -84,22 +84,54 @@ def _seed_workspace(db: Session) -> tuple[Workspace, Space, Collection]:
     space = Space(workspace_id=ws.id, slug="main", name="Main")
     db.add(space)
     db.flush()
-    col = Collection(space_id=space.id, slug="docs", name="Docs")
-    db.add(col)
-    db.flush()
-    return ws, space, col
+    return ws, space
 
 
-def _create_page(db: Session, col: Collection, slug: str, title: str, content: str) -> Page:
-    page = Page(collection_id=col.id, slug=slug, title=title)
-    db.add(page)
+def _create_page(
+    db: Session,
+    space: Space,
+    slug: str,
+    name: str,
+    content: str,
+    parent: Node | None = None,
+) -> Node:
+    """Create a page node with one revision. Uses deferred FK for current_revision_id."""
+    node = Node(
+        space_id=space.id,
+        parent_id=parent.id if parent else None,
+        type="page",
+        name=name,
+        slug=slug,
+        position="a0",
+    )
+    db.add(node)
     db.flush()
-    rev = Revision(page_id=page.id, content=content)
+    rev = Revision(node_id=node.id, content=content)
     db.add(rev)
     db.flush()
-    page.current_revision_id = rev.id
+    node.current_revision_id = rev.id
     db.flush()
-    return page
+    return node
+
+
+def _create_folder(
+    db: Session,
+    space: Space,
+    slug: str,
+    name: str,
+    parent: Node | None = None,
+) -> Node:
+    node = Node(
+        space_id=space.id,
+        parent_id=parent.id if parent else None,
+        type="folder",
+        name=name,
+        slug=slug,
+        position="a0",
+    )
+    db.add(node)
+    db.flush()
+    return node
 
 
 # ---------------------------------------------------------------------------
@@ -108,13 +140,10 @@ def _create_page(db: Session, col: Collection, slug: str, title: str, content: s
 
 
 def test_search_vector_populated_on_revision_insert(db):
-    """Inserting a revision should populate the page's search_vector."""
-    ws, _, col = _seed_workspace(db)
+    """Inserting a revision should populate the node's search_vector."""
+    ws, space = _seed_workspace(db)
     page = _create_page(
-        db,
-        col,
-        "test-page",
-        "Quantum Computing",
+        db, space, "test-page", "Quantum Computing",
         "An introduction to qubits and superposition",
     )
 
@@ -126,10 +155,10 @@ def test_search_vector_populated_on_revision_insert(db):
 
 def test_search_vector_updates_on_new_revision(db):
     """Adding a new revision should update the search_vector with new content."""
-    ws, _, col = _seed_workspace(db)
-    page = _create_page(db, col, "evolving", "Original Title", "First draft about elephants")
+    ws, space = _seed_workspace(db)
+    page = _create_page(db, space, "evolving", "Original Name", "First draft about elephants")
 
-    new_rev = Revision(page_id=page.id, content="Revised content about dinosaurs")
+    new_rev = Revision(node_id=page.id, content="Revised content about dinosaurs")
     db.add(new_rev)
     db.flush()
     page.current_revision_id = new_rev.id
@@ -140,12 +169,12 @@ def test_search_vector_updates_on_new_revision(db):
     assert "dinosaur" in sv
 
 
-def test_search_vector_updates_on_title_change(db):
-    """Changing only the page title should refresh the search_vector."""
-    ws, _, col = _seed_workspace(db)
-    page = _create_page(db, col, "title-change", "Old Title", "Some body content")
+def test_search_vector_updates_on_name_change(db):
+    """Changing only the node name should refresh the search_vector."""
+    ws, space = _seed_workspace(db)
+    page = _create_page(db, space, "name-change", "Old Name", "Some body content")
 
-    page.title = "Brand New Title"
+    page.name = "Brand New Name"
     db.flush()
     db.refresh(page)
 
@@ -153,47 +182,71 @@ def test_search_vector_updates_on_title_change(db):
     assert "brand" in sv
 
 
+def test_search_vector_not_set_on_folder(db):
+    """Folder nodes must never have a search_vector (enforced by shape constraint)."""
+    ws, space = _seed_workspace(db)
+    folder = _create_folder(db, space, "a-folder", "My Folder")
+
+    db.refresh(folder)
+    assert folder.search_vector is None
+
+
+def test_search_vector_updates_on_slug_change(db):
+    """Changing node slug should also trigger a search_vector refresh."""
+    ws, space = _seed_workspace(db)
+    page = _create_page(db, space, "original-slug", "Slug Test", "Some body content")
+
+    page.slug = "new-slug"
+    db.flush()
+    db.refresh(page)
+
+    # search_vector should still be populated (trigger must not have blanked it)
+    assert page.search_vector is not None
+
+
 # ---------------------------------------------------------------------------
-# Search query tests (using raw SQL to test the PostgresSearchBackend logic)
+# Search query tests (raw SQL mirroring PostgresSearchBackend logic)
 # ---------------------------------------------------------------------------
 
 
-def test_search_returns_matching_pages(db):
-    """Search should find pages matching the query."""
-    ws, _, col = _seed_workspace(db)
-    _create_page(db, col, "p1", "Rust Programming", "Rust is a systems programming language")
-    _create_page(db, col, "p2", "Python Guide", "Python is great for scripting")
+def test_search_returns_matching_nodes(db):
+    """Search should find page nodes matching the query."""
+    ws, space = _seed_workspace(db)
+    _create_page(db, space, "p1", "Rust Programming", "Rust is a systems programming language")
+    _create_page(db, space, "p2", "Python Guide", "Python is great for scripting")
 
     rows = db.execute(
         text("""
-            SELECT p.id, p.title,
-                   ts_rank(p.search_vector, plainto_tsquery('english', :q)) AS rank
-            FROM pages p
-            JOIN collections c ON c.id = p.collection_id
-            JOIN spaces s ON s.id = c.space_id
+            SELECT n.id, n.name,
+                   ts_rank(n.search_vector, plainto_tsquery('english', :q)) AS rank
+            FROM nodes n
+            JOIN spaces s ON s.id = n.space_id
             WHERE s.workspace_id = :ws_id
-              AND p.search_vector @@ plainto_tsquery('english', :q)
+              AND n.type = 'page'
+              AND n.deleted_at IS NULL
+              AND n.search_vector @@ plainto_tsquery('english', :q)
             ORDER BY rank DESC
         """),
         {"ws_id": ws.id, "q": "rust programming"},
     ).fetchall()
 
     assert len(rows) >= 1
-    assert rows[0].title == "Rust Programming"
+    assert rows[0].name == "Rust Programming"
 
 
 def test_search_empty_query_returns_nothing(db):
-    """An empty query should not match any pages."""
-    ws, _, col = _seed_workspace(db)
-    _create_page(db, col, "p1", "Some Page", "Some content")
+    """An empty FTS query should not match any nodes."""
+    ws, space = _seed_workspace(db)
+    _create_page(db, space, "p1", "Some Page", "Some content")
 
     rows = db.execute(
         text("""
-            SELECT p.id FROM pages p
-            JOIN collections c ON c.id = p.collection_id
-            JOIN spaces s ON s.id = c.space_id
+            SELECT n.id FROM nodes n
+            JOIN spaces s ON s.id = n.space_id
             WHERE s.workspace_id = :ws_id
-              AND p.search_vector @@ plainto_tsquery('english', :q)
+              AND n.type = 'page'
+              AND n.deleted_at IS NULL
+              AND n.search_vector @@ plainto_tsquery('english', :q)
         """),
         {"ws_id": ws.id, "q": ""},
     ).fetchall()
@@ -202,36 +255,36 @@ def test_search_empty_query_returns_nothing(db):
 
 
 def test_search_respects_workspace_scoping(db):
-    """Pages in a different workspace should not appear in search results."""
-    ws1, _, col1 = _seed_workspace(db)
-    ws2, _, col2 = _seed_workspace(db)
+    """Nodes in a different workspace must not appear in search results."""
+    ws1, space1 = _seed_workspace(db)
+    ws2, space2 = _seed_workspace(db)
 
-    _create_page(db, col1, "unique-ws1", "Blockchain Article", "Blockchain fundamentals")
-    _create_page(db, col2, "unique-ws2", "Cooking Guide", "How to make pasta")
+    _create_page(db, space1, "unique-ws1", "Blockchain Article", "Blockchain fundamentals")
+    _create_page(db, space2, "unique-ws2", "Cooking Guide", "How to make pasta")
 
-    # Search ws1 for "blockchain"
     rows = db.execute(
         text("""
-            SELECT p.id, p.title FROM pages p
-            JOIN collections c ON c.id = p.collection_id
-            JOIN spaces s ON s.id = c.space_id
+            SELECT n.id, n.name FROM nodes n
+            JOIN spaces s ON s.id = n.space_id
             WHERE s.workspace_id = :ws_id
-              AND p.search_vector @@ plainto_tsquery('english', :q)
+              AND n.type = 'page'
+              AND n.deleted_at IS NULL
+              AND n.search_vector @@ plainto_tsquery('english', :q)
         """),
         {"ws_id": ws1.id, "q": "blockchain"},
     ).fetchall()
 
     assert len(rows) == 1
-    assert rows[0].title == "Blockchain Article"
+    assert rows[0].name == "Blockchain Article"
 
-    # Search ws2 for "blockchain" — should find nothing
     rows2 = db.execute(
         text("""
-            SELECT p.id FROM pages p
-            JOIN collections c ON c.id = p.collection_id
-            JOIN spaces s ON s.id = c.space_id
+            SELECT n.id FROM nodes n
+            JOIN spaces s ON s.id = n.space_id
             WHERE s.workspace_id = :ws_id
-              AND p.search_vector @@ plainto_tsquery('english', :q)
+              AND n.type = 'page'
+              AND n.deleted_at IS NULL
+              AND n.search_vector @@ plainto_tsquery('english', :q)
         """),
         {"ws_id": ws2.id, "q": "blockchain"},
     ).fetchall()
@@ -240,31 +293,57 @@ def test_search_respects_workspace_scoping(db):
 
 
 def test_title_matches_rank_higher_than_body(db):
-    """A match in the title (weight A) should rank higher than body (weight B)."""
-    ws, _, col = _seed_workspace(db)
-    _create_page(db, col, "title-match", "Kubernetes", "Container orchestration platform")
-    _create_page(db, col, "body-match", "DevOps Guide", "This guide covers Kubernetes and more")
+    """A match in the name (weight A) should rank higher than body (weight B)."""
+    ws, space = _seed_workspace(db)
+    _create_page(db, space, "name-match", "Kubernetes", "Container orchestration platform")
+    _create_page(db, space, "body-match", "DevOps Guide", "This guide covers Kubernetes and more")
 
     rows = db.execute(
         text("""
-            SELECT p.title,
-                   ts_rank(p.search_vector, plainto_tsquery('english', :q)) AS rank
-            FROM pages p
-            JOIN collections c ON c.id = p.collection_id
-            JOIN spaces s ON s.id = c.space_id
+            SELECT n.name,
+                   ts_rank(n.search_vector, plainto_tsquery('english', :q)) AS rank
+            FROM nodes n
+            JOIN spaces s ON s.id = n.space_id
             WHERE s.workspace_id = :ws_id
-              AND p.search_vector @@ plainto_tsquery('english', :q)
+              AND n.type = 'page'
+              AND n.deleted_at IS NULL
+              AND n.search_vector @@ plainto_tsquery('english', :q)
             ORDER BY rank DESC
         """),
         {"ws_id": ws.id, "q": "kubernetes"},
     ).fetchall()
 
     assert len(rows) == 2
-    assert rows[0].title == "Kubernetes"
+    assert rows[0].name == "Kubernetes"
+
+
+def test_deleted_nodes_excluded_from_search(db):
+    """Soft-deleted nodes must not appear in search results."""
+    from datetime import datetime, timezone
+
+    ws, space = _seed_workspace(db)
+    page = _create_page(db, space, "deleted-page", "Deleted Content", "I should not be found")
+
+    page.deleted_at = datetime.now(tz=timezone.utc)
+    db.flush()
+
+    rows = db.execute(
+        text("""
+            SELECT n.id FROM nodes n
+            JOIN spaces s ON s.id = n.space_id
+            WHERE s.workspace_id = :ws_id
+              AND n.type = 'page'
+              AND n.deleted_at IS NULL
+              AND n.search_vector @@ plainto_tsquery('english', :q)
+        """),
+        {"ws_id": ws.id, "q": "deleted"},
+    ).fetchall()
+
+    assert len(rows) == 0
 
 
 # ---------------------------------------------------------------------------
-# PostgresSearchBackend class tests (browse + title-ILIKE paths)
+# PostgresSearchBackend class tests (browse + name-ILIKE paths + node_path)
 # ---------------------------------------------------------------------------
 
 
@@ -272,30 +351,59 @@ def test_backend_browse_empty_query_returns_all_pages(db):
     """An empty query should return all pages in the workspace (browse mode)."""
     from marrow.search import PostgresSearchBackend
 
-    ws, _, col = _seed_workspace(db)
-    _create_page(db, col, "page-a", "Alpha", "First page content")
-    _create_page(db, col, "page-b", "Beta", "Second page content")
+    ws, space = _seed_workspace(db)
+    _create_page(db, space, "page-a", "Alpha", "First page content")
+    _create_page(db, space, "page-b", "Beta", "Second page content")
 
     backend = PostgresSearchBackend()
     results = backend.search(ws.id, "", db, limit=20)
 
-    titles = {r.title for r in results}
-    assert "Alpha" in titles
-    assert "Beta" in titles
+    names = {r.name for r in results}
+    assert "Alpha" in names
+    assert "Beta" in names
 
 
-def test_backend_title_ilike_matches_partial_title(db):
-    """A partial title query should match via ILIKE even if body lacks the word."""
+def test_backend_name_ilike_matches_partial_name(db):
+    """A partial name query should match via ILIKE even if body lacks the word."""
     from marrow.search import PostgresSearchBackend
 
-    ws, _, col = _seed_workspace(db)
-    _create_page(db, col, "getting-started", "Getting Started Guide", "Welcome to Marrow.")
-    _create_page(db, col, "unrelated", "API Reference", "Lists all endpoints.")
+    ws, space = _seed_workspace(db)
+    _create_page(db, space, "getting-started", "Getting Started Guide", "Welcome to Marrow.")
+    _create_page(db, space, "unrelated", "API Reference", "Lists all endpoints.")
 
     backend = PostgresSearchBackend()
     results = backend.search(ws.id, "getting", db, limit=20)
 
-    titles = [r.title for r in results]
-    assert "Getting Started Guide" in titles
-    # The title match should rank first
-    assert titles[0] == "Getting Started Guide"
+    names = [r.name for r in results]
+    assert "Getting Started Guide" in names
+    assert names[0] == "Getting Started Guide"
+
+
+def test_backend_result_includes_node_path(db):
+    """Search results should include the ordered ancestor folder names as node_path."""
+    from marrow.search import PostgresSearchBackend
+
+    ws, space = _seed_workspace(db)
+    engineering = _create_folder(db, space, "engineering", "Engineering")
+    backend_folder = _create_folder(db, space, "backend", "Backend", parent=engineering)
+    _create_page(db, space, "auth-page", "Auth", "Authentication details", parent=backend_folder)
+
+    backend = PostgresSearchBackend()
+    results = backend.search(ws.id, "authentication", db, limit=20)
+
+    assert len(results) == 1
+    assert results[0].node_path == ["Engineering", "Backend"]
+
+
+def test_backend_result_node_path_empty_for_root_page(db):
+    """A page at space root (no parent) should have an empty node_path."""
+    from marrow.search import PostgresSearchBackend
+
+    ws, space = _seed_workspace(db)
+    _create_page(db, space, "root-page", "Root Page", "Top-level content here")
+
+    backend = PostgresSearchBackend()
+    results = backend.search(ws.id, "top-level", db, limit=20)
+
+    assert len(results) == 1
+    assert results[0].node_path == []


### PR DESCRIPTION
## Summary

- **Migration** (`fdf65c08ffa8`): adds two PG triggers (`trg_revision_update_node_search_vector` on revision insert, `trg_node_name_update_search_vector` on node name/slug update) and a partial GIN index `idx_nodes_search` scoped to `type='page' AND deleted_at IS NULL`
- **`search.py`**: rewrites `PostgresSearchBackend` to query `nodes JOIN spaces` (no more `collections`); `SearchResult` drops `collection_id`/`collection_name`, adds `node_path` (list of ancestor folder names computed via LATERAL recursive CTE, root→leaf order)
- **`schemas.py`**: updates `SearchResultItem` to match — `node_id`, `name`, `snippet`, `space_id`, `space_name`, `node_path`, `rank`
- **`test_search.py`**: full rewrite against Node/Revision models — 14 tests covering trigger fires, folder exclusion, soft-delete exclusion, workspace scoping, ranking, browse mode, ILIKE fallback, `node_path` contents, and empty path for root-level pages

## Test plan

- [x] `pytest tests/test_search.py` — 14/14 pass
- [x] No regressions in `test_models_smoke.py`, `test_auth.py` (pre-existing failures in `test_migration_cycle`, `test_export`, `test_rbac`, `test_restore`, `test_round_trip` are unrelated v0.2 stubs, not introduced here)
- [x] Single Alembic head (`fdf65c08ffa8`) — no branch conflict

Closes #125. Part of #122 (v0.2).