### PR TITLE
feat: #101 2.7: Comments backend

### DIFF
--- a/api/alembic/versions/a1b2c3d4e5f6_add_comments_table.py
+++ b/api/alembic/versions/a1b2c3d4e5f6_add_comments_table.py
@@ -1,0 +1,98 @@
+"""add comments table
+
+Revision ID: a1b2c3d4e5f6
+Revises: c58f38d0a5aa
+Create Date: 2026-05-13 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "c58f38d0a5aa"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_VIA_WORKSPACE = "org_id = current_setting('app.current_org', true)::uuid"
+_UNSET = (
+    "current_setting('app.current_org', true) IS NULL"
+    " OR current_setting('app.current_org', true) = ''"
+)
+_VIA_COMMENT = (
+    "node_id IN ("
+    "SELECT n.id FROM nodes n"
+    " JOIN spaces s ON s.id = n.space_id"
+    " JOIN workspaces w ON w.id = s.workspace_id"
+    f" WHERE {_VIA_WORKSPACE})"
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "comments",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "node_id", sa.UUID(), sa.ForeignKey("nodes.id", ondelete="CASCADE"), nullable=False
+        ),
+        sa.Column(
+            "author_user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "parent_comment_id",
+            sa.UUID(),
+            sa.ForeignKey("comments.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        # Reserved for future block-level comments (#92 follow-up).
+        sa.Column("block_id", sa.Text(), nullable=True),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_comments_node_id", "comments", ["node_id"])
+    op.create_index("ix_comments_parent_comment_id", "comments", ["parent_comment_id"])
+
+    # Enforce that comments only attach to page-typed nodes.
+    op.execute(
+        "ALTER TABLE comments ADD CONSTRAINT comments_node_is_page CHECK (node_is_page(node_id))"
+    )
+
+    # RLS — match the policy applied to revisions/attachments in 2b5326d2d299.
+    op.execute("ALTER TABLE comments ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE comments FORCE ROW LEVEL SECURITY")
+    op.execute(
+        f"CREATE POLICY tenant_isolation ON comments USING ({_UNSET} OR {_VIA_COMMENT})"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS tenant_isolation ON comments")
+    op.execute("ALTER TABLE comments DISABLE ROW LEVEL SECURITY")
+    op.drop_index("ix_comments_parent_comment_id", table_name="comments")
+    op.drop_index("ix_comments_node_id", table_name="comments")
+    op.drop_table("comments")

--- a/api/marrow/app.py
+++ b/api/marrow/app.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from .dependencies import verify_auth
-from .routers import auth, billing, nodes, organizations, spaces, workspaces
+from .routers import auth, billing, comments, nodes, organizations, spaces, workspaces
 
 
 def _truthy(value: str | None) -> bool:
@@ -59,6 +59,7 @@ app.include_router(billing.router)
 app.include_router(workspaces.router, dependencies=_auth)
 app.include_router(spaces.router, dependencies=_auth)
 app.include_router(nodes.router, dependencies=_auth)
+app.include_router(comments.router, dependencies=_auth)
 
 
 @app.get("/health")

--- a/api/marrow/models.py
+++ b/api/marrow/models.py
@@ -253,3 +253,30 @@ class User(Base):
     __table_args__ = (UniqueConstraint("oidc_issuer", "oidc_subject"),)
 
     memberships: Mapped[list["OrgMembership"]] = relationship(back_populates="user")
+
+
+class Comment(Base):
+    __tablename__ = "comments"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    node_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    author_user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    parent_comment_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    # Reserved for future block-level comments — currently always NULL.
+    block_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+        ForeignKeyConstraint(["author_user_id"], ["users.id"], ondelete="CASCADE"),
+        ForeignKeyConstraint(["parent_comment_id"], ["comments.id"], ondelete="CASCADE"),
+    )

--- a/api/marrow/rbac.py
+++ b/api/marrow/rbac.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from .dependencies import AuthContext, get_db, verify_auth
 from .models import (
+    Comment,
     Node,
     OrgMembership,
     OrgRole,
@@ -99,6 +100,28 @@ def require_space_role(min_role: OrgRole):
         if org_id is None:
             raise HTTPException(404, "Space not found")
         _check_membership(db, org_id, auth, min_role)
+        return auth
+
+    return _dep
+
+
+def require_comment_role(min_role: OrgRole):
+    """Dependency factory: resolve comment → node → space → workspace → org, then enforce role."""
+
+    def _dep(
+        comment_id: uuid.UUID,
+        db: Session = Depends(get_db),
+        auth: AuthContext = Depends(verify_auth),
+    ) -> AuthContext:
+        comment = db.get(Comment, comment_id)
+        if comment is None:
+            raise HTTPException(404, "Comment not found")
+        node = db.get(Node, comment.node_id)
+        if node is None:
+            raise HTTPException(404, "Comment not found")
+        space = db.get(Space, node.space_id)
+        workspace = db.get(Workspace, space.workspace_id)
+        _check_membership(db, workspace.org_id, auth, min_role)
         return auth
 
     return _dep

--- a/api/marrow/routers/comments.py
+++ b/api/marrow/routers/comments.py
@@ -1,0 +1,166 @@
+"""Page-level comment CRUD endpoints.
+
+Comments attach to page nodes. Replies are modeled via self-referential
+``parent_comment_id`` and resolved comments are flagged by a non-null
+``resolved_at`` timestamp.
+
+RBAC:
+    * viewer — list / read
+    * editor — post / reply / resolve / unresolve / edit-own
+    * owner or comment author — delete
+"""
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from ..dependencies import AuthContext, get_db
+from ..models import Comment, Node, OrgMembership, OrgRole, Space, Workspace
+from ..rbac import (
+    ROLE_HIERARCHY,
+    require_comment_role,
+    require_node_role,
+)
+from ..schemas import CommentCreate, CommentRead, CommentUpdate, UnreadCountResponse
+
+router = APIRouter(tags=["comments"])
+
+
+def _user_is_owner(db: Session, org_id: UUID, user_id: UUID | None) -> bool:
+    if user_id is None:
+        return False
+    role = db.execute(
+        select(OrgMembership.role).where(
+            OrgMembership.org_id == org_id,
+            OrgMembership.user_id == user_id,
+        )
+    ).scalar_one_or_none()
+    return role is not None and ROLE_HIERARCHY[OrgRole(role)] >= ROLE_HIERARCHY[OrgRole.OWNER]
+
+
+@router.post("/api/nodes/{node_id}/comments", response_model=CommentRead, status_code=201)
+def create_comment(
+    node_id: UUID,
+    body: CommentCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    node = db.get(Node, node_id)
+    if node is None or node.deleted_at is not None:
+        raise HTTPException(404, "Node not found")
+    if node.type != "page":
+        raise HTTPException(400, "Comments can only be attached to page nodes")
+    if auth.user_id is None:
+        raise HTTPException(401, "Authentication required to post comments")
+
+    if body.parent_comment_id is not None:
+        parent = db.get(Comment, body.parent_comment_id)
+        if parent is None or parent.node_id != node_id:
+            raise HTTPException(400, "Parent comment not found on this node")
+
+    comment = Comment(
+        node_id=node_id,
+        author_user_id=auth.user_id,
+        parent_comment_id=body.parent_comment_id,
+        body=body.body,
+    )
+    db.add(comment)
+    db.commit()
+    db.refresh(comment)
+    return comment
+
+
+@router.get("/api/nodes/{node_id}/comments", response_model=list[CommentRead])
+def list_comments(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    node = db.get(Node, node_id)
+    if node is None or node.deleted_at is not None:
+        raise HTTPException(404, "Node not found")
+    return (
+        db.execute(
+            select(Comment)
+            .where(Comment.node_id == node_id)
+            .order_by(Comment.created_at)
+        )
+        .scalars()
+        .all()
+    )
+
+
+@router.get("/api/nodes/{node_id}/comments/unread", response_model=UnreadCountResponse)
+def unread_count(
+    node_id: UUID,
+    since: datetime | None = None,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    """Return the count of comments created after ``since``.
+
+    Used by the floating bubble badge in the comments drawer (#92). The
+    "last visit" timestamp is tracked client-side and passed via ``since``.
+    When ``since`` is omitted the unread count is the total comment count.
+    """
+    node = db.get(Node, node_id)
+    if node is None or node.deleted_at is not None:
+        raise HTTPException(404, "Node not found")
+
+    stmt = select(func.count()).select_from(Comment).where(Comment.node_id == node_id)
+    if since is not None:
+        stmt = stmt.where(Comment.created_at > since)
+    count = db.execute(stmt).scalar_one()
+    return UnreadCountResponse(unread=int(count))
+
+
+@router.patch("/api/comments/{comment_id}", response_model=CommentRead)
+def update_comment(
+    comment_id: UUID,
+    body: CommentUpdate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_comment_role(OrgRole.EDITOR)),
+):
+    comment = db.get(Comment, comment_id)
+    if comment is None:
+        raise HTTPException(404, "Comment not found")
+
+    # Editing the body is restricted to the original author.
+    if body.body is not None:
+        if auth.user_id is not None and comment.author_user_id != auth.user_id:
+            raise HTTPException(403, "Only the author may edit a comment's body")
+        comment.body = body.body
+
+    if body.resolved is not None:
+        comment.resolved_at = datetime.now(timezone.utc) if body.resolved else None
+
+    comment.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(comment)
+    return comment
+
+
+@router.delete("/api/comments/{comment_id}", status_code=204)
+def delete_comment(
+    comment_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_comment_role(OrgRole.VIEWER)),
+):
+    """Delete a comment. Author may delete their own; owners may delete any."""
+    comment = db.get(Comment, comment_id)
+    if comment is None:
+        raise HTTPException(404, "Comment not found")
+
+    # api_key / anonymous bypass the role check entirely.
+    if auth.user_id is not None and comment.author_user_id != auth.user_id:
+        node = db.get(Node, comment.node_id)
+        space = db.get(Space, node.space_id)
+        workspace = db.get(Workspace, space.workspace_id)
+        if not _user_is_owner(db, workspace.org_id, auth.user_id):
+            raise HTTPException(403, "Only the author or an owner may delete this comment")
+
+    db.delete(comment)
+    db.commit()

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -224,3 +224,33 @@ class AuthStatus(BaseModel):
     user: UserRead | None = None
     method: str
     oidc_enabled: bool
+
+
+# ---------------------------------------------------------------------------
+# Comments
+# ---------------------------------------------------------------------------
+
+
+class CommentCreate(BaseModel):
+    body: str
+    parent_comment_id: UUID | None = None
+
+
+class CommentUpdate(BaseModel):
+    body: str | None = None
+    resolved: bool | None = None
+
+
+class CommentRead(_ReadBase):
+    id: UUID
+    node_id: UUID
+    author_user_id: UUID
+    parent_comment_id: UUID | None
+    body: str
+    resolved_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class UnreadCountResponse(BaseModel):
+    unread: int

--- a/api/tests/test_comments.py
+++ b/api/tests/test_comments.py
@@ -1,0 +1,347 @@
+"""Integration tests for the comments API (#101)."""
+
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from marrow.auth import COOKIE_NAME, create_session_jwt, reset_oidc_config
+from marrow.models import (
+    Comment,
+    Node,
+    Organization,
+    OrgMembership,
+    OrgRole,
+    Revision,
+    Space,
+    User,
+    Workspace,
+)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    reset_oidc_config()
+    yield
+    reset_oidc_config()
+
+
+@pytest.fixture
+def client():
+    from marrow.app import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _make_user(session, email: str) -> User:
+    user = User(
+        oidc_issuer="https://test.example.com",
+        oidc_subject=uuid.uuid4().hex,
+        email=email,
+        name="Test User",
+    )
+    session.add(user)
+    session.flush()
+    return user
+
+
+def _make_page(session):
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Org")
+    session.add(org)
+    session.flush()
+    ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="WS")
+    session.add(ws)
+    session.flush()
+    space = Space(workspace_id=ws.id, slug="main", name="Main")
+    session.add(space)
+    session.flush()
+    node = Node(space_id=space.id, type="page", name="Page", slug="page", position="a0")
+    session.add(node)
+    session.flush()
+    rev = Revision(node_id=node.id, content="hi", content_format="markdown")
+    session.add(rev)
+    session.flush()
+    node.current_revision_id = rev.id
+    return org, ws, space, node
+
+
+def _membership(session, org, user, role: OrgRole):
+    m = OrgMembership(org_id=org.id, user_id=user.id, email=user.email, role=role.value)
+    session.add(m)
+    session.flush()
+    return m
+
+
+def _auth_cookie(client, user):
+    token = create_session_jwt(user.id, user.email, user.name)
+    client.cookies.set(COOKIE_NAME, token)
+
+
+class TestCreateComment:
+    def test_editor_can_post(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-post@test.com")
+            org, ws, space, node = _make_page(db)
+            _membership(db, org, user, OrgRole.EDITOR)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(
+                f"/api/nodes/{node.id}/comments", json={"body": "first comment"}
+            )
+            assert res.status_code == 201, res.text
+            data = res.json()
+            assert data["body"] == "first comment"
+            assert data["author_user_id"] == str(user.id)
+            assert data["resolved_at"] is None
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_viewer_cannot_post(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-post@test.com")
+            org, ws, space, node = _make_page(db)
+            _membership(db, org, user, OrgRole.VIEWER)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(f"/api/nodes/{node.id}/comments", json={"body": "nope"})
+            assert res.status_code == 403
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_cannot_comment_on_folder(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-folder-comment@test.com")
+            org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Org")
+            db.add(org)
+            db.flush()
+            ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="WS")
+            db.add(ws)
+            db.flush()
+            sp = Space(workspace_id=ws.id, slug="main", name="Main")
+            db.add(sp)
+            db.flush()
+            folder = Node(
+                space_id=sp.id, type="folder", name="F", slug="f", position="a0"
+            )
+            db.add(folder)
+            _membership(db, org, user, OrgRole.EDITOR)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(f"/api/nodes/{folder.id}/comments", json={"body": "x"})
+            assert res.status_code == 400
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_reply_to_comment(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-reply@test.com")
+            org, ws, space, node = _make_page(db)
+            _membership(db, org, user, OrgRole.EDITOR)
+            parent = Comment(node_id=node.id, author_user_id=user.id, body="parent")
+            db.add(parent)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(
+                f"/api/nodes/{node.id}/comments",
+                json={"body": "reply", "parent_comment_id": str(parent.id)},
+            )
+            assert res.status_code == 201, res.text
+            assert res.json()["parent_comment_id"] == str(parent.id)
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestListComments:
+    def test_viewer_can_list(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-list@test.com")
+            author = _make_user(db, "author-list@test.com")
+            org, ws, space, node = _make_page(db)
+            _membership(db, org, user, OrgRole.VIEWER)
+            db.add(Comment(node_id=node.id, author_user_id=author.id, body="hi"))
+            db.add(Comment(node_id=node.id, author_user_id=author.id, body="hey"))
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.get(f"/api/nodes/{node.id}/comments")
+            assert res.status_code == 200
+            assert len(res.json()) == 2
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestUnreadCount:
+    def test_unread_since_filter(self, client):
+        from datetime import datetime, timedelta, timezone
+
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-unread@test.com")
+            org, ws, space, node = _make_page(db)
+            _membership(db, org, user, OrgRole.VIEWER)
+            db.add(Comment(node_id=node.id, author_user_id=user.id, body="a"))
+            db.commit()
+
+            cutoff = datetime.now(timezone.utc) + timedelta(seconds=1)
+
+            _auth_cookie(client, user)
+            res = client.get(
+                f"/api/nodes/{node.id}/comments/unread",
+                params={"since": cutoff.isoformat()},
+            )
+            assert res.status_code == 200
+            assert res.json()["unread"] == 0
+
+            res2 = client.get(f"/api/nodes/{node.id}/comments/unread")
+            assert res2.status_code == 200
+            assert res2.json()["unread"] == 1
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestPatchComment:
+    def test_resolve_and_unresolve(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-resolve@test.com")
+            org, ws, space, node = _make_page(db)
+            _membership(db, org, user, OrgRole.EDITOR)
+            c = Comment(node_id=node.id, author_user_id=user.id, body="todo")
+            db.add(c)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.patch(f"/api/comments/{c.id}", json={"resolved": True})
+            assert res.status_code == 200
+            assert res.json()["resolved_at"] is not None
+
+            res2 = client.patch(f"/api/comments/{c.id}", json={"resolved": False})
+            assert res2.status_code == 200
+            assert res2.json()["resolved_at"] is None
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_non_author_cannot_edit_body(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            author = _make_user(db, "author-edit@test.com")
+            other = _make_user(db, "other-edit@test.com")
+            org, ws, space, node = _make_page(db)
+            _membership(db, org, author, OrgRole.EDITOR)
+            _membership(db, org, other, OrgRole.EDITOR)
+            c = Comment(node_id=node.id, author_user_id=author.id, body="orig")
+            db.add(c)
+            db.commit()
+
+            _auth_cookie(client, other)
+            res = client.patch(f"/api/comments/{c.id}", json={"body": "hijack"})
+            assert res.status_code == 403
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestDeleteComment:
+    def test_author_can_delete_own(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "author-delete@test.com")
+            org, ws, space, node = _make_page(db)
+            _membership(db, org, user, OrgRole.EDITOR)
+            c = Comment(node_id=node.id, author_user_id=user.id, body="bye")
+            db.add(c)
+            db.commit()
+            cid = c.id
+
+            _auth_cookie(client, user)
+            res = client.delete(f"/api/comments/{cid}")
+            assert res.status_code == 204
+
+            db.expire_all()
+            assert db.get(Comment, cid) is None
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_non_author_editor_cannot_delete(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            author = _make_user(db, "author-other-del@test.com")
+            other = _make_user(db, "other-editor-del@test.com")
+            org, ws, space, node = _make_page(db)
+            _membership(db, org, author, OrgRole.EDITOR)
+            _membership(db, org, other, OrgRole.EDITOR)
+            c = Comment(node_id=node.id, author_user_id=author.id, body="mine")
+            db.add(c)
+            db.commit()
+
+            _auth_cookie(client, other)
+            res = client.delete(f"/api/comments/{c.id}")
+            assert res.status_code == 403
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_owner_can_delete_anyones(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            author = _make_user(db, "author-owner-del@test.com")
+            owner = _make_user(db, "owner-del@test.com")
+            org, ws, space, node = _make_page(db)
+            _membership(db, org, author, OrgRole.EDITOR)
+            _membership(db, org, owner, OrgRole.OWNER)
+            c = Comment(node_id=node.id, author_user_id=author.id, body="bye")
+            db.add(c)
+            db.commit()
+            cid = c.id
+
+            _auth_cookie(client, owner)
+            res = client.delete(f"/api/comments/{cid}")
+            assert res.status_code == 204
+        finally:
+            db.rollback()
+            client.cookies.clear()


### PR DESCRIPTION
Closes #101.

## Summary

Implements page-level comments (backend only) for the comments drawer/floating bubble from #92.

- **Migration** `a1b2c3d4e5f6_add_comments_table.py` — new `comments` table with `node_id`, `author_user_id`, `parent_comment_id` (self-FK), `block_id` (reserved for future block-level comments, always NULL today), `body`, `resolved_at`, timestamps. CHECK constraint reuses the existing `node_is_page(uuid)` function to enforce page-only attachment; RLS policy mirrors the tenant-isolation pattern from `2b5326d2d299` (`revisions`/`attachments`).
- **Model + schemas** — `Comment` ORM model, `CommentCreate` / `CommentUpdate` / `CommentRead` / `UnreadCountResponse` Pydantic schemas.
- **Router** `routers/comments.py`:
  - `POST /api/nodes/{nid}/comments` — editor+, rejects folder nodes, supports replies via `parent_comment_id`.
  - `GET  /api/nodes/{nid}/comments` — viewer+, ordered by `created_at`.
  - `GET  /api/nodes/{nid}/comments/unread?since=<ts>` — viewer+, drives the floating bubble badge. Simple v1 heuristic per the issue: count of comments created after the supplied `since` timestamp (tracked client-side as last-visit).
  - `PATCH /api/comments/{cid}` — editor+ to toggle `resolved`; body edits restricted to original author.
  - `DELETE /api/comments/{cid}` — viewer-level entry, then enforces author-or-owner inside the handler so an author who has been demoted to viewer can still delete their own comment.
- **RBAC** — new `require_comment_role` dependency walks comment → node → space → workspace → org → membership.
- **Tests** `tests/test_comments.py` — CRUD, RBAC (viewer/editor/owner × create/edit/delete), reply threading, folder rejection, resolve/unresolve, unread-since filtering.

## Out of scope (called out in the issue)

- Block-level comments — schema reserves `block_id` but no API exposes it yet.
- Frontend drawer/bubble wiring — UI work tracked under #92.
- Export/restore inclusion — the v0.1 `export.py`/`restore.py` are stubbed pending the v4 bundle rewrites in #132 (`2.0j`) and #133. Once those land, comments will be added to the bundle and to the round-trip regression test as part of that work, per the existing CLAUDE.md note about #124/#132/#133.

## Test plan

- [ ] `cd api && pytest tests/test_comments.py` — pass against a fresh-migrated DB (could not run locally in the worktree; no Postgres reachable on `:5433`).
- [ ] Verify migration applies cleanly: `alembic upgrade head` from a fresh schema.
- [ ] Manual smoke: post → reply → resolve → unresolve → delete via the OpenAPI docs UI.

_Created by swarm coordinator_