### PR TITLE
feat: #129 2.0g: Workspace auto-create + creation UX

### DIFF
--- a/api/marrow/routers/organizations.py
+++ b/api/marrow/routers/organizations.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..dependencies import AuthContext, get_db, verify_auth
-from ..models import Organization, OrgMembership, OrgRole, User
+from ..models import Organization, OrgMembership, OrgRole, User, Workspace
 from ..rbac import require_org_role
 from ..schemas import (
     OrganizationCreate,
@@ -16,6 +16,8 @@ from ..schemas import (
     OrgMembershipCreate,
     OrgMembershipRead,
     OrgMembershipUpdate,
+    WorkspaceCreate,
+    WorkspaceRead,
 )
 from .billing import TIER_SEAT_LIMITS, _saas_mode
 
@@ -169,6 +171,27 @@ def update_member_role(
     db.commit()
     db.refresh(membership)
     return membership
+
+
+@router.post("/{org_id}/workspaces", response_model=WorkspaceRead, status_code=201)
+def create_workspace_in_org(
+    org_id: UUID,
+    body: WorkspaceCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_org_role(OrgRole.EDITOR)),
+):
+    """Create a workspace inside an org. Requires editor or owner role."""
+    from sqlalchemy.exc import IntegrityError
+
+    ws = Workspace(org_id=org_id, slug=body.slug, name=body.name)
+    db.add(ws)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail=f"Workspace slug '{body.slug}' already exists")
+    db.refresh(ws)
+    return ws
 
 
 @router.delete("/{org_id}/members/{membership_id}", status_code=204)

--- a/api/marrow/routers/workspaces.py
+++ b/api/marrow/routers/workspaces.py
@@ -11,7 +11,6 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..dependencies import AuthContext, get_db, get_search_backend, verify_auth
@@ -22,7 +21,6 @@ from ..schemas import (
     SearchResponse,
     SearchResultItem,
     SpaceTreeItem,
-    WorkspaceCreate,
     WorkspaceRead,
     WorkspaceTree,
 )
@@ -79,38 +77,13 @@ def list_workspaces(
     )
 
 
-@router.post("", response_model=WorkspaceRead, status_code=201)
-def create_workspace(
-    body: WorkspaceCreate,
-    db: Session = Depends(get_db),
-    auth: AuthContext = Depends(verify_auth),
-):
-    org_id = body.org_id
-
-    # For session users without explicit org_id, use their first org
-    if org_id is None and auth.user_id is not None:
-        membership = db.execute(
-            select(OrgMembership)
-            .where(OrgMembership.user_id == auth.user_id)
-            .order_by(OrgMembership.created_at)
-        ).scalar_one_or_none()
-        if membership is None:
-            raise HTTPException(403, "You must belong to an organization to create a workspace")
-        org_id = membership.org_id
-
-    # For API key/anonymous, org_id is required
-    if org_id is None:
-        raise HTTPException(422, "org_id is required for API key or anonymous access")
-
-    ws = Workspace(org_id=org_id, slug=body.slug, name=body.name)
-    db.add(ws)
-    try:
-        db.commit()
-    except IntegrityError:
-        db.rollback()
-        raise HTTPException(status_code=409, detail=f"Workspace slug '{body.slug}' already exists")
-    db.refresh(ws)
-    return ws
+@router.post("", status_code=410)
+def create_workspace_deprecated():
+    """Deprecated. Use POST /api/orgs/{org_id}/workspaces instead."""
+    raise HTTPException(
+        status_code=410,
+        detail="This endpoint has moved. Use POST /api/orgs/{org_id}/workspaces.",
+    )
 
 
 @router.post("/restore", response_model=WorkspaceRead, status_code=201)

