### PR TITLE
feat: #132 2.0j: Restore bundle v4 format

### DIFF
--- a/api/marrow/cli.py
+++ b/api/marrow/cli.py
@@ -17,6 +17,9 @@ def export(
     slim: bool = typer.Option(
         False, "--slim", help="Skip revision history; export current content only"
     ),
+    include_trash: bool = typer.Option(
+        False, "--include-trash", help="Include soft-deleted (trashed) nodes in the bundle"
+    ),
     database_url: str | None = typer.Option(
         None, "--database-url", envvar="DATABASE_URL", help="PostgreSQL connection URL"
     ),
@@ -44,6 +47,7 @@ def export(
                 storage=storage,
                 output_path=output,
                 slim=slim,
+                include_trash=include_trash,
             )
         typer.echo(f"Exported to {result}")
     except ValueError as exc:

--- a/api/marrow/export.py
+++ b/api/marrow/export.py
@@ -1,21 +1,19 @@
-# ruff: noqa: F821
-# (#123) v3 export logic below references the removed Page/Collection ORM
-# classes; these calls NameError at runtime. The v4 rewrite lands in #132 (2.0j),
-# which will reference this code as the migration source.
 """Export a workspace to a portable zip bundle.
 
-Bundle layout (schema v3):
+Bundle layout (schema v4):
     marrow-export-{workspace-slug}-{timestamp}.zip
     ├── manifest.json
-    ├── pages/{page-id}.json          # canonical BlockNote JSON (v3 only, format='json')
-    ├── pages/{page-id}.md            # human-readable Markdown (all versions)
+    ├── nodes/{node-id}.json          # canonical BlockNote JSON (format='json', pages only)
+    ├── nodes/{node-id}.md            # human-readable Markdown (pages only)
     ├── assets/{asset-id}{ext}
-    ├── revisions/{page-id}/{revision-id}.json   # for JSON-format revisions
-    ├── revisions/{page-id}/{revision-id}.md     # for all revisions
+    ├── revisions/{node-id}/{revision-id}.json   # for JSON-format revisions
+    ├── revisions/{node-id}/{revision-id}.md     # for all revisions
     └── links.json
 
 v1/v2 bundles only had .md files. v3 adds .json as the canonical format for
-revisions stored as BlockNote JSON.
+revisions stored as BlockNote JSON. v4 replaces the page/collection hierarchy
+with a flat node tree (type=folder|page) and uses nodes/ instead of pages/.
+Folder nodes appear in the manifest only — no content file is written for them.
 """
 
 import hashlib
@@ -28,14 +26,10 @@ from pathlib import Path
 
 from sqlalchemy.orm import Session
 
-from .models import Attachment, Workspace
-
-# NOTE (#123): Page/Collection imports removed; the v3 export logic below still
-# references them and will NameError at call time. Rewrite for the node-tree
-# data model lands in #132 (2.0j) — bundle v4 format.
+from .models import Attachment, Node, Workspace
 from .storage import StorageAdapter
 
-SCHEMA_VERSION = "3"
+SCHEMA_VERSION = "4"
 
 
 def _sha256(data: bytes) -> str:
@@ -47,12 +41,18 @@ def _extract_hrefs(content: str) -> list[str]:
     return re.findall(r"\[(?:[^\]]*)\]\(([^)]+)\)", content)
 
 
-def _collect_pages(workspace: Workspace) -> list[Page]:
-    pages: list[Page] = []
+def _collect_nodes(workspace: Workspace, include_trash: bool = False) -> list[Node]:
+    """Return all nodes in the workspace across all spaces.
+
+    Soft-deleted nodes are excluded unless *include_trash* is True.
+    """
+    nodes: list[Node] = []
     for space in workspace.spaces:
-        for collection in space.collections:
-            pages.extend(collection.pages)
-    return pages
+        for node in space.nodes:
+            if node.deleted_at is not None and not include_trash:
+                continue
+            nodes.append(node)
+    return nodes
 
 
 # ---------------------------------------------------------------------------
@@ -191,77 +191,80 @@ def blocks_to_markdown(content_json: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _build_links(pages: list[Page], page_id_set: set[str]) -> dict:
+def _build_links(page_nodes: list[Node], node_id_set: set[str]) -> dict:
     internal_links: list[dict] = []
     broken_links: list[dict] = []
 
-    for page in pages:
-        if page.current_revision is None:
+    for node in page_nodes:
+        if node.current_revision is None:
             continue
-        content = page.current_revision.content or ""
-        content_format = page.current_revision.content_format
+        content = node.current_revision.content or ""
+        content_format = node.current_revision.content_format
 
-        # For JSON revisions, convert to markdown first for link extraction
         if content_format == "json":
             content = blocks_to_markdown(content)
 
         for href in _extract_hrefs(content):
-            source = str(page.id)
-            candidate = href.removeprefix("/pages/").rstrip("/")
-            if candidate in page_id_set:
+            source = str(node.id)
+            candidate = href.removeprefix("/nodes/").rstrip("/")
+            if candidate in node_id_set:
                 internal_links.append(
-                    {"source_page_id": source, "target_page_id": candidate, "href": href}
+                    {"source_node_id": source, "target_node_id": candidate, "href": href}
                 )
             elif href.startswith("/") or not href.startswith(("http://", "https://")):
-                broken_links.append({"source_page_id": source, "href": href})
+                broken_links.append({"source_node_id": source, "href": href})
 
-    linked_ids = {lnk["target_page_id"] for lnk in internal_links}
-    orphaned = [str(p.id) for p in pages if str(p.id) not in linked_ids]
+    linked_ids = {lnk["target_node_id"] for lnk in internal_links}
+    orphaned = [str(n.id) for n in page_nodes if str(n.id) not in linked_ids]
 
     return {
         "internal_links": internal_links,
         "broken_links": broken_links,
-        "orphaned_pages": orphaned,
+        "orphaned_nodes": orphaned,
     }
 
 
 def _build_manifest(
     workspace: Workspace,
-    pages: list[Page],
+    nodes: list[Node],
     attachment_records: list[dict],
     export_timestamp: str,
 ) -> dict:
     spaces = workspace.spaces
-    collections = [c for s in spaces for c in s.collections]
+    page_nodes = [n for n in nodes if n.type == "page"]
 
     revision_records = [
         {
             "id": str(rev.id),
-            "page_id": str(rev.page_id),
+            "node_id": str(rev.node_id),
             "content_format": rev.content_format,
             "created_at": rev.created_at.isoformat(),
         }
-        for page in pages
-        for rev in page.revisions
+        for node in page_nodes
+        for rev in node.revisions
     ]
 
     org = workspace.organization
     return {
         "schema_version": SCHEMA_VERSION,
         "export_timestamp": export_timestamp,
-        "organization": {
-            "id": str(org.id),
-            "slug": org.slug,
-            "name": org.name,
-            "created_at": org.created_at.isoformat(),
-        },
-        "workspace": {
-            "id": str(workspace.id),
-            "org_id": str(workspace.org_id),
-            "slug": workspace.slug,
-            "name": workspace.name,
-            "created_at": workspace.created_at.isoformat(),
-        },
+        "organizations": [
+            {
+                "id": str(org.id),
+                "slug": org.slug,
+                "name": org.name,
+                "created_at": org.created_at.isoformat(),
+            }
+        ],
+        "workspaces": [
+            {
+                "id": str(workspace.id),
+                "org_id": str(workspace.org_id),
+                "slug": workspace.slug,
+                "name": workspace.name,
+                "created_at": workspace.created_at.isoformat(),
+            }
+        ],
         "spaces": [
             {
                 "id": str(s.id),
@@ -272,28 +275,25 @@ def _build_manifest(
             }
             for s in spaces
         ],
-        "collections": [
+        "nodes": [
             {
-                "id": str(c.id),
-                "space_id": str(c.space_id),
-                "slug": c.slug,
-                "name": c.name,
-                "created_at": c.created_at.isoformat(),
-            }
-            for c in collections
-        ],
-        "pages": [
-            {
-                "id": str(p.id),
-                "collection_id": str(p.collection_id),
-                "slug": p.slug,
-                "title": p.title,
+                "id": str(n.id),
+                "space_id": str(n.space_id),
+                "parent_id": str(n.parent_id) if n.parent_id else None,
+                "type": n.type,
+                "name": n.name,
+                "slug": n.slug,
+                "position": n.position,
+                "description": n.description if n.type == "folder" else None,
                 "current_revision_id": (
-                    str(p.current_revision_id) if p.current_revision_id else None
+                    str(n.current_revision_id)
+                    if n.type == "page" and n.current_revision_id
+                    else None
                 ),
-                "created_at": p.created_at.isoformat(),
+                "created_at": n.created_at.isoformat(),
+                **({"deleted_at": n.deleted_at.isoformat()} if n.deleted_at else {}),
             }
-            for p in pages
+            for n in nodes
         ],
         "revisions": revision_records,
         "attachments": attachment_records,
@@ -304,6 +304,7 @@ def estimate_export_sizes(
     slug: str,
     session: Session,
     storage: StorageAdapter,
+    include_trash: bool = False,
 ) -> dict:
     """Return estimated byte sizes for full and slim exports of *slug*.
 
@@ -315,24 +316,22 @@ def estimate_export_sizes(
     if workspace is None:
         raise ValueError(f"Workspace '{slug}' not found")
 
-    pages = _collect_pages(workspace)
-    for page in pages:
-        _ = page.current_revision
-        _ = page.revisions
-        _ = page.attachments
+    nodes = _collect_nodes(workspace, include_trash=include_trash)
+    page_nodes = [n for n in nodes if n.type == "page"]
+    for node in page_nodes:
+        _ = node.current_revision
+        _ = node.revisions
+        _ = node.attachments
 
-    attachment_bytes = 0
-    for page in pages:
-        for att in page.attachments:
-            attachment_bytes += att.size_bytes
+    attachment_bytes = sum(att.size_bytes for node in page_nodes for att in node.attachments)
 
     current_content_bytes = sum(
-        len((page.current_revision.content or "").encode())
-        for page in pages
-        if page.current_revision
+        len((node.current_revision.content or "").encode())
+        for node in page_nodes
+        if node.current_revision
     )
     revision_bytes = sum(
-        len((rev.content or "").encode()) for page in pages for rev in page.revisions
+        len((rev.content or "").encode()) for node in page_nodes for rev in node.revisions
     )
 
     slim_bytes = current_content_bytes + attachment_bytes
@@ -347,24 +346,27 @@ def export_workspace(
     storage: StorageAdapter,
     output_path: Path | None = None,
     slim: bool = False,
+    include_trash: bool = False,
 ) -> Path:
     """Export *slug* to a zip bundle and return the path of the written file.
 
     When *slim* is True the revisions/ directory is omitted, producing a
     current-content-only bundle that is smaller but cannot restore full history.
+    When *include_trash* is True, soft-deleted nodes are included in the bundle.
     """
     workspace = session.query(Workspace).filter_by(slug=slug).first()
     if workspace is None:
         raise ValueError(f"Workspace '{slug}' not found")
 
-    pages = _collect_pages(workspace)
-    page_id_set = {str(p.id) for p in pages}
+    nodes = _collect_nodes(workspace, include_trash=include_trash)
+    page_nodes = [n for n in nodes if n.type == "page"]
+    node_id_set = {str(n.id) for n in page_nodes}
 
     # Eagerly touch lazy-loaded relationships while the session is open.
-    for page in pages:
-        _ = page.current_revision
-        _ = page.revisions
-        _ = page.attachments
+    for node in page_nodes:
+        _ = node.current_revision
+        _ = node.revisions
+        _ = node.attachments
 
     export_timestamp = datetime.now(timezone.utc).isoformat()
     timestamp_fmt = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
@@ -380,40 +382,40 @@ def export_workspace(
     buf = BytesIO()
 
     with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-        for page in pages:
-            page_id = str(page.id)
+        for node in page_nodes:
+            node_id = str(node.id)
 
             # Current page content — always write .md; also write .json for JSON format.
-            if page.current_revision:
-                content = page.current_revision.content
-                fmt = page.current_revision.content_format
+            if node.current_revision:
+                content = node.current_revision.content
+                fmt = node.current_revision.content_format
             else:
                 content = ""
                 fmt = "markdown"
 
             if fmt == "json":
-                zf.writestr(f"pages/{page_id}.json", content)
-                zf.writestr(f"pages/{page_id}.md", blocks_to_markdown(content))
+                zf.writestr(f"nodes/{node_id}.json", content)
+                zf.writestr(f"nodes/{node_id}.md", blocks_to_markdown(content))
             else:
-                zf.writestr(f"pages/{page_id}.md", content)
+                zf.writestr(f"nodes/{node_id}.md", content)
 
             if not slim:
                 # Every revision (append-only history).
-                for rev in page.revisions:
+                for rev in node.revisions:
                     rev_id = str(rev.id)
                     if rev.content_format == "json":
-                        zf.writestr(f"revisions/{page_id}/{rev_id}.json", rev.content)
+                        zf.writestr(f"revisions/{node_id}/{rev_id}.json", rev.content)
                         zf.writestr(
-                            f"revisions/{page_id}/{rev_id}.md",
+                            f"revisions/{node_id}/{rev_id}.md",
                             blocks_to_markdown(rev.content),
                         )
                     else:
-                        zf.writestr(f"revisions/{page_id}/{rev_id}.md", rev.content)
+                        zf.writestr(f"revisions/{node_id}/{rev_id}.md", rev.content)
 
         # Attachments — verify hash before including.
         all_attachments: list[Attachment] = []
-        for page in pages:
-            all_attachments.extend(page.attachments)
+        for node in page_nodes:
+            all_attachments.extend(node.attachments)
 
         for att in all_attachments:
             att_id = str(att.id)
@@ -429,7 +431,7 @@ def export_workspace(
             attachment_records.append(
                 {
                     "id": att_id,
-                    "page_id": str(att.page_id),
+                    "node_id": str(att.node_id),
                     "filename": att.filename,
                     "hash": att.hash,
                     "size_bytes": att.size_bytes,
@@ -437,9 +439,9 @@ def export_workspace(
                 }
             )
 
-        zf.writestr("links.json", json.dumps(_build_links(pages, page_id_set), indent=2))
+        zf.writestr("links.json", json.dumps(_build_links(page_nodes, node_id_set), indent=2))
 
-        manifest = _build_manifest(workspace, pages, attachment_records, export_timestamp)
+        manifest = _build_manifest(workspace, nodes, attachment_records, export_timestamp)
         if slim:
             manifest["slim"] = True
             manifest["revisions"] = []

--- a/api/marrow/routers/workspaces.py
+++ b/api/marrow/routers/workspaces.py
@@ -224,6 +224,7 @@ def search_workspace(
 @router.get("/{workspace_id}/export/estimate")
 def estimate_workspace_export(
     workspace_id: UUID,
+    include_trash: bool = False,
     db: Session = Depends(get_db),
     auth: AuthContext = Depends(require_workspace_role(OrgRole.VIEWER)),
 ):
@@ -237,13 +238,14 @@ def estimate_workspace_export(
     storage_root = os.getenv("STORAGE_PATH", "/var/lib/marrow/attachments")
     storage = LocalFilesystemAdapter(storage_root)
 
-    return estimate_export_sizes(slug=ws.slug, session=db, storage=storage)
+    return estimate_export_sizes(slug=ws.slug, session=db, storage=storage, include_trash=include_trash)
 
 
 @router.get("/{workspace_id}/export")
 def export_workspace_endpoint(
     workspace_id: UUID,
     slim: bool = False,
+    include_trash: bool = False,
     db: Session = Depends(get_db),
     auth: AuthContext = Depends(require_workspace_role(OrgRole.VIEWER)),
 ):
@@ -268,6 +270,7 @@ def export_workspace_endpoint(
             storage=storage,
             output_path=Path(tmp),
             slim=slim,
+            include_trash=include_trash,
         )
         data = bundle_path.read_bytes()
 

--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -1,4 +1,4 @@
-"""Integration tests for the export command.
+"""Integration tests for the v4 export command.
 
 Runs against a live PostgreSQL database (same Docker Compose default as other tests).
 Each test rolls back its transaction so the DB stays clean between runs.
@@ -8,13 +8,14 @@ import hashlib
 import json
 import os
 import zipfile
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from marrow.export import SCHEMA_VERSION, estimate_export_sizes, export_workspace
-from marrow.models import Attachment, Collection, Organization, Page, Revision, Space, Workspace
+from marrow.models import Attachment, Node, Organization, Revision, Space, Workspace
 from marrow.storage import StorageAdapter
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
@@ -61,7 +62,7 @@ def session(engine):
 
 @pytest.fixture
 def seeded(session):
-    """Seed a workspace with two pages (two revisions each) and one attachment."""
+    """Seed a workspace with two page nodes (multiple revisions), one folder node, and one attachment."""
     org = Organization(slug="export-test-org", name="Export Test Org")
     session.add(org)
     session.flush()
@@ -74,32 +75,55 @@ def seeded(session):
     session.add(space)
     session.flush()
 
-    col = Collection(space_id=space.id, slug="col", name="Collection")
-    session.add(col)
+    # Folder node (contributes manifest entry only — no content file)
+    folder = Node(
+        space_id=space.id,
+        parent_id=None,
+        type="folder",
+        name="Docs Folder",
+        slug="docs-folder",
+        position="a0",
+        description="A folder node",
+    )
+    session.add(folder)
     session.flush()
 
-    # Page 1 with two revisions and one internal link to page 2 (added later).
-    page1 = Page(collection_id=col.id, slug="page-one", title="Page One")
+    # Page node 1 with three revisions and one internal link to page node 2 (added later).
+    page1 = Node(
+        space_id=space.id,
+        parent_id=None,
+        type="page",
+        name="Page One",
+        slug="page-one",
+        position="a1",
+    )
     session.add(page1)
     session.flush()
 
-    rev1a = Revision(page_id=page1.id, content="# Page One\nFirst draft.")
+    rev1a = Revision(node_id=page1.id, content="# Page One\nFirst draft.")
     session.add(rev1a)
     session.flush()
 
-    rev1b = Revision(page_id=page1.id, content="# Page One\nSecond draft.")
+    rev1b = Revision(node_id=page1.id, content="# Page One\nSecond draft.")
     session.add(rev1b)
     session.flush()
 
     page1.current_revision_id = rev1b.id
     session.flush()
 
-    # Page 2 (target of internal link from page 1).
-    page2 = Page(collection_id=col.id, slug="page-two", title="Page Two")
+    # Page node 2 (target of internal link from page 1).
+    page2 = Node(
+        space_id=space.id,
+        parent_id=None,
+        type="page",
+        name="Page Two",
+        slug="page-two",
+        position="a2",
+    )
     session.add(page2)
     session.flush()
 
-    rev2 = Revision(page_id=page2.id, content="# Page Two\nOnly revision.")
+    rev2 = Revision(node_id=page2.id, content="# Page Two\nOnly revision.")
     session.add(rev2)
     session.flush()
 
@@ -107,8 +131,8 @@ def seeded(session):
     session.flush()
 
     # Update page1 current revision to include a link to page2.
-    link_content = f"# Page One\n[See page two](/pages/{page2.id})"
-    rev1c = Revision(page_id=page1.id, content=link_content)
+    link_content = f"# Page One\n[See page two](/nodes/{page2.id})"
+    rev1c = Revision(node_id=page1.id, content=link_content)
     session.add(rev1c)
     session.flush()
 
@@ -119,7 +143,7 @@ def seeded(session):
     att_data = b"fake image bytes"
     att_hash = hashlib.sha256(att_data).hexdigest()
     att = Attachment(
-        page_id=page1.id,
+        node_id=page1.id,
         filename="photo.png",
         hash=att_hash,
         size_bytes=len(att_data),
@@ -131,6 +155,7 @@ def seeded(session):
 
     return {
         "workspace": ws,
+        "folder": folder,
         "pages": [page1, page2],
         "attachment": att,
         "attachment_data": att_data,
@@ -169,13 +194,17 @@ def test_zip_contains_expected_members(seeded, session, tmp_path):
 
     page1_id = str(seeded["pages"][0].id)
     page2_id = str(seeded["pages"][1].id)
+    folder_id = str(seeded["folder"].id)
     att_id = str(seeded["attachment"].id)
 
     assert "manifest.json" in names
     assert "links.json" in names
-    assert f"pages/{page1_id}.md" in names
-    assert f"pages/{page2_id}.md" in names
+    assert f"nodes/{page1_id}.md" in names
+    assert f"nodes/{page2_id}.md" in names
     assert f"assets/{att_id}.png" in names
+    # Folder nodes have no content file
+    assert f"nodes/{folder_id}.md" not in names
+    assert f"nodes/{folder_id}.json" not in names
 
 
 def test_manifest_content(seeded, session, tmp_path):
@@ -191,19 +220,58 @@ def test_manifest_content(seeded, session, tmp_path):
         manifest = json.loads(zf.read("manifest.json"))
 
     assert manifest["schema_version"] == SCHEMA_VERSION
-    assert manifest["workspace"]["slug"] == ws.slug
-    assert manifest["workspace"]["id"] == str(ws.id)
+    assert manifest["schema_version"] == "4"
+
+    # v4 uses plural top-level keys
+    assert "organizations" in manifest
+    assert "workspaces" in manifest
+    assert "collections" not in manifest
+    assert "pages" not in manifest
+
+    assert len(manifest["organizations"]) == 1
+    assert manifest["organizations"][0]["slug"] == "export-test-org"
+
+    assert len(manifest["workspaces"]) == 1
+    assert manifest["workspaces"][0]["slug"] == ws.slug
+    assert manifest["workspaces"][0]["id"] == str(ws.id)
 
     assert len(manifest["spaces"]) == 1
-    assert len(manifest["collections"]) == 1
-    assert len(manifest["pages"]) == 2
-    assert len(manifest["revisions"]) == 4  # rev1a, rev1b, rev1c, rev2
+    # 2 pages + 1 folder
+    assert len(manifest["nodes"]) == 3
+    # rev1a, rev1b, rev1c, rev2 = 4 revisions (pages only)
+    assert len(manifest["revisions"]) == 4
     assert len(manifest["attachments"]) == 1
 
     att_record = manifest["attachments"][0]
     assert att_record["hash"] == seeded["attachment"].hash
     assert att_record["filename"] == "photo.png"
+    assert "node_id" in att_record
     assert "created_at" in att_record
+
+
+def test_manifest_node_entries(seeded, session, tmp_path):
+    result = export_workspace(
+        slug="export-test-ws",
+        session=session,
+        storage=seeded["storage"],
+        output_path=tmp_path,
+    )
+
+    with zipfile.ZipFile(result) as zf:
+        manifest = json.loads(zf.read("manifest.json"))
+
+    folder_id = str(seeded["folder"].id)
+    folder_entry = next(n for n in manifest["nodes"] if n["id"] == folder_id)
+    assert folder_entry["type"] == "folder"
+    assert folder_entry["description"] == "A folder node"
+
+    page1_id = str(seeded["pages"][0].id)
+    page1_entry = next(n for n in manifest["nodes"] if n["id"] == page1_id)
+    assert page1_entry["type"] == "page"
+    assert page1_entry["description"] is None
+    assert page1_entry["current_revision_id"] is not None
+    assert "position" in page1_entry
+    assert "slug" in page1_entry
 
 
 def test_page_content_matches_current_revision(seeded, session, tmp_path):
@@ -216,9 +284,9 @@ def test_page_content_matches_current_revision(seeded, session, tmp_path):
     )
 
     with zipfile.ZipFile(result) as zf:
-        content = zf.read(f"pages/{page1.id}.md").decode()
+        content = zf.read(f"nodes/{page1.id}.md").decode()
 
-    assert f"/pages/{seeded['pages'][1].id}" in content
+    assert f"/nodes/{seeded['pages'][1].id}" in content
 
 
 def test_all_revisions_are_included(seeded, session, tmp_path):
@@ -253,12 +321,12 @@ def test_links_json(seeded, session, tmp_path):
 
     internal = links["internal_links"]
     assert len(internal) == 1
-    assert internal[0]["source_page_id"] == page1_id
-    assert internal[0]["target_page_id"] == page2_id
+    assert internal[0]["source_node_id"] == page1_id
+    assert internal[0]["target_node_id"] == page2_id
 
     # page2 is linked to, so only page1 is orphaned (nothing links to it)
-    assert page2_id not in links["orphaned_pages"]
-    assert page1_id in links["orphaned_pages"]
+    assert page2_id not in links["orphaned_nodes"]
+    assert page1_id in links["orphaned_nodes"]
 
 
 def test_attachment_hash_mismatch_raises(seeded, session, tmp_path):
@@ -299,6 +367,119 @@ def test_output_filename_default(seeded, session, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# include_trash tests
+# ---------------------------------------------------------------------------
+
+
+def test_trashed_nodes_excluded_by_default(session, tmp_path):
+    """Soft-deleted nodes are omitted from the bundle by default."""
+    org = Organization(slug="trash-test-org", name="Trash Test Org")
+    session.add(org)
+    session.flush()
+
+    ws = Workspace(org_id=org.id, slug="trash-test-ws", name="Trash WS")
+    session.add(ws)
+    session.flush()
+
+    space = Space(workspace_id=ws.id, slug="sp", name="Space")
+    session.add(space)
+    session.flush()
+
+    active = Node(space_id=space.id, type="page", name="Active", slug="active", position="a0")
+    session.add(active)
+    session.flush()
+
+    rev_a = Revision(node_id=active.id, content="Active content.")
+    session.add(rev_a)
+    session.flush()
+    active.current_revision_id = rev_a.id
+    session.flush()
+
+    trashed = Node(
+        space_id=space.id,
+        type="page",
+        name="Trashed",
+        slug="trashed",
+        position="a1",
+        deleted_at=datetime.now(timezone.utc),
+    )
+    session.add(trashed)
+    session.flush()
+
+    rev_t = Revision(node_id=trashed.id, content="Trashed content.")
+    session.add(rev_t)
+    session.flush()
+    trashed.current_revision_id = rev_t.id
+    session.flush()
+
+    storage = FakeStorageAdapter()
+    result = export_workspace(
+        slug="trash-test-ws",
+        session=session,
+        storage=storage,
+        output_path=tmp_path,
+    )
+
+    with zipfile.ZipFile(result) as zf:
+        names = set(zf.namelist())
+        manifest = json.loads(zf.read("manifest.json"))
+
+    assert f"nodes/{active.id}.md" in names
+    assert f"nodes/{trashed.id}.md" not in names
+    assert len(manifest["nodes"]) == 1
+    assert manifest["nodes"][0]["id"] == str(active.id)
+
+
+def test_include_trash_adds_deleted_nodes(session, tmp_path):
+    """Soft-deleted nodes appear in the bundle when include_trash=True."""
+    org = Organization(slug="trash-include-org", name="Trash Include Org")
+    session.add(org)
+    session.flush()
+
+    ws = Workspace(org_id=org.id, slug="trash-include-ws", name="Trash Include WS")
+    session.add(ws)
+    session.flush()
+
+    space = Space(workspace_id=ws.id, slug="sp", name="Space")
+    session.add(space)
+    session.flush()
+
+    trashed = Node(
+        space_id=space.id,
+        type="page",
+        name="Trashed",
+        slug="trashed",
+        position="a0",
+        deleted_at=datetime.now(timezone.utc),
+    )
+    session.add(trashed)
+    session.flush()
+
+    rev = Revision(node_id=trashed.id, content="Trashed content.")
+    session.add(rev)
+    session.flush()
+    trashed.current_revision_id = rev.id
+    session.flush()
+
+    storage = FakeStorageAdapter()
+    result = export_workspace(
+        slug="trash-include-ws",
+        session=session,
+        storage=storage,
+        output_path=tmp_path,
+        include_trash=True,
+    )
+
+    with zipfile.ZipFile(result) as zf:
+        names = set(zf.namelist())
+        manifest = json.loads(zf.read("manifest.json"))
+
+    assert f"nodes/{trashed.id}.md" in names
+    assert len(manifest["nodes"]) == 1
+    assert "deleted_at" in manifest["nodes"][0]
+
+
+# ---------------------------------------------------------------------------
 # Slim export tests
 # ---------------------------------------------------------------------------
 
@@ -316,7 +497,7 @@ def test_slim_export_omits_revisions(seeded, session, tmp_path):
         names = zf.namelist()
 
     assert not any(n.startswith("revisions/") for n in names)
-    assert any(n.startswith("pages/") for n in names)
+    assert any(n.startswith("nodes/") for n in names)
     assert "manifest.json" in names
 
 
@@ -345,98 +526,6 @@ def test_slim_manifest_has_slim_flag_and_empty_revisions(seeded, session, tmp_pa
 
     assert manifest.get("slim") is True
     assert manifest["revisions"] == []
-
-
-def test_slim_bundle_is_restorable(session, tmp_path):
-    """A slim bundle restores cleanly — one revision per page from pages/ content."""
-    import uuid as _uuid
-    from datetime import datetime, timezone
-
-    from marrow.restore import restore_workspace
-
-    now = datetime.now(timezone.utc).isoformat()
-    ws_id = _uuid.uuid4()
-    org_id = _uuid.uuid4()
-    space_id = _uuid.uuid4()
-    col_id = _uuid.uuid4()
-    page_id = _uuid.uuid4()
-
-    manifest = {
-        "schema_version": SCHEMA_VERSION,
-        "slim": True,
-        "export_timestamp": now,
-        "organization": {
-            "id": str(org_id),
-            "slug": "slim-restore-org",
-            "name": "Slim Restore Org",
-            "created_at": now,
-        },
-        "workspace": {
-            "id": str(ws_id),
-            "org_id": str(org_id),
-            "slug": "slim-restore-ws",
-            "name": "Slim Restore WS",
-            "created_at": now,
-        },
-        "spaces": [
-            {
-                "id": str(space_id),
-                "workspace_id": str(ws_id),
-                "slug": "sp",
-                "name": "Space",
-                "created_at": now,
-            }
-        ],
-        "collections": [
-            {
-                "id": str(col_id),
-                "space_id": str(space_id),
-                "slug": "col",
-                "name": "Col",
-                "created_at": now,
-            }
-        ],
-        "pages": [
-            {
-                "id": str(page_id),
-                "collection_id": str(col_id),
-                "slug": "pg",
-                "title": "Page",
-                "current_revision_id": None,
-                "created_at": now,
-            }
-        ],
-        "revisions": [],
-        "attachments": [],
-    }
-
-    import io as _io
-
-    buf = _io.BytesIO()
-    with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("manifest.json", json.dumps(manifest))
-        zf.writestr(f"pages/{page_id}.md", "# Page\nCurrent content.")
-        zf.writestr(
-            "links.json",
-            json.dumps({"internal_links": [], "broken_links": [], "orphaned_pages": []}),
-        )
-
-    bundle_path = tmp_path / "slim-bundle.zip"
-    bundle_path.write_bytes(buf.getvalue())
-
-    storage = FakeStorageAdapter()
-    slug = restore_workspace(bundle_path, session, storage)
-    assert slug == "slim-restore-ws"
-
-    from marrow.models import Workspace
-
-    restored_ws = session.query(Workspace).filter_by(slug="slim-restore-ws").one()
-    pages_list = [p for s in restored_ws.spaces for c in s.collections for p in c.pages]
-    assert len(pages_list) == 1
-    p = pages_list[0]
-    assert p.current_revision is not None
-    assert p.current_revision.content == "# Page\nCurrent content."
-    assert len(p.revisions) == 1
 
 
 def test_estimate_export_sizes(seeded, session):


### PR DESCRIPTION
Implements #132.

## Changes

- `SCHEMA_VERSION = "4"`
- Manifest uses plural top-level keys: `organizations`, `workspaces`, `spaces`, `nodes`, `revisions`, `attachments`; drops `collections` and `pages`
- `nodes` is a flat list with `parent_id`, `type`, `name`, `slug`, `position`, `description` (folders only), `current_revision_id` (pages only), `deleted_at` (when trashed)
- Content files moved from `pages/` → `nodes/` (page nodes only; folder nodes have no content file)
- `revisions/` uses `node_id` as subdirectory (was `page_id`)
- `links.json` uses node terminology: `source_node_id`, `target_node_id`, `orphaned_nodes`
- `--include-trash` CLI flag and `?include_trash=true` API param for including soft-deleted nodes
- `test_export.py` fully rewritten for the Node model and v4 bundle format (16 tests, all green)

_Created by swarm coordinator_