### PR TITLE
feat: #59 2.2a: Cloudflare R2 storage adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Current status: **v0.1 MVP** — core hierarchy, append-only revisions, export/r
 - **Auth**: OIDC authentication (any IdP) with API key fallback — see `api/marrow/auth.py`
 - **Search**: PostgreSQL full-text search; Meilisearch/OpenSearch later
 - **Frontend**: Next.js 16 (React 19), located in `web/`
-- **Storage**: Pluggable adapter interface — local filesystem is the only current implementation
+- **Storage**: Pluggable adapter interface — `LocalFilesystemAdapter` (default) and `R2StorageAdapter` (Cloudflare R2, gated by `STORAGE_BACKEND=r2`)
 - **CLI**: Typer (`marrow export` / `marrow restore`)
 
 ---
@@ -60,6 +60,13 @@ SECRET_KEY=changeme
 STORAGE_PATH=./storage       # resolves relative to api/ directory
 API_KEY=                     # optional; if set, enforces X-API-Key header on all routes
 CORS_ORIGINS=http://localhost:3000
+
+# Cloudflare R2 storage (SaaS / Cloud only — set STORAGE_BACKEND=r2 to activate)
+# STORAGE_BACKEND=r2         # default: "local" (LocalFilesystemAdapter)
+# R2_ACCOUNT_ID=             # Cloudflare account ID; endpoint = https://{id}.r2.cloudflarestorage.com
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=
+# R2_BUCKET=
 
 # OIDC Authentication (optional — omit OIDC_ISSUER to disable)
 # OIDC_ISSUER=https://accounts.google.com

--- a/api/.env.example
+++ b/api/.env.example
@@ -8,6 +8,13 @@ SECRET_KEY=changeme
 # Relative paths resolve from the api/ directory; absolute paths also work.
 STORAGE_PATH=./storage
 
+# Cloudflare R2 storage (SaaS / Cloud only — set STORAGE_BACKEND=r2 to activate)
+# STORAGE_BACKEND=r2
+# R2_ACCOUNT_ID=
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=
+# R2_BUCKET=
+
 # API key authentication (optional — omit to allow anonymous access in dev)
 # API_KEY=
 

--- a/api/marrow/storage.py
+++ b/api/marrow/storage.py
@@ -38,7 +38,7 @@ class LocalFilesystemAdapter(StorageAdapter):
 class R2StorageAdapter(StorageAdapter):
     """Reads/writes attachments in a Cloudflare R2 bucket (S3-compatible API).
 
-    Set STORAGE_BACKEND=r2 plus R2_ENDPOINT_URL, R2_ACCESS_KEY_ID,
+    Set STORAGE_BACKEND=r2 plus R2_ACCOUNT_ID, R2_ACCESS_KEY_ID,
     R2_SECRET_ACCESS_KEY, and R2_BUCKET to use this adapter.
     """
 
@@ -76,8 +76,9 @@ class R2StorageAdapter(StorageAdapter):
 def get_default_adapter() -> StorageAdapter:
     backend = os.getenv("STORAGE_BACKEND", "local").lower()
     if backend == "r2":
+        account_id = os.environ["R2_ACCOUNT_ID"]
         return R2StorageAdapter(
-            endpoint_url=os.environ["R2_ENDPOINT_URL"],
+            endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
             access_key_id=os.environ["R2_ACCESS_KEY_ID"],
             secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
             bucket=os.environ["R2_BUCKET"],


### PR DESCRIPTION
Implements #59.

## Changes

- Updated `get_default_adapter()` in `api/marrow/storage.py` to construct the R2 endpoint URL from `R2_ACCOUNT_ID` (as specified in the issue: `https://{R2_ACCOUNT_ID}.r2.cloudflarestorage.com`) rather than requiring the full URL via `R2_ENDPOINT_URL`
- Documented all R2 env vars in `api/.env.example`: `STORAGE_BACKEND`, `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`
- Updated `CLAUDE.md` env vars section and Tech Stack entry to reflect R2 support
- `boto3` and `moto[s3]` were already present in `pyproject.toml`

_Created by swarm coordinator_