### PR TITLE
feat: #126 2.0d: Soft-delete & trash

### DIFF
--- a/api/marrow/cli.py
+++ b/api/marrow/cli.py
@@ -89,5 +89,38 @@ def restore(
         raise typer.Exit(1)
 
 
+@app.command("purge-trash")
+def purge_trash(
+    days: int = typer.Option(
+        30, "--days", help="Hard-delete nodes whose deleted_at is older than this many days"
+    ),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="DATABASE_URL", help="PostgreSQL connection URL"
+    ),
+) -> None:
+    """Permanently delete trashed nodes older than the threshold (default 30 days).
+
+    Safe to run repeatedly. Cron recipe (daily at 03:00):
+
+        0 3 * * * /usr/local/bin/marrow purge-trash >> /var/log/marrow-purge.log 2>&1
+    """
+    load_dotenv()
+
+    from sqlalchemy import text
+
+    from .db import get_session
+
+    with get_session(database_url) as session:
+        result = session.execute(
+            text(
+                "DELETE FROM nodes WHERE deleted_at IS NOT NULL "
+                "AND deleted_at < NOW() - make_interval(days => :days)"
+            ),
+            {"days": days},
+        )
+        session.commit()
+        typer.echo(f"Purged {result.rowcount} trashed node(s) older than {days} days")
+
+
 if __name__ == "__main__":
     app()

