### PR TITLE
feat: #102 2.8: Starred nodes

### DIFF
--- a/api/alembic/versions/a1b2c3d4e5f6_add_user_stars.py
+++ b/api/alembic/versions/a1b2c3d4e5f6_add_user_stars.py
@@ -1,0 +1,43 @@
+"""add user_stars table
+
+Revision ID: a1b2c3d4e5f6
+Revises: c58f38d0a5aa
+Create Date: 2026-05-13 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "c58f38d0a5aa"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_stars",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("node_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("user_id", "node_id", name="uq_user_stars_user_node"),
+    )
+    op.create_index("idx_user_stars_user", "user_stars", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_user_stars_user", table_name="user_stars")
+    op.drop_table("user_stars")

--- a/api/marrow/app.py
+++ b/api/marrow/app.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from .dependencies import verify_auth
-from .routers import auth, billing, nodes, organizations, spaces, workspaces
+from .routers import auth, billing, nodes, organizations, spaces, stars, workspaces
 
 
 def _truthy(value: str | None) -> bool:
@@ -59,6 +59,7 @@ app.include_router(billing.router)
 app.include_router(workspaces.router, dependencies=_auth)
 app.include_router(spaces.router, dependencies=_auth)
 app.include_router(nodes.router, dependencies=_auth)
+app.include_router(stars.router, dependencies=_auth)
 
 
 @app.get("/health")

--- a/api/marrow/models.py
+++ b/api/marrow/models.py
@@ -253,3 +253,22 @@ class User(Base):
     __table_args__ = (UniqueConstraint("oidc_issuer", "oidc_subject"),)
 
     memberships: Mapped[list["OrgMembership"]] = relationship(back_populates="user")
+
+
+class UserStar(Base):
+    __tablename__ = "user_stars"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    node_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+        UniqueConstraint("user_id", "node_id", name="uq_user_stars_user_node"),
+    )

--- a/api/marrow/routers/stars.py
+++ b/api/marrow/routers/stars.py
@@ -1,0 +1,92 @@
+"""Per-user starred-node endpoints."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ..dependencies import AuthContext, get_db, verify_auth
+from ..models import Node, OrgRole, Space, UserStar, Workspace
+from ..rbac import require_node_role
+from ..schemas import StarredNode
+
+router = APIRouter(tags=["stars"])
+
+
+def _require_user(auth: AuthContext) -> UUID:
+    if auth.user_id is None:
+        # API key / anonymous have no user identity to scope stars against.
+        raise HTTPException(400, "Starring requires a user session")
+    return auth.user_id
+
+
+@router.get("/api/users/me/starred", response_model=list[StarredNode])
+def list_my_starred(
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(verify_auth),
+):
+    user_id = _require_user(auth)
+    rows = db.execute(
+        select(
+            UserStar.node_id,
+            UserStar.created_at,
+            Node.space_id,
+            Node.type,
+            Node.name,
+            Node.slug,
+            Space.workspace_id,
+        )
+        .join(Node, Node.id == UserStar.node_id)
+        .join(Space, Space.id == Node.space_id)
+        .where(
+            UserStar.user_id == user_id,
+            Node.deleted_at.is_(None),
+        )
+        .order_by(UserStar.created_at.desc())
+    ).all()
+    return [
+        StarredNode(
+            node_id=r.node_id,
+            space_id=r.space_id,
+            workspace_id=r.workspace_id,
+            type=r.type,
+            name=r.name,
+            slug=r.slug,
+            starred_at=r.created_at,
+        )
+        for r in rows
+    ]
+
+
+@router.post("/api/nodes/{node_id}/star", status_code=204)
+def star_node(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    user_id = _require_user(auth)
+    star = UserStar(user_id=user_id, node_id=node_id)
+    db.add(star)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()  # Already starred — treat as idempotent success.
+    return Response(status_code=204)
+
+
+@router.delete("/api/nodes/{node_id}/star", status_code=204)
+def unstar_node(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    user_id = _require_user(auth)
+    existing = db.execute(
+        select(UserStar).where(UserStar.user_id == user_id, UserStar.node_id == node_id)
+    ).scalar_one_or_none()
+    if existing is not None:
+        db.delete(existing)
+        db.commit()
+    return Response(status_code=204)

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -224,3 +224,18 @@ class AuthStatus(BaseModel):
     user: UserRead | None = None
     method: str
     oidc_enabled: bool
+
+
+# ---------------------------------------------------------------------------
+# Stars
+# ---------------------------------------------------------------------------
+
+
+class StarredNode(_ReadBase):
+    node_id: UUID
+    space_id: UUID
+    workspace_id: UUID
+    type: Literal["folder", "page"]
+    name: str
+    slug: str
+    starred_at: datetime

--- a/api/tests/test_stars.py
+++ b/api/tests/test_stars.py
@@ -1,0 +1,210 @@
+"""Integration tests for starred-nodes endpoints (#102)."""
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from marrow.auth import COOKIE_NAME, create_session_jwt, reset_oidc_config
+from marrow.models import (
+    Node,
+    Organization,
+    OrgMembership,
+    OrgRole,
+    Space,
+    User,
+    UserStar,
+    Workspace,
+)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    reset_oidc_config()
+    yield
+    reset_oidc_config()
+
+
+@pytest.fixture
+def client():
+    from marrow.app import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _make_user(session, email: str) -> User:
+    user = User(
+        oidc_issuer="https://test.example.com",
+        oidc_subject=uuid.uuid4().hex,
+        email=email,
+        name="Test User",
+    )
+    session.add(user)
+    session.flush()
+    return user
+
+
+def _make_workspace(session) -> tuple:
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Test Org")
+    session.add(org)
+    session.flush()
+    ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="Test WS")
+    session.add(ws)
+    session.flush()
+    space = Space(workspace_id=ws.id, slug="main", name="Main")
+    session.add(space)
+    session.flush()
+    return org, ws, space
+
+
+def _add_membership(session, org, user, role):
+    m = OrgMembership(org_id=org.id, user_id=user.id, email=user.email, role=role.value)
+    session.add(m)
+    session.flush()
+
+
+def _auth(client, user):
+    token = create_session_jwt(user.id, user.email, user.name)
+    client.cookies.set(COOKIE_NAME, token)
+
+
+def _make_node(db, space, name="Node") -> Node:
+    n = Node(
+        space_id=space.id,
+        type="folder",
+        name=name,
+        slug=name.lower().replace(" ", "-"),
+        position="a0",
+    )
+    db.add(n)
+    db.flush()
+    return n
+
+
+class TestStarUnstar:
+    def test_star_node_creates_row(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "star@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+            node = _make_node(db, space, "Important")
+            db.commit()
+
+            _auth(client, user)
+            res = client.post(f"/api/nodes/{node.id}/star")
+            assert res.status_code == 204
+
+            # idempotent
+            res2 = client.post(f"/api/nodes/{node.id}/star")
+            assert res2.status_code == 204
+
+            res3 = client.get("/api/users/me/starred")
+            assert res3.status_code == 200
+            data = res3.json()
+            assert len(data) == 1
+            assert data[0]["node_id"] == str(node.id)
+            assert data[0]["name"] == "Important"
+            assert data[0]["workspace_id"] == str(ws.id)
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_unstar_removes_row(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "unstar@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+            node = _make_node(db, space)
+            db.add(UserStar(user_id=user.id, node_id=node.id))
+            db.commit()
+
+            _auth(client, user)
+            res = client.delete(f"/api/nodes/{node.id}/star")
+            assert res.status_code == 204
+
+            res2 = client.get("/api/users/me/starred")
+            assert res2.json() == []
+
+            # idempotent — unstarring again is fine
+            res3 = client.delete(f"/api/nodes/{node.id}/star")
+            assert res3.status_code == 204
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_stars_scoped_per_user(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            alice = _make_user(db, "alice@test.com")
+            bob = _make_user(db, "bob@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, alice, OrgRole.VIEWER)
+            _add_membership(db, org, bob, OrgRole.VIEWER)
+            node = _make_node(db, space, "Shared")
+            db.add(UserStar(user_id=alice.id, node_id=node.id))
+            db.commit()
+
+            _auth(client, bob)
+            res = client.get("/api/users/me/starred")
+            assert res.status_code == 200
+            assert res.json() == []
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_trashed_nodes_excluded(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "trash@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+            node = _make_node(db, space, "Trashy")
+            db.add(UserStar(user_id=user.id, node_id=node.id))
+            db.commit()
+
+            # Soft-delete the node after starring
+            node.deleted_at = datetime.now(timezone.utc)
+            db.commit()
+
+            _auth(client, user)
+            res = client.get("/api/users/me/starred")
+            assert res.status_code == 200
+            assert res.json() == []
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_non_member_cannot_star(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "outsider@test.com")
+            org, ws, space = _make_workspace(db)
+            # No membership added
+            node = _make_node(db, space)
+            db.commit()
+
+            _auth(client, user)
+            res = client.post(f"/api/nodes/{node.id}/star")
+            assert res.status_code == 403
+        finally:
+            db.rollback()
+            client.cookies.clear()

--- a/web/components/inset-header.tsx
+++ b/web/components/inset-header.tsx
@@ -11,6 +11,7 @@ interface Props {
   saveLabel: string;
   onOpenDrawer: (which: PageMenuDrawer) => void;
   onShare: () => void;
+  nodeId?: string;
 }
 
 const MOCK_AVATARS = [
@@ -71,6 +72,7 @@ export function EditorHeader({
   saveLabel,
   onOpenDrawer,
   onShare,
+  nodeId,
 }: Props) {
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -98,6 +100,7 @@ export function EditorHeader({
       <PageMenu
         open={menuOpen}
         onOpenChange={setMenuOpen}
+        nodeId={nodeId}
         onOpenDrawer={(which) => {
           setMenuOpen(false);
           onOpenDrawer(which);

--- a/web/components/page-editor.tsx
+++ b/web/components/page-editor.tsx
@@ -394,6 +394,7 @@ export function PageEditor({ initialPage }: Props) {
         saveLabel={statusLabel}
         onOpenDrawer={handleOpenDrawer}
         onShare={handleShareStub}
+        nodeId={initialPage.id}
       />
 
       {/* Attachments — retained while Phase A omits an Attachments menu entry */}

--- a/web/components/page-menu.tsx
+++ b/web/components/page-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ArrowRight,
   BookOpen,
@@ -12,6 +12,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { toast } from "sonner";
+import { listStarred, starNode, unstarNode } from "@/lib/api";
 
 export type PageMenuDrawer = "backlinks" | "history";
 
@@ -33,29 +34,54 @@ type Item =
       destructive?: boolean;
     };
 
-const ITEMS: Item[] = [
-  { kind: "drawer", id: "backlinks", icon: LinkIcon, label: "Backlinks", meta: "0" },
-  { kind: "drawer", id: "history", icon: History, label: "Version history" },
-  { kind: "divider" },
-  { kind: "action", id: "star", icon: Star, label: "Star", meta: "⌥S" },
-  { kind: "action", id: "watch", icon: Eye, label: "Watch" },
-  { kind: "divider" },
-  { kind: "action", id: "duplicate", icon: Copy, label: "Duplicate" },
-  { kind: "action", id: "move", icon: ArrowRight, label: "Move…" },
-  { kind: "action", id: "export", icon: BookOpen, label: "Export as Markdown" },
-  { kind: "divider" },
-  { kind: "action", id: "archive", icon: Trash2, label: "Archive", destructive: true },
-];
+function buildItems(starred: boolean): Item[] {
+  return [
+    { kind: "drawer", id: "backlinks", icon: LinkIcon, label: "Backlinks", meta: "0" },
+    { kind: "drawer", id: "history", icon: History, label: "Version history" },
+    { kind: "divider" },
+    {
+      kind: "action",
+      id: "star",
+      icon: Star,
+      label: starred ? "Unstar" : "Star",
+      meta: "⌥S",
+    },
+    { kind: "action", id: "watch", icon: Eye, label: "Watch" },
+    { kind: "divider" },
+    { kind: "action", id: "duplicate", icon: Copy, label: "Duplicate" },
+    { kind: "action", id: "move", icon: ArrowRight, label: "Move…" },
+    { kind: "action", id: "export", icon: BookOpen, label: "Export as Markdown" },
+    { kind: "divider" },
+    { kind: "action", id: "archive", icon: Trash2, label: "Archive", destructive: true },
+  ];
+}
 
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onOpenDrawer: (which: PageMenuDrawer) => void;
   trigger: React.ReactNode;
+  nodeId?: string;
 }
 
-export function PageMenu({ open, onOpenChange, onOpenDrawer, trigger }: Props) {
+export function PageMenu({ open, onOpenChange, onOpenDrawer, trigger, nodeId }: Props) {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const [starred, setStarred] = useState(false);
+
+  useEffect(() => {
+    if (!open || !nodeId) return;
+    let cancelled = false;
+    listStarred()
+      .then((items) => {
+        if (!cancelled) setStarred(items.some((i) => i.node_id === nodeId));
+      })
+      .catch(() => {
+        /* leave default */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, nodeId]);
 
   useEffect(() => {
     if (!open) return;
@@ -68,6 +94,29 @@ export function PageMenu({ open, onOpenChange, onOpenDrawer, trigger }: Props) {
     return () => document.removeEventListener("mousedown", onDoc);
   }, [open, onOpenChange]);
 
+  async function handleStarToggle() {
+    if (!nodeId) {
+      toast.info("Star — coming soon");
+      return;
+    }
+    const wasStarred = starred;
+    setStarred(!wasStarred);
+    try {
+      if (wasStarred) {
+        await unstarNode(nodeId);
+        toast.success("Removed from starred");
+      } else {
+        await starNode(nodeId);
+        toast.success("Added to starred");
+      }
+    } catch (e) {
+      setStarred(wasStarred);
+      toast.error(e instanceof Error ? e.message : "Could not update star");
+    }
+  }
+
+  const items = buildItems(starred);
+
   return (
     <div ref={wrapperRef} className="relative">
       {trigger}
@@ -76,13 +125,14 @@ export function PageMenu({ open, onOpenChange, onOpenDrawer, trigger }: Props) {
           role="menu"
           className="absolute right-0 top-9 z-20 w-60 rounded-lg border border-border bg-popover p-1.5 shadow-[0_20px_40px_-15px_rgba(0,0,0,0.5)]"
         >
-          {ITEMS.map((item, i) => {
+          {items.map((item, i) => {
             if (item.kind === "divider") {
               return <div key={`div-${i}`} className="my-1 h-px bg-border" />;
             }
 
             const Icon = item.icon;
             const destructive = item.kind === "action" && item.destructive;
+            const isStarItem = item.kind === "action" && item.id === "star";
 
             return (
               <button
@@ -92,6 +142,9 @@ export function PageMenu({ open, onOpenChange, onOpenDrawer, trigger }: Props) {
                 onClick={() => {
                   if (item.kind === "drawer") {
                     onOpenDrawer(item.id);
+                  } else if (isStarItem) {
+                    void handleStarToggle();
+                    onOpenChange(false);
                   } else {
                     toast.info(`${item.label} — coming soon`);
                     onOpenChange(false);
@@ -103,7 +156,11 @@ export function PageMenu({ open, onOpenChange, onOpenDrawer, trigger }: Props) {
               >
                 <Icon
                   className={`h-3.5 w-3.5 shrink-0 ${
-                    destructive ? "text-destructive" : "text-muted-foreground"
+                    destructive
+                      ? "text-destructive"
+                      : isStarItem && starred
+                        ? "fill-current text-amber-500"
+                        : "text-muted-foreground"
                   }`}
                 />
                 <span className="flex-1">{item.label}</span>

--- a/web/components/rail-panels/starred-panel.tsx
+++ b/web/components/rail-panels/starred-panel.tsx
@@ -1,17 +1,77 @@
 "use client";
 
-import { Star } from "lucide-react";
+import { useEffect, useState } from "react";
+import { FileText, Folder, Star } from "lucide-react";
+import { listStarred, type StarredNode } from "@/lib/api";
 
 export function StarredPanel() {
-  return (
-    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
-      <Star className="h-6 w-6 text-muted-foreground/60" />
-      <div>
-        <p className="text-sm font-medium text-foreground">No starred pages</p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Star pages from the page menu to keep them one click away.
-        </p>
+  const [items, setItems] = useState<StarredNode[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    listStarred()
+      .then((data) => {
+        if (!cancelled) setItems(data);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 px-6 text-center">
+        <p className="text-xs text-muted-foreground">Couldn’t load starred items.</p>
       </div>
-    </div>
+    );
+  }
+
+  if (items === null) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center px-6 text-xs text-muted-foreground">
+        Loading…
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+        <Star className="h-6 w-6 text-muted-foreground/60" />
+        <div>
+          <p className="text-sm font-medium text-foreground">No starred pages</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Star pages from the page menu to keep them one click away.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-2 py-2">
+      {items.map((item) => {
+        const Icon = item.type === "folder" ? Folder : FileText;
+        const href =
+          item.type === "page"
+            ? `/w/${item.workspace_id}/pages/${item.node_id}`
+            : `/w/${item.workspace_id}`;
+        return (
+          <li key={item.node_id}>
+            <a
+              href={href}
+              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-[13px] text-foreground hover:bg-accent"
+            >
+              <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span className="truncate">{item.name}</span>
+            </a>
+          </li>
+        );
+      })}
+    </ul>
   );
 }

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -313,6 +313,32 @@ export function removeMember(orgId: string, membershipId: string): Promise<void>
   });
 }
 
+// ---------------------------------------------------------------------------
+// Stars
+// ---------------------------------------------------------------------------
+
+export interface StarredNode {
+  node_id: string;
+  space_id: string;
+  workspace_id: string;
+  type: "folder" | "page";
+  name: string;
+  slug: string;
+  starred_at: string;
+}
+
+export function listStarred(): Promise<StarredNode[]> {
+  return apiFetch("/api/users/me/starred");
+}
+
+export function starNode(nodeId: string): Promise<void> {
+  return apiFetch(`/api/nodes/${nodeId}/star`, { method: "POST" });
+}
+
+export function unstarNode(nodeId: string): Promise<void> {
+  return apiFetch(`/api/nodes/${nodeId}/star`, { method: "DELETE" });
+}
+
 /** Convert a display name to a URL-safe slug. */
 export function slugify(name: string): string {
   return name


### PR DESCRIPTION
Closes #102.

## Summary
- Adds `user_stars` table (user_id, node_id, unique pair) + Alembic migration
- New endpoints: `GET /api/users/me/starred`, `POST /api/nodes/{nid}/star`, `DELETE /api/nodes/{nid}/star` (viewer-level RBAC)
- `StarredPanel` rail now fetches `/api/users/me/starred` and renders the list with empty/loading states
- `PageMenu` shows a Star/Unstar toggle reflecting current state (filled amber icon when starred)
- Stars are per-user; trashed nodes (deleted_at IS NOT NULL) are excluded from listing
- Stars are not part of the export bundle — user-scoped state, round-trip unaffected

## Tests
- New `tests/test_stars.py` covers: star (idempotent), unstar (idempotent), per-user scoping, trashed-node exclusion, non-member 403
- Note: backend test suite couldn't be executed in this swarm environment (no local Postgres at :5433); please verify `pytest -x -q` in CI

_Created by swarm coordinator_