### PR TITLE
feat: #97 B.3: Marketing — Product page

### DIFF
--- a/web-marketing/app/globals.css
+++ b/web-marketing/app/globals.css
@@ -1,0 +1,93 @@
+@import "tailwindcss";
+
+/* -------------------------------------------------------------------------
+ * Marrow marketing design tokens
+ * Reference: references/design-tokens.md
+ * ------------------------------------------------------------------------- */
+
+/* Light mode */
+:root {
+  /* Structural */
+  --color-base: #dde3ee;
+  --color-surface: #eaeff7;
+  --color-surface-elevated: #f4f6fb;
+  --color-border: #c8d0e0;
+
+  /* Text */
+  --color-text-primary: #1e293b;
+  --color-text-secondary: #64748b;
+  --color-text-muted: #94a3b8;
+
+  /* Brand accent (terracotta) */
+  --color-accent: #9a3412;
+  --color-accent-ink: #ffffff;
+
+  /* Marketing-only warm tones */
+  --color-cream: #f5ecd9;
+  --color-bone: #ece3d0;
+
+  /* Status */
+  --color-success: #34d399;
+  --color-destructive: #dc2626;
+
+  /* Font stacks */
+  --font-display: var(--font-fraunces), ui-serif, Georgia, serif;
+  --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+/* Dark mode (primary design target) */
+.dark {
+  --color-base: #111318;
+  --color-surface: #1a1d27;
+  --color-surface-elevated: #222636;
+  --color-border: #2d3348;
+
+  --color-text-primary: #e2e8f0;
+  --color-text-secondary: #94a3b8;
+  --color-text-muted: #475569;
+
+  --color-accent: #e8805c;
+  --color-accent-ink: #1a0f0a;
+
+  /* Cream stays warm even in dark mode (used for CTA sections) */
+  --color-cream: #f5ecd9;
+  --color-bone: #ece3d0;
+
+  --color-success: #34d399;
+  --color-destructive: #dc2626;
+}
+
+@layer base {
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+
+  html {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  body {
+    background-color: var(--color-base);
+    color: var(--color-text-primary);
+    font-family: var(--font-sans);
+    line-height: 1.5;
+  }
+
+  button {
+    background: none;
+    cursor: pointer;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+}

--- a/web-marketing/app/layout.tsx
+++ b/web-marketing/app/layout.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import { Fraunces } from "next/font/google";
+import { JetBrains_Mono } from "next/font/google";
+import { ThemeProvider } from "@/components/theme-provider";
+import "./globals.css";
+
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin"],
+});
+
+const fraunces = Fraunces({
+  variable: "--font-fraunces",
+  subsets: ["latin"],
+  // Include optical size, SOFT, and WONK axes for full design-system fidelity
+  axes: ["opsz", "SOFT", "WONK"],
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
+  subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+  title: "Marrow — Your knowledge, owned outright",
+  description:
+    "A self-hosted knowledge base built around a non-negotiable restore guarantee. Your docs, your server, always exportable.",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body
+        className={`${inter.variable} ${fraunces.variable} ${jetbrainsMono.variable} antialiased`}
+      >
+        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/web-marketing/app/page.tsx
+++ b/web-marketing/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function RootPage() {
+  redirect("/product");
+}

--- a/web-marketing/app/product/page.tsx
+++ b/web-marketing/app/product/page.tsx
@@ -1,0 +1,862 @@
+import type { Metadata } from "next";
+import { SiteNav, SiteFooter, Eyebrow, MarketingButton } from "@/components/chrome";
+import {
+  IconArrow,
+  IconQuote,
+  IconCode,
+  IconBolt,
+  IconPage,
+  IconFolder,
+  IconLink,
+  IconClock,
+  IconSearch,
+} from "@/components/icons";
+
+export const metadata: Metadata = {
+  title: "Product — Marrow",
+  description:
+    "A product tour of Marrow's four core features: editor, organization, search, and history.",
+};
+
+export default function ProductPage() {
+  return (
+    <div style={{ background: "var(--color-base)", minHeight: "100vh" }}>
+      <SiteNav />
+      <main>
+        <ProductHero />
+        <EditorDeepDive />
+        <OrganizationSection />
+        <SearchSection />
+        <HistorySection />
+        <IntegrationsStrip />
+        <ProductFinalCTA />
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}
+
+function ProductHero() {
+  return (
+    <section
+      style={{
+        background: "var(--color-base)",
+        padding: "112px 32px 72px",
+        borderBottom: "1px solid var(--color-border)",
+      }}
+    >
+      <div style={{ maxWidth: 1000, margin: "0 auto", textAlign: "center" }}>
+        <Eyebrow>Product tour</Eyebrow>
+        <h1
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: "clamp(44px, 5.5vw, 72px)",
+            marginTop: 16,
+            lineHeight: 1.02,
+            fontVariationSettings: '"SOFT" 80',
+            color: "var(--color-text-primary)",
+          }}
+        >
+          Four pieces.
+          <br />
+          <em
+            style={{
+              fontStyle: "italic",
+              color: "var(--color-accent)",
+              fontVariationSettings: '"SOFT" 100, "WONK" 1',
+            }}
+          >
+            One
+          </em>{" "}
+          small product.
+        </h1>
+        <p
+          style={{
+            fontSize: 18,
+            color: "var(--color-text-secondary)",
+            marginTop: 28,
+            maxWidth: 620,
+            margin: "28px auto 0",
+            lineHeight: 1.6,
+          }}
+        >
+          An editor, an organizer, a search, and a history. Each of them does
+          one thing with obvious care. Together they&rsquo;re everything a
+          knowledge base should be.
+        </p>
+        <div
+          style={{
+            display: "flex",
+            gap: 12,
+            justifyContent: "center",
+            marginTop: 36,
+          }}
+        >
+          <MarketingButton variant="primary" size="lg" href="/app">
+            Open the editor <IconArrow size={15} />
+          </MarketingButton>
+          <MarketingButton variant="secondary" size="lg" href="/pricing">
+            See pricing
+          </MarketingButton>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface SectionShellProps {
+  num: string;
+  eyebrow: string;
+  title: string;
+  body: string;
+  children: React.ReactNode;
+  accent?: boolean;
+  reverse?: boolean;
+}
+
+function SectionShell({
+  num,
+  eyebrow,
+  title,
+  body,
+  children,
+  accent,
+  reverse,
+}: SectionShellProps) {
+  return (
+    <section
+      style={{
+        padding: "120px 32px",
+        borderBottom: "1px solid var(--color-border)",
+        background: accent ? "var(--color-surface)" : "var(--color-base)",
+      }}
+    >
+      <div style={{ maxWidth: 1200, margin: "0 auto" }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: reverse ? "1.2fr 1fr" : "1fr 1.2fr",
+            gap: 72,
+            alignItems: "center",
+          }}
+        >
+          {!reverse && <div style={{ order: 1 }}>{children}</div>}
+          <div style={{ order: reverse ? 1 : 2 }}>
+            <div
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 11,
+                color: "var(--color-text-muted)",
+                letterSpacing: "0.18em",
+                textTransform: "uppercase",
+              }}
+            >
+              {num}
+            </div>
+            <Eyebrow style={{ marginTop: 12 }}>{eyebrow}</Eyebrow>
+            <h2
+              style={{
+                fontFamily: "var(--font-display)",
+                fontSize: 42,
+                marginTop: 14,
+                fontVariationSettings: '"SOFT" 60',
+                lineHeight: 1.08,
+                color: "var(--color-text-primary)",
+              }}
+            >
+              {title}
+            </h2>
+            <p
+              style={{
+                fontSize: 16,
+                color: "var(--color-text-secondary)",
+                marginTop: 20,
+                lineHeight: 1.7,
+                maxWidth: 480,
+              }}
+            >
+              {body}
+            </p>
+          </div>
+          {reverse && <div style={{ order: 2 }}>{children}</div>}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function EditorDeepDive() {
+  return (
+    <SectionShell
+      num="01 / The editor"
+      eyebrow="Slash commands, wiki-links, plain Markdown"
+      title="Type a slash. Type a word. Ship a doc."
+      body="A proper block editor with none of the maximalist chrome. 42 block types, keyboard shortcuts for everything, and a file on disk at the end."
+    >
+      <EditorDemo />
+    </SectionShell>
+  );
+}
+
+function EditorDemo() {
+  const slashItems = [
+    {
+      icon: IconQuote,
+      label: "Callout",
+      desc: "Highlight an aside",
+      active: true,
+    },
+    { icon: IconCode, label: "Code block", desc: "Syntax highlighted" },
+    { icon: IconPage, label: "Canvas embed", desc: "Embed a Marrow canvas" },
+    {
+      icon: IconBolt,
+      label: "Cmd palette",
+      desc: "Trigger a shortcut inline",
+    },
+  ];
+
+  return (
+    <div
+      style={{
+        background: "var(--color-surface)",
+        border: "1px solid var(--color-border)",
+        borderRadius: 14,
+        padding: "28px 32px",
+        position: "relative",
+      }}
+    >
+      <h3
+        style={{
+          fontFamily: "var(--font-display)",
+          fontSize: 24,
+          fontVariationSettings: '"SOFT" 70',
+          color: "var(--color-text-primary)",
+        }}
+      >
+        Platform migration, week three
+      </h3>
+      <p
+        style={{
+          fontSize: 14,
+          color: "var(--color-text-secondary)",
+          marginTop: 12,
+          lineHeight: 1.7,
+        }}
+      >
+        We ran the first write-shadow through prod last night. Latency stayed
+        within envelope, but the{" "}
+        <span style={{ color: "var(--color-accent)" }}>p99.9 tail</span> did
+        its familiar thing around 02:40.
+      </p>
+
+      {/* slash menu */}
+      <div style={{ marginTop: 18, position: "relative" }}>
+        <div
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 13,
+            color: "var(--color-text-secondary)",
+            background: "var(--color-surface-elevated)",
+            borderRadius: 6,
+            padding: "8px 12px",
+            display: "inline-block",
+          }}
+        >
+          /<span style={{ color: "var(--color-accent)" }}>cal</span>
+          <span
+            style={{
+              display: "inline-block",
+              width: 2,
+              height: 14,
+              background: "var(--color-accent)",
+              marginLeft: 2,
+              verticalAlign: -2,
+            }}
+          />
+        </div>
+
+        <div
+          style={{
+            position: "absolute",
+            top: 38,
+            left: 0,
+            width: 300,
+            background: "var(--color-surface-elevated)",
+            border: "1px solid var(--color-border)",
+            borderRadius: 10,
+            boxShadow: "0 20px 40px -20px rgba(0,0,0,0.4)",
+            padding: 6,
+            zIndex: 2,
+          }}
+        >
+          {slashItems.map((item, i) => (
+            <div
+              key={i}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                padding: "8px 10px",
+                borderRadius: 6,
+                background: item.active
+                  ? "color-mix(in oklab, var(--color-accent) 16%, transparent)"
+                  : "transparent",
+              }}
+            >
+              <item.icon
+                size={14}
+                style={{
+                  color: item.active
+                    ? "var(--color-accent)"
+                    : "var(--color-text-secondary)",
+                }}
+              />
+              <div style={{ flex: 1 }}>
+                <div
+                  style={{
+                    fontSize: 13,
+                    color: "var(--color-text-primary)",
+                  }}
+                >
+                  {item.label}
+                </div>
+                <div style={{ fontSize: 11, color: "var(--color-text-muted)" }}>
+                  {item.desc}
+                </div>
+              </div>
+              {item.active && (
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    color: "var(--color-text-muted)",
+                  }}
+                >
+                  ↵
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ height: 180 }} />
+    </div>
+  );
+}
+
+function OrganizationSection() {
+  return (
+    <SectionShell
+      reverse
+      accent
+      num="02 / Organization"
+      eyebrow="A tree that knows its edges"
+      title="Nest forever. Rename at will. Nothing breaks."
+      body="Move a page, rename a page, demote a page — Marrow updates every link that points to it. The bone structure holds."
+    >
+      <TreeDemo />
+    </SectionShell>
+  );
+}
+
+function TreeDemo() {
+  interface RowProps {
+    depth?: number;
+    icon?: React.ComponentType<{ size?: number; style?: React.CSSProperties }>;
+    label: string;
+    muted?: boolean;
+    active?: boolean;
+    dragging?: boolean;
+    dropTarget?: boolean;
+  }
+
+  function Row({
+    depth = 0,
+    icon: I = IconPage,
+    label,
+    muted,
+    active,
+    dragging,
+    dropTarget,
+  }: RowProps) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "5px 10px",
+          paddingLeft: 10 + depth * 16,
+          borderRadius: 6,
+          fontSize: 13,
+          color: active
+            ? "var(--color-text-primary)"
+            : muted
+              ? "var(--color-text-muted)"
+              : "var(--color-text-secondary)",
+          background: active
+            ? "color-mix(in oklab, var(--color-accent) 14%, transparent)"
+            : dropTarget
+              ? "color-mix(in oklab, var(--color-accent) 8%, transparent)"
+              : "transparent",
+          border: dropTarget
+            ? "1px dashed var(--color-accent)"
+            : "1px solid transparent",
+          opacity: dragging ? 0.5 : 1,
+        }}
+      >
+        <I
+          size={13}
+          style={{
+            color: active ? "var(--color-accent)" : "var(--color-text-muted)",
+          }}
+        />
+        <span>{label}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        background: "var(--color-base)",
+        border: "1px solid var(--color-border)",
+        borderRadius: 14,
+        padding: "18px 14px",
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 10,
+          textTransform: "uppercase",
+          letterSpacing: "0.1em",
+          color: "var(--color-text-muted)",
+          padding: "6px 10px 12px",
+        }}
+      >
+        Engineering
+      </div>
+      <Row icon={IconFolder} label="Runbooks" />
+      <Row depth={1} label="Ingest — on-call" />
+      <Row depth={1} label="Postgres failover" />
+      <Row icon={IconFolder} label="Architecture" active />
+      <Row depth={1} label="RFC-0141 — Write path" />
+      <Row depth={1} label="RFC-0142 — Ingest v2" dragging />
+      <Row depth={1} label="Q2 planning" dropTarget />
+      <Row depth={1} label="Postmortems" muted />
+      <Row depth={2} label="2025-11-04 · saturation" />
+      <Row icon={IconFolder} label="Onboarding" />
+      <div
+        style={{
+          padding: "12px 10px 4px",
+          borderTop: "1px solid var(--color-border)",
+          marginTop: 10,
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          color: "var(--color-accent)",
+        }}
+      >
+        <IconLink size={11} /> 4 backlinks updated automatically
+      </div>
+    </div>
+  );
+}
+
+function SearchSection() {
+  const results = [
+    {
+      title: "RFC-0142 — Ingest v2",
+      path: "engineering / architecture",
+      snip: "Adds <em>backpressure</em> shedding at the writer boundary…",
+      active: true,
+    },
+    {
+      title: "Postmortem 2025-11-04",
+      path: "engineering / postmortems",
+      snip: "Saturation caused by absent <em>backpressure</em>…",
+    },
+    {
+      title: "Runbook / Ingest on-call",
+      path: "engineering / runbooks",
+      snip: "Step 3 — verify <em>backpressure</em> signal reaches the writer…",
+    },
+  ];
+
+  return (
+    <SectionShell
+      num="03 / Search"
+      eyebrow="Cmd+K is the navigation"
+      title="One field. Everything in it."
+      body="Full-text across pages, attachments, comments, and revisions. Ranked by what you've touched lately, not by who pays for placement."
+    >
+      <div
+        style={{
+          background: "var(--color-surface-elevated)",
+          border: "1px solid var(--color-border)",
+          borderRadius: 14,
+          padding: 6,
+          width: "100%",
+          maxWidth: 560,
+          boxShadow: "0 30px 60px -30px rgba(0,0,0,0.5)",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "14px 16px",
+            borderBottom: "1px solid var(--color-border)",
+          }}
+        >
+          <IconSearch size={16} style={{ color: "var(--color-text-muted)" }} />
+          <span
+            style={{ fontSize: 15, color: "var(--color-text-primary)" }}
+          >
+            backpressure
+          </span>
+          <span
+            style={{
+              width: 2,
+              height: 16,
+              background: "var(--color-accent)",
+            }}
+          />
+          <span style={{ flex: 1 }} />
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              color: "var(--color-text-muted)",
+            }}
+          >
+            8 results · 12ms
+          </span>
+        </div>
+
+        <div style={{ padding: 6 }}>
+          {results.map((r, i) => (
+            <div
+              key={i}
+              style={{
+                padding: "12px 14px",
+                borderRadius: 8,
+                background: r.active
+                  ? "color-mix(in oklab, var(--color-accent) 12%, transparent)"
+                  : "transparent",
+                marginBottom: 2,
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <IconPage
+                  size={13}
+                  style={{
+                    color: r.active
+                      ? "var(--color-accent)"
+                      : "var(--color-text-muted)",
+                  }}
+                />
+                <span
+                  style={{
+                    fontSize: 14,
+                    color: "var(--color-text-primary)",
+                  }}
+                >
+                  {r.title}
+                </span>
+                <span style={{ flex: 1 }} />
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    color: "var(--color-text-muted)",
+                  }}
+                >
+                  {r.path}
+                </span>
+              </div>
+              <div
+                style={{
+                  fontSize: 12,
+                  color: "var(--color-text-secondary)",
+                  marginTop: 6,
+                  lineHeight: 1.55,
+                  paddingLeft: 21,
+                }}
+                dangerouslySetInnerHTML={{
+                  __html: r.snip
+                    .replace(
+                      /<em>/g,
+                      '<em style="font-style:normal;color:var(--color-accent);background:color-mix(in oklab, var(--color-accent) 20%, transparent);padding:0 3px;border-radius:3px">'
+                    )
+                    .replace(/<\/em>/g, "</em>"),
+                }}
+              />
+            </div>
+          ))}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            gap: 16,
+            padding: "10px 16px",
+            borderTop: "1px solid var(--color-border)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <span>↑↓ navigate</span>
+          <span>↵ open</span>
+          <span>⌘↵ open in pane</span>
+          <span style={{ marginLeft: "auto" }}>esc</span>
+        </div>
+      </div>
+    </SectionShell>
+  );
+}
+
+function HistorySection() {
+  return (
+    <SectionShell
+      reverse
+      accent
+      num="04 / History"
+      eyebrow="Every keystroke, diffable"
+      title="Go back. Not far, not much, just enough."
+      body="A quiet autosave every ten seconds. Named checkpoints when you publish. Side-by-side diffs when you need to know what you broke."
+    >
+      <div
+        style={{
+          background: "var(--color-base)",
+          border: "1px solid var(--color-border)",
+          borderRadius: 14,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{ display: "flex", borderBottom: "1px solid var(--color-border)" }}
+        >
+          <div
+            style={{
+              flex: 1,
+              padding: "10px 16px",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              color: "var(--color-text-muted)",
+              borderRight: "1px solid var(--color-border)",
+            }}
+          >
+            <IconClock size={11} style={{ verticalAlign: -1, marginRight: 6 }} />
+            Nov 04 · 02:41 · Maya
+          </div>
+          <div
+            style={{
+              flex: 1,
+              padding: "10px 16px",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+              color: "var(--color-accent)",
+            }}
+          >
+            <IconClock size={11} style={{ verticalAlign: -1, marginRight: 6 }} />
+            Nov 04 · 09:12 · Maya · current
+          </div>
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr" }}>
+          <div
+            style={{
+              padding: "20px 22px",
+              borderRight: "1px solid var(--color-border)",
+              fontSize: 13,
+              lineHeight: 1.7,
+              color: "var(--color-text-secondary)",
+            }}
+          >
+            <span
+              style={{
+                background: "color-mix(in oklab, #dc2626 22%, transparent)",
+                padding: "2px 4px",
+                borderRadius: 3,
+              }}
+            >
+              Queue depth climbed past 40k
+            </span>
+            . Retries stacked, the writer dropped. Alerts fired after 90s.
+          </div>
+          <div
+            style={{
+              padding: "20px 22px",
+              fontSize: 13,
+              lineHeight: 1.7,
+              color: "var(--color-text-secondary)",
+            }}
+          >
+            <span
+              style={{
+                background: "color-mix(in oklab, #34d399 22%, transparent)",
+                padding: "2px 4px",
+                borderRadius: 3,
+              }}
+            >
+              Queue depth climbed past 40k at 02:14 UTC
+            </span>
+            . Retries stacked, the writer started dropping, alerts fired 90
+            seconds later.
+          </div>
+        </div>
+
+        <div
+          style={{
+            padding: "14px 18px",
+            borderTop: "1px solid var(--color-border)",
+            background: "var(--color-surface)",
+            display: "flex",
+            gap: 20,
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <span>+12 words</span>
+          <span>-3 words</span>
+          <span style={{ color: "var(--color-accent)" }}>revert to left</span>
+        </div>
+      </div>
+    </SectionShell>
+  );
+}
+
+function IntegrationsStrip() {
+  const items = [
+    "Slack",
+    "GitHub",
+    "Linear",
+    "Notion import",
+    "Confluence import",
+    "Obsidian vault",
+    "Google SSO",
+    "Okta",
+    "S3 backups",
+    "Webhooks",
+    "REST API",
+    "CLI",
+  ];
+
+  return (
+    <section
+      style={{ padding: "96px 32px", background: "var(--color-base)" }}
+    >
+      <div
+        style={{ maxWidth: 1100, margin: "0 auto", textAlign: "center" }}
+      >
+        <Eyebrow>Integrations</Eyebrow>
+        <h2
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: 36,
+            marginTop: 12,
+            fontVariationSettings: '"SOFT" 60',
+            color: "var(--color-text-primary)",
+          }}
+        >
+          Speaks the protocols you already run.
+        </h2>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 10,
+            justifyContent: "center",
+            marginTop: 40,
+          }}
+        >
+          {items.map((item) => (
+            <span
+              key={item}
+              style={{
+                padding: "10px 18px",
+                border: "1px solid var(--color-border)",
+                borderRadius: 999,
+                fontSize: 13,
+                color: "var(--color-text-secondary)",
+                background: "var(--color-surface)",
+              }}
+            >
+              {item}
+            </span>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ProductFinalCTA() {
+  return (
+    <section
+      style={{
+        background: "var(--color-cream)",
+        color: "#2b2017",
+        padding: "112px 32px",
+      }}
+    >
+      <div style={{ maxWidth: 900, margin: "0 auto", textAlign: "center" }}>
+        <h2
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: "clamp(36px, 5vw, 56px)",
+            fontVariationSettings: '"SOFT" 80',
+            lineHeight: 1.05,
+            color: "#2b2017",
+          }}
+        >
+          See it running.{" "}
+          <em
+            style={{
+              color: "#9a3412",
+              fontStyle: "italic",
+              fontVariationSettings: '"SOFT" 100, "WONK" 1',
+            }}
+          >
+            Right now.
+          </em>
+        </h2>
+        <p
+          style={{
+            fontSize: 17,
+            marginTop: 24,
+            color: "#4a3a2c",
+            maxWidth: 540,
+            margin: "24px auto 0",
+          }}
+        >
+          The full app ships preloaded with sample content. No account, no
+          download, no waiting.
+        </p>
+        <div
+          style={{
+            marginTop: 36,
+            display: "flex",
+            gap: 12,
+            justifyContent: "center",
+          }}
+        >
+          <MarketingButton variant="creamPrimary" size="lg" href="/app">
+            Open the demo <IconArrow size={15} />
+          </MarketingButton>
+          <MarketingButton variant="creamSecondary" size="lg" href="/pricing">
+            See pricing
+          </MarketingButton>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web-marketing/components/chrome.tsx
+++ b/web-marketing/components/chrome.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useTheme } from "next-themes";
+import { MarrowWordmark, IconSun, IconMoon } from "@/components/icons";
+
+const NAV_LINKS = [
+  { href: "/", label: "Home" },
+  { href: "/product", label: "Product" },
+  { href: "/pricing", label: "Pricing" },
+];
+
+export function SiteNav() {
+  const pathname = usePathname();
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <header
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 40,
+        background: "color-mix(in oklab, var(--color-base) 88%, transparent)",
+        backdropFilter: "blur(12px)",
+        WebkitBackdropFilter: "blur(12px)",
+        borderBottom: "1px solid var(--color-border)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 1400,
+          margin: "0 auto",
+          padding: "14px 32px",
+          display: "flex",
+          alignItems: "center",
+          gap: 24,
+        }}
+      >
+        <Link
+          href="/"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            color: "var(--color-text-primary)",
+          }}
+        >
+          <MarrowWordmark size={19} />
+        </Link>
+
+        <nav style={{ display: "flex", gap: 2, marginLeft: 8 }}>
+          {NAV_LINKS.map((link) => {
+            const active = pathname === link.href;
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                style={{
+                  padding: "7px 14px",
+                  borderRadius: 8,
+                  fontSize: 14,
+                  color: active
+                    ? "var(--color-text-primary)"
+                    : "var(--color-text-secondary)",
+                  background: active ? "var(--color-surface)" : "transparent",
+                  transition: "background 120ms, color 120ms",
+                }}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <div style={{ flex: 1 }} />
+
+        <button
+          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+          title={theme === "dark" ? "Switch to light" : "Switch to dark"}
+          style={{
+            width: 34,
+            height: 34,
+            borderRadius: 8,
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "var(--color-text-secondary)",
+            border: "1px solid var(--color-border)",
+            background: "transparent",
+            cursor: "pointer",
+          }}
+        >
+          {theme === "dark" ? <IconSun size={15} /> : <IconMoon size={15} />}
+        </button>
+
+        <Link
+          href="/login"
+          style={{
+            fontSize: 14,
+            color: "var(--color-text-secondary)",
+          }}
+        >
+          Sign in
+        </Link>
+
+        <Link
+          href="/app"
+          style={{
+            padding: "8px 16px",
+            borderRadius: 8,
+            fontSize: 14,
+            fontWeight: 500,
+            background: "var(--color-accent)",
+            color: "var(--color-accent-ink)",
+            display: "inline-block",
+          }}
+        >
+          Open Marrow
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+export function SiteFooter() {
+  return (
+    <footer
+      style={{
+        borderTop: "1px solid var(--color-border)",
+        padding: "48px 32px",
+        background: "var(--color-base)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 1200,
+          margin: "0 auto",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 24,
+        }}
+      >
+        <MarrowWordmark size={16} />
+        <div
+          style={{
+            display: "flex",
+            gap: 24,
+            fontSize: 13,
+            color: "var(--color-text-muted)",
+          }}
+        >
+          <Link href="/product">Product</Link>
+          <Link href="/pricing">Pricing</Link>
+          <a
+            href="https://github.com/spmcgraw/marrow"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub
+          </a>
+          <Link href="/docs">Docs</Link>
+        </div>
+        <span style={{ fontSize: 12, color: "var(--color-text-muted)" }}>
+          Apache 2.0 · Self-hosted
+        </span>
+      </div>
+    </footer>
+  );
+}
+
+export function Eyebrow({
+  children,
+  style,
+}: {
+  children: React.ReactNode;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: 11,
+        letterSpacing: "0.14em",
+        textTransform: "uppercase",
+        color: "var(--color-accent)",
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "ghost"
+  | "creamPrimary"
+  | "creamSecondary";
+type ButtonSize = "sm" | "md" | "lg";
+
+const SIZES: Record<ButtonSize, React.CSSProperties> = {
+  sm: { padding: "7px 14px", fontSize: 13 },
+  md: { padding: "11px 20px", fontSize: 14 },
+  lg: { padding: "14px 24px", fontSize: 15 },
+};
+
+const VARIANTS: Record<ButtonVariant, React.CSSProperties> = {
+  primary: {
+    background: "var(--color-accent)",
+    color: "var(--color-accent-ink)",
+    border: "1px solid var(--color-accent)",
+  },
+  secondary: {
+    background: "transparent",
+    color: "var(--color-text-primary)",
+    border: "1px solid var(--color-border)",
+  },
+  ghost: {
+    background: "transparent",
+    color: "var(--color-text-primary)",
+    border: "1px solid transparent",
+  },
+  creamPrimary: {
+    background: "#2b2017",
+    color: "var(--color-cream)",
+    border: "1px solid #2b2017",
+  },
+  creamSecondary: {
+    background: "transparent",
+    color: "#2b2017",
+    border: "1px solid #2b2017",
+  },
+};
+
+export function MarketingButton({
+  children,
+  variant = "primary",
+  size = "md",
+  onClick,
+  href,
+  style,
+}: {
+  children: React.ReactNode;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  onClick?: () => void;
+  href?: string;
+  style?: React.CSSProperties;
+}) {
+  const buttonStyle: React.CSSProperties = {
+    ...SIZES[size],
+    ...VARIANTS[variant],
+    borderRadius: 8,
+    fontWeight: 500,
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 8,
+    cursor: "pointer",
+    transition: "transform 120ms, filter 120ms",
+    ...style,
+  };
+
+  if (href) {
+    return (
+      <Link href={href} style={buttonStyle}>
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <button onClick={onClick} style={buttonStyle}>
+      {children}
+    </button>
+  );
+}

--- a/web-marketing/components/icons.tsx
+++ b/web-marketing/components/icons.tsx
@@ -1,0 +1,224 @@
+import type { CSSProperties, SVGProps } from "react";
+
+interface IconProps extends SVGProps<SVGSVGElement> {
+  size?: number;
+  style?: CSSProperties;
+}
+
+function Icon({ size = 16, children, style, ...rest }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ flexShrink: 0, ...style }}
+      {...rest}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export const IconSearch = (p: IconProps) => (
+  <Icon {...p}>
+    <circle cx="11" cy="11" r="7" />
+    <path d="m21 21-4.3-4.3" />
+  </Icon>
+);
+export const IconPlus = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M12 5v14M5 12h14" />
+  </Icon>
+);
+export const IconChevR = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="m9 6 6 6-6 6" />
+  </Icon>
+);
+export const IconChevD = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="m6 9 6 6 6-6" />
+  </Icon>
+);
+export const IconCheck = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M20 6 9 17l-5-5" />
+  </Icon>
+);
+export const IconX = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M18 6 6 18M6 6l12 12" />
+  </Icon>
+);
+export const IconArrow = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M5 12h14M13 6l6 6-6 6" />
+  </Icon>
+);
+export const IconPage = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" />
+    <path d="M14 3v6h6" />
+  </Icon>
+);
+export const IconFolder = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M3 6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+  </Icon>
+);
+export const IconHome = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="m3 11 9-8 9 8" />
+    <path d="M5 10v10h14V10" />
+  </Icon>
+);
+export const IconInbox = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M22 12h-6l-2 3h-4l-2-3H2" />
+    <path d="M5.5 5.5 3 12v6a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-6l-2.5-6.5A2 2 0 0 0 16.6 4H7.4a2 2 0 0 0-1.9 1.5z" />
+  </Icon>
+);
+export const IconStar = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="m12 3 2.8 6.1 6.7.6-5 4.5 1.5 6.5L12 17.3 5.9 20.7l1.5-6.5-5-4.5 6.7-.6z" />
+  </Icon>
+);
+export const IconSettings = (p: IconProps) => (
+  <Icon {...p}>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 0 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 0 1 0-4h.1A1.7 1.7 0 0 0 4.6 9a1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h0a1.7 1.7 0 0 0 1-1.5V3a2 2 0 0 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v0a1.7 1.7 0 0 0 1.5 1H21a2 2 0 0 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" />
+  </Icon>
+);
+export const IconLink = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.8 1.7" />
+    <path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7L12.3 19" />
+  </Icon>
+);
+export const IconClock = (p: IconProps) => (
+  <Icon {...p}>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7v5l3 2" />
+  </Icon>
+);
+export const IconHash = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M4 9h16M4 15h16M10 3 8 21M16 3l-2 18" />
+  </Icon>
+);
+export const IconGlobe = (p: IconProps) => (
+  <Icon {...p}>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M3 12h18M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18z" />
+  </Icon>
+);
+export const IconShield = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M12 3 4 6v6c0 5 3.5 8 8 9 4.5-1 8-4 8-9V6z" />
+  </Icon>
+);
+export const IconBolt = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M13 2 4 14h7l-1 8 9-12h-7z" />
+  </Icon>
+);
+export const IconMoon = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+  </Icon>
+);
+export const IconSun = (p: IconProps) => (
+  <Icon {...p}>
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+  </Icon>
+);
+export const IconMenu = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M4 6h16M4 12h16M4 18h16" />
+  </Icon>
+);
+export const IconQuote = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="M3 21c3 0 6-2 6-8V5H3v8h3c0 3-1 5-3 5zM15 21c3 0 6-2 6-8V5h-6v8h3c0 3-1 5-3 5z" />
+  </Icon>
+);
+export const IconCode = (p: IconProps) => (
+  <Icon {...p}>
+    <path d="m16 18 6-6-6-6M8 6l-6 6 6 6" />
+  </Icon>
+);
+
+export const MarrowGlyph = ({
+  size = 24,
+  style,
+}: {
+  size?: number;
+  style?: CSSProperties;
+}) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 32 32"
+    style={style}
+    aria-hidden="true"
+  >
+    <rect
+      x="1.5"
+      y="1.5"
+      width="29"
+      height="29"
+      rx="6"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M7 23 V10 L11 10 L16 17 L21 10 L25 10 V23"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <circle cx="16" cy="20.5" r="1.6" fill="currentColor" />
+  </svg>
+);
+
+export const MarrowWordmark = ({
+  size = 22,
+  style,
+  showGlyph = true,
+}: {
+  size?: number;
+  style?: CSSProperties;
+  showGlyph?: boolean;
+}) => (
+  <div
+    style={{
+      display: "inline-flex",
+      alignItems: "center",
+      gap: 10,
+      color: "currentColor",
+      ...style,
+    }}
+  >
+    {showGlyph && <MarrowGlyph size={size + 4} />}
+    <span
+      style={{
+        fontFamily: "var(--font-display)",
+        fontSize: size,
+        fontWeight: 400,
+        letterSpacing: "-0.02em",
+        fontVariationSettings: '"SOFT" 30, "WONK" 0',
+      }}
+    >
+      marrow
+    </span>
+  </div>
+);