--- a/web/app/workspaces/page.tsx
+++ b/web/app/workspaces/page.tsx
@@ -18,19 +18,25 @@ export default function WorkspacesPage() {
   const [auth, setAuth] = useState<AuthStatus | null>(null);
   const [name, setName] = useState("");
   const [creating, setCreating] = useState(false);
+  const [activeOrgId, setActiveOrgId] = useState<string | null>(null);
 
   useEffect(() => {
     listWorkspaces().then(setWorkspaces).catch(() => toast.error("Failed to load workspaces"));
-    listOrgs().then(setOrgs).catch(() => {});
+    listOrgs().then((orgs) => {
+      setOrgs(orgs);
+      if (orgs.length > 0) setActiveOrgId(orgs[0].id);
+    }).catch(() => {});
     getAuthStatus().then(setAuth).catch(() => {});
   }, []);
 
+  const activeOrg = orgs.find((o) => o.id === activeOrgId) ?? orgs[0] ?? null;
+
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
-    if (!name.trim()) return;
+    if (!name.trim() || !activeOrg) return;
     setCreating(true);
     try {
-      const ws = await createWorkspace(slugify(name), name.trim());
+      const ws = await createWorkspace(activeOrg.id, slugify(name), name.trim());
       router.push(`/w/${ws.id}`);
     } catch (err) {
       toast.error(String(err));
@@ -113,7 +119,26 @@ export default function WorkspacesPage() {
         )}
 
         {/* Create workspace */}
-        <div className="rounded-lg border bg-card p-4">
+        <div className="rounded-lg border bg-card p-4 space-y-3">
+          {orgs.length > 1 && activeOrg && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span>Creating workspace in</span>
+              <select
+                className="rounded border bg-background px-2 py-1 text-sm font-medium text-foreground"
+                value={activeOrgId ?? ""}
+                onChange={(e) => setActiveOrgId(e.target.value)}
+              >
+                {orgs.map((o) => (
+                  <option key={o.id} value={o.id}>{o.name}</option>
+                ))}
+              </select>
+            </div>
+          )}
+          {orgs.length === 1 && activeOrg && (
+            <p className="text-xs text-muted-foreground">
+              Creating workspace in <span className="font-semibold">{activeOrg.name}</span>
+            </p>
+          )}
           <form onSubmit={handleCreate} className="flex gap-2">
             <Input
               placeholder="New workspace name"
@@ -121,7 +146,7 @@ export default function WorkspacesPage() {
               onChange={(e) => setName(e.target.value)}
               disabled={creating}
             />
-            <Button type="submit" disabled={creating || !name.trim()}>
+            <Button type="submit" disabled={creating || !name.trim() || !activeOrg}>
               Create
             </Button>
           </form>

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -78,8 +78,8 @@ export function listWorkspaces(): Promise<Workspace[]> {
   return apiFetch("/api/workspaces");
 }
 
-export function createWorkspace(slug: string, name: string): Promise<Workspace> {
-  return apiFetch("/api/workspaces", {
+export function createWorkspace(orgId: string, slug: string, name: string): Promise<Workspace> {
+  return apiFetch(`/api/orgs/${orgId}/workspaces`, {
     method: "POST",
     body: JSON.stringify({ slug, name }),
   });


### PR DESCRIPTION
Implements #129.

## Changes

**Backend:**
- Added `POST /api/orgs/{org_id}/workspaces` — requires editor or owner org role; org resolved from path param so the request body needs no `org_id`
- Deprecated `POST /api/workspaces` — now returns 410 Gone with a pointer to the new route

**Frontend:**
- `createWorkspace()` in `api.ts` now takes `orgId` and posts to `/api/orgs/{org_id}/workspaces`
- Workspace creation form shows current org as context (label for single-org users, dropdown switcher for multi-org users); no `org_id` field exposed to the user
- After creation the user is navigated directly into the new workspace

## Acceptance criteria
- [x] `POST /api/orgs/{org_id}/workspaces` route exists; old `POST /api/workspaces` returns 410 Gone
- [x] RBAC: must be org owner OR org editor to create
- [x] Frontend form has no `org_id` field; shows current-org context for multi-org users
- [x] Newly created workspace becomes the active workspace (router.push into it)

_Created by swarm coordinator_