### PR TITLE
feat: #109 2.11: Skip workspace selection: route signed-in users to Home

### DIFF
--- a/web/app/auth/callback/page.tsx
+++ b/web/app/auth/callback/page.tsx
@@ -2,19 +2,28 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { getAuthStatus } from "@/lib/api";
+import { getAuthStatus, listWorkspaces } from "@/lib/api";
 
 export default function AuthCallbackPage() {
   const router = useRouter();
 
   useEffect(() => {
     getAuthStatus()
-      .then((status) => {
-        if (status.authenticated) {
-          router.replace("/workspaces");
-        } else {
+      .then(async (status) => {
+        if (!status.authenticated) {
           router.replace("/login");
+          return;
         }
+        try {
+          const workspaces = await listWorkspaces();
+          if (workspaces.length > 0) {
+            router.replace(`/w/${workspaces[0].id}`);
+            return;
+          }
+        } catch {
+          // fall through to workspace list
+        }
+        router.replace("/workspaces");
       })
       .catch(() => {
         router.replace("/login");

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,17 @@
 import { redirect } from "next/navigation";
+import { listWorkspaces } from "@/lib/api";
 
-// Root always redirects to the workspace list.
-export default function Home() {
+// Root: land signed-in users directly in their workspace. Falls back to
+// /workspaces (create/select screen) when no workspace exists yet.
+export default async function Home() {
+  try {
+    const workspaces = await listWorkspaces();
+    if (workspaces.length > 0) {
+      redirect(`/w/${workspaces[0].id}`);
+    }
+  } catch {
+    // Not authenticated or API error — fall through to /workspaces which
+    // handles both the unauthenticated and empty-workspace states.
+  }
   redirect("/workspaces");
 }


### PR DESCRIPTION
Closes #109.

## Summary
- Root `/` page now fetches workspaces server-side and redirects to the first workspace (`/w/{id}`) instead of `/workspaces`
- OIDC callback page does the same after confirming authentication
- Both fall back to `/workspaces` when no workspace exists yet or on API error — so the create/select screen remains accessible as an edge case

_Created by swarm coordinator_