--- a/web-marketing/components/theme-provider.tsx
+++ b/web-marketing/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ComponentProps } from "react";
+
+export function ThemeProvider({
+  children,
+  ...props
+}: ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/web-marketing/next.config.ts
+++ b/web-marketing/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/web-marketing/package.json
+++ b/web-marketing/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "web-marketing",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3001",
+    "build": "next build",
+    "start": "next start --port 3001",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^16.2.4",
+    "next-themes": "^0.4.6",
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@types/node": "^24",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "tailwindcss": "^4",
+    "typescript": "^5"
+  }
+}

--- a/web-marketing/postcss.config.mjs
+++ b/web-marketing/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/web-marketing/tsconfig.json
+++ b/web-marketing/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Implements #97.

## What's included

- **`web-marketing/` app scaffold** (bootstrapped ahead of #95 since it's in a later batch): package.json, next.config.ts, tsconfig.json, postcss.config.mjs
- **Design tokens** (`app/globals.css`): full `--color-*` set for both dark (primary) and light modes, matching `references/design-tokens.md`
- **Fonts** (`app/layout.tsx`): Fraunces with `opsz`, `SOFT`, `WONK` axes via `next/font/google`; Inter; JetBrains Mono; `next-themes` ThemeProvider
- **`components/icons.tsx`**: all icon primitives + `MarrowGlyph` / `MarrowWordmark` ported from `icons.jsx`
- **`components/chrome.tsx`**: `SiteNav` (sticky, blur backdrop), `SiteFooter`, `Eyebrow`, `MarketingButton` (primary / secondary / ghost / creamPrimary / creamSecondary) ported from `chrome.jsx`
- **`app/product/page.tsx`**: four-section product tour ported faithfully from `product.jsx`:
  - **01 / Editor** — slash-command demo with active item highlight
  - **02 / Organization** — tree with drag/drop visual, backlink count
  - **03 / Search** — Cmd+K results mock with highlighted matches
  - **04 / History** — side-by-side diff with add/remove coloring
  - IntegrationsStrip + cream-background final CTA

_Created by swarm coordinator_