--- a/api/marrow/routers/nodes.py
+++ b/api/marrow/routers/nodes.py
@@ -6,12 +6,13 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Response, UploadFile
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from ..dependencies import AuthContext, get_db, get_storage
-from ..models import Attachment, Node, OrgRole, Revision, Space
+from ..dependencies import AuthContext, get_db, get_storage, verify_auth
+from ..models import Attachment, Node, OrgRole, Revision, Space, Workspace
+from ..rbac import _check_membership as _enforce_membership
 from ..rbac import require_node_role, require_space_role
 from ..schemas import (
     AttachmentRead,
@@ -169,17 +170,79 @@ def delete_node(
     db: Session = Depends(get_db),
     auth: AuthContext = Depends(require_node_role(OrgRole.OWNER)),
 ):
-    node = _node_or_404(node_id, db)
-    now = datetime.now(timezone.utc)
+    _node_or_404(node_id, db)
+    db.execute(
+        text("""
+            WITH RECURSIVE subtree(id) AS (
+                SELECT id FROM nodes WHERE id = :node_id
+                UNION ALL
+                SELECT n.id FROM nodes n
+                JOIN subtree s ON n.parent_id = s.id
+            )
+            UPDATE nodes SET deleted_at = NOW()
+            WHERE id IN (SELECT id FROM subtree) AND deleted_at IS NULL
+        """),
+        {"node_id": node_id},
+    )
+    db.commit()
 
-    def _soft_delete(n: Node) -> None:
-        n.deleted_at = now
-        for child in db.execute(
-            select(Node).where(Node.parent_id == n.id, Node.deleted_at.is_(None))
-        ).scalars():
-            _soft_delete(child)
 
-    _soft_delete(node)
+@router.post("/api/nodes/{node_id}/restore", status_code=200, response_model=NodeRead)
+def restore_node(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(verify_auth),
+):
+    # Allow restoring soft-deleted nodes — bypass require_node_role's 404 on deleted.
+    node = db.get(Node, node_id)
+    if node is None:
+        raise HTTPException(404, "Node not found")
+
+    space = db.get(Space, node.space_id)
+    workspace = db.get(Workspace, space.workspace_id)
+    _enforce_membership(db, workspace.org_id, auth, OrgRole.OWNER)
+
+    if node.deleted_at is None:
+        raise HTTPException(422, "Node is not trashed")
+
+    if node.parent_id is not None:
+        parent = db.get(Node, node.parent_id)
+        if parent is None or parent.deleted_at is not None:
+            raise HTTPException(422, "Cannot restore: a non-trashed ancestor does not exist")
+
+    db.execute(
+        text("""
+            WITH RECURSIVE subtree(id) AS (
+                SELECT id FROM nodes WHERE id = :node_id
+                UNION ALL
+                SELECT n.id FROM nodes n
+                JOIN subtree s ON n.parent_id = s.id
+            )
+            UPDATE nodes SET deleted_at = NULL
+            WHERE id IN (SELECT id FROM subtree) AND deleted_at IS NOT NULL
+        """),
+        {"node_id": node_id},
+    )
+    db.commit()
+    db.refresh(node)
+    return node
+
+
+@router.delete("/api/nodes/{node_id}/purge", status_code=204)
+def purge_node(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(verify_auth),
+):
+    node = db.get(Node, node_id)
+    if node is None:
+        raise HTTPException(404, "Node not found")
+
+    space = db.get(Space, node.space_id)
+    workspace = db.get(Workspace, space.workspace_id)
+    _enforce_membership(db, workspace.org_id, auth, OrgRole.OWNER)
+
+    db.delete(node)
     db.commit()
 
 

--- a/api/marrow/routers/workspaces.py
+++ b/api/marrow/routers/workspaces.py
@@ -18,6 +18,7 @@ from ..dependencies import AuthContext, get_db, get_search_backend, verify_auth
 from ..models import Node, OrgMembership, OrgRole, Space, Workspace
 from ..rbac import require_workspace_role
 from ..schemas import (
+    NodeRead,
     NodeTreeItem,
     SearchResponse,
     SearchResultItem,
@@ -219,6 +220,41 @@ def search_workspace(
         query=q,
         results=[SearchResultItem(**vars(r)) for r in results],
     )
+
+
+@router.get("/{workspace_id}/trash", response_model=list[NodeRead])
+def list_workspace_trash(
+    workspace_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_workspace_role(OrgRole.VIEWER)),
+):
+    """List top-level trashed nodes — those whose nearest non-trashed ancestor is the space."""
+    ws = db.get(Workspace, workspace_id)
+    if ws is None:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    space_ids_subq = select(Space.id).where(Space.workspace_id == workspace_id).scalar_subquery()
+    parent_alias = Node.__table__.alias("parent")
+
+    # Top-level trashed = node is trashed AND (parent is null OR parent is not trashed).
+    # Using outer join to handle the null-parent case.
+    from sqlalchemy import or_
+
+    nodes = (
+        db.execute(
+            select(Node)
+            .outerjoin(parent_alias, Node.parent_id == parent_alias.c.id)
+            .where(
+                Node.space_id.in_(space_ids_subq),
+                Node.deleted_at.is_not(None),
+                or_(Node.parent_id.is_(None), parent_alias.c.deleted_at.is_(None)),
+            )
+            .order_by(Node.deleted_at.desc())
+        )
+        .scalars()
+        .all()
+    )
+    return nodes
 
 
 @router.get("/{workspace_id}/export/estimate")

--- a/api/tests/test_nodes.py
+++ b/api/tests/test_nodes.py
@@ -299,6 +299,196 @@ class TestDeleteNode:
             client.cookies.clear()
 
 
+class TestTrash:
+    def test_restore_cascades_to_descendants(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "owner-restore@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.OWNER)
+
+            parent = Node(
+                space_id=space.id, type="folder", name="P", slug="p", position="a0"
+            )
+            db.add(parent)
+            db.flush()
+            child = Node(
+                space_id=space.id,
+                parent_id=parent.id,
+                type="page",
+                name="C",
+                slug="c",
+                position="a0",
+            )
+            db.add(child)
+            db.commit()
+
+            _auth_cookie(client, user)
+            assert client.delete(f"/api/nodes/{parent.id}").status_code == 204
+            res = client.post(f"/api/nodes/{parent.id}/restore")
+            assert res.status_code == 200, res.text
+
+            db.expire_all()
+            db.refresh(parent)
+            db.refresh(child)
+            assert parent.deleted_at is None
+            assert child.deleted_at is None
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_restore_orphaned_node_returns_422(self, client):
+        from datetime import datetime, timezone
+
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "owner-orphan@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.OWNER)
+
+            parent = Node(
+                space_id=space.id,
+                type="folder",
+                name="OP",
+                slug="op",
+                position="a0",
+                deleted_at=datetime.now(timezone.utc),
+            )
+            db.add(parent)
+            db.flush()
+            child = Node(
+                space_id=space.id,
+                parent_id=parent.id,
+                type="page",
+                name="OC",
+                slug="oc",
+                position="a0",
+                deleted_at=datetime.now(timezone.utc),
+            )
+            db.add(child)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(f"/api/nodes/{child.id}/restore")
+            assert res.status_code == 422
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_trash_list_returns_top_level_only(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "owner-trashlist@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.OWNER)
+
+            parent = Node(
+                space_id=space.id, type="folder", name="TP", slug="tp", position="a0"
+            )
+            db.add(parent)
+            db.flush()
+            child = Node(
+                space_id=space.id,
+                parent_id=parent.id,
+                type="page",
+                name="TC",
+                slug="tc",
+                position="a0",
+            )
+            db.add(child)
+            db.commit()
+
+            _auth_cookie(client, user)
+            client.delete(f"/api/nodes/{parent.id}")
+
+            res = client.get(f"/api/workspaces/{ws.id}/trash")
+            assert res.status_code == 200
+            ids = {n["id"] for n in res.json()}
+            assert str(parent.id) in ids
+            assert str(child.id) not in ids
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_purge_hard_deletes(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "owner-purge@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.OWNER)
+
+            node = Node(
+                space_id=space.id, type="folder", name="X", slug="x", position="a0"
+            )
+            db.add(node)
+            db.commit()
+            node_id = node.id
+
+            _auth_cookie(client, user)
+            res = client.delete(f"/api/nodes/{node_id}/purge")
+            assert res.status_code == 204
+
+            db.expire_all()
+            assert db.get(Node, node_id) is None
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_purge_trash_cli_respects_threshold(self, client):
+        from datetime import datetime, timedelta, timezone
+
+        from sqlalchemy import text
+
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            org, ws, space = _make_workspace(db)
+            old = Node(
+                space_id=space.id,
+                type="folder",
+                name="Old",
+                slug="old",
+                position="a0",
+                deleted_at=datetime.now(timezone.utc) - timedelta(days=60),
+            )
+            recent = Node(
+                space_id=space.id,
+                type="folder",
+                name="New",
+                slug="new",
+                position="a0",
+                deleted_at=datetime.now(timezone.utc) - timedelta(days=5),
+            )
+            db.add(old)
+            db.add(recent)
+            db.commit()
+            old_id, recent_id = old.id, recent.id
+
+            db.execute(
+                text(
+                    "DELETE FROM nodes WHERE deleted_at IS NOT NULL "
+                    "AND deleted_at < NOW() - make_interval(days => :days)"
+                ),
+                {"days": 30},
+            )
+            db.commit()
+
+            assert db.get(Node, old_id) is None
+            assert db.get(Node, recent_id) is not None
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
 class TestRevisions:
     def test_list_revisions_multiple_entries(self, client):
         from marrow.dependencies import get_db


### PR DESCRIPTION
Closes #126.

## Summary
- Cascade soft-delete on `DELETE /api/nodes/{id}` via recursive CTE in a single transaction
- New `GET /api/workspaces/{id}/trash` — top-level trashed nodes (those whose parent is null or not trashed)
- New `POST /api/nodes/{id}/restore` — cascade-restores subtree; 422 if non-trashed ancestor missing
- New `DELETE /api/nodes/{id}/purge` — owner-only hard-delete
- New `marrow purge-trash` CLI command — hard-deletes trashed nodes older than `--days` (default 30); idempotent
- Test coverage: cascade delete, cascade restore, orphan-restore rejection, trash list filtering, purge endpoint, threshold-respecting purge

_Created by swarm coordinator_