### PR TITLE
feat: #100 2.6: Backlinks backend

### DIFF
--- a/api/alembic/versions/a1b2c3d4e5f6_add_node_links.py
+++ b/api/alembic/versions/a1b2c3d4e5f6_add_node_links.py
@@ -1,0 +1,63 @@
+"""add node_links table for backlinks
+
+Revision ID: a1b2c3d4e5f6
+Revises: c58f38d0a5aa
+Create Date: 2026-05-13 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "c58f38d0a5aa"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "node_links",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("source_node_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("target_node_id", UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_node_id"], ["nodes.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["target_node_id"], ["nodes.id"], ondelete="CASCADE"
+        ),
+        sa.UniqueConstraint(
+            "source_node_id", "target_node_id", name="uq_node_links_pair"
+        ),
+        sa.CheckConstraint(
+            "source_node_id <> target_node_id", name="node_links_no_self"
+        ),
+    )
+    op.create_index(
+        "idx_node_links_target", "node_links", ["target_node_id"]
+    )
+    op.create_index(
+        "idx_node_links_source", "node_links", ["source_node_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_node_links_source", table_name="node_links")
+    op.drop_index("idx_node_links_target", table_name="node_links")
+    op.drop_table("node_links")

--- a/api/marrow/links.py
+++ b/api/marrow/links.py
@@ -1,0 +1,156 @@
+"""Backlinks: parse node content for references to other nodes, and
+reconcile the `node_links` table on save.
+
+Wiki-link forms recognized:
+    - Markdown:  [label](/w/<workspaceId>/pages/<nodeId>)
+                 [label](/nodes/<nodeId>)
+                 any link whose href contains a UUID path segment
+    - BlockNote JSON: link inline content with `href` matching the same patterns,
+      and `mention` inline content of type "node" with `props.nodeId` (forward-compat
+      for node-style @mentions; user mentions are ignored because they do not target
+      a node).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from typing import Iterable
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from .models import Node, NodeLink
+
+_UUID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
+_MD_LINK_RE = re.compile(r"\[(?:[^\]]*)\]\(([^)\s]+)\)")
+_AT_MENTION_RE = re.compile(r"(?<!\w)@([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})", re.IGNORECASE)
+
+
+def _href_to_uuid(href: str) -> UUID | None:
+    """Return the last UUID found in href, or None."""
+    matches = _UUID_RE.findall(href or "")
+    if not matches:
+        return None
+    try:
+        return UUID(matches[-1])
+    except ValueError:
+        return None
+
+
+def _walk_blocknote(blocks: Iterable) -> Iterable[UUID]:
+    for block in blocks or []:
+        if not isinstance(block, dict):
+            continue
+        content = block.get("content")
+        if isinstance(content, list):
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                itype = item.get("type")
+                if itype == "link":
+                    target = _href_to_uuid(item.get("href", ""))
+                    if target is not None:
+                        yield target
+                elif itype == "mention":
+                    # Future-compat: node mentions carry props.nodeId.
+                    # User mentions (props.userId) are intentionally ignored.
+                    props = item.get("props") or {}
+                    node_id = props.get("nodeId")
+                    if isinstance(node_id, str):
+                        try:
+                            yield UUID(node_id)
+                        except ValueError:
+                            pass
+        children = block.get("children")
+        if isinstance(children, list):
+            yield from _walk_blocknote(children)
+
+
+def extract_link_targets(content: str | None, content_format: str | None) -> set[UUID]:
+    """Return the set of node UUIDs that *content* references."""
+    if not content:
+        return set()
+
+    targets: set[UUID] = set()
+    if content_format == "json":
+        try:
+            blocks = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            blocks = None
+        if isinstance(blocks, list):
+            targets.update(_walk_blocknote(blocks))
+        # Fall through: also scan the raw JSON for UUIDs in case the structure
+        # surprises us. _walk_blocknote already gave us the canonical hits;
+        # the regex pass below catches markdown-style hrefs accidentally
+        # stored as plain text.
+
+    # Markdown links and bare @uuid mentions.
+    for href in _MD_LINK_RE.findall(content):
+        target = _href_to_uuid(href)
+        if target is not None:
+            targets.add(target)
+    for m in _AT_MENTION_RE.findall(content):
+        try:
+            targets.add(UUID(m))
+        except ValueError:
+            pass
+
+    return targets
+
+
+def reconcile_node_links(
+    db: Session,
+    source_node_id: UUID,
+    content: str | None,
+    content_format: str | None,
+) -> None:
+    """Replace the set of outbound links from *source_node_id* with those parsed
+    from *content*. Self-links and links to missing/trashed nodes are dropped.
+    """
+    parsed = extract_link_targets(content, content_format)
+    parsed.discard(source_node_id)
+
+    if parsed:
+        existing_targets = {
+            row[0]
+            for row in db.execute(
+                select(Node.id).where(
+                    Node.id.in_(parsed), Node.deleted_at.is_(None)
+                )
+            ).all()
+        }
+    else:
+        existing_targets = set()
+
+    current = {
+        row[0]
+        for row in db.execute(
+            select(NodeLink.target_node_id).where(
+                NodeLink.source_node_id == source_node_id
+            )
+        ).all()
+    }
+
+    to_add = existing_targets - current
+    to_remove = current - existing_targets
+
+    if to_remove:
+        db.query(NodeLink).filter(
+            NodeLink.source_node_id == source_node_id,
+            NodeLink.target_node_id.in_(to_remove),
+        ).delete(synchronize_session=False)
+
+    for target in to_add:
+        stmt = (
+            pg_insert(NodeLink)
+            .values(source_node_id=source_node_id, target_node_id=target)
+            .on_conflict_do_nothing(index_elements=["source_node_id", "target_node_id"])
+        )
+        db.execute(stmt)

--- a/api/marrow/models.py
+++ b/api/marrow/models.py
@@ -233,6 +233,26 @@ class Attachment(Base):
     node: Mapped["Node"] = relationship(back_populates="attachments")
 
 
+class NodeLink(Base):
+    __tablename__ = "node_links"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    source_node_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    target_node_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(["source_node_id"], ["nodes.id"], ondelete="CASCADE"),
+        ForeignKeyConstraint(["target_node_id"], ["nodes.id"], ondelete="CASCADE"),
+        UniqueConstraint("source_node_id", "target_node_id", name="uq_node_links_pair"),
+        CheckConstraint("source_node_id <> target_node_id", name="node_links_no_self"),
+    )
+
+
 class User(Base):
     __tablename__ = "users"
 

--- a/api/marrow/routers/nodes.py
+++ b/api/marrow/routers/nodes.py
@@ -11,7 +11,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..dependencies import AuthContext, get_db, get_storage
-from ..models import Attachment, Node, OrgRole, Revision, Space
+from ..links import reconcile_node_links
+from ..models import Attachment, Node, NodeLink, OrgRole, Revision, Space
 from ..rbac import require_node_role, require_space_role
 from ..schemas import (
     AttachmentRead,
@@ -80,6 +81,7 @@ def create_node(
         db.flush()
         node.current_revision_id = rev.id
         db.flush()
+        reconcile_node_links(db, node.id, content, body.content_format)
 
     db.commit()
     db.refresh(node)
@@ -150,6 +152,7 @@ def update_node(
         db.add(rev)
         db.flush()
         node.current_revision_id = rev.id
+        reconcile_node_links(db, node.id, body.content, body.content_format or "markdown")
 
     node.updated_at = datetime.now(timezone.utc)
 
@@ -233,6 +236,29 @@ def get_revision(
     if rev is None or rev.node_id != node_id:
         raise HTTPException(404, "Revision not found")
     return rev
+
+
+@router.get("/api/nodes/{node_id}/backlinks", response_model=list[NodeRead])
+def list_backlinks(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    """Return live nodes whose current content links to *node_id*."""
+    _node_or_404(node_id, db)
+    return (
+        db.execute(
+            select(Node)
+            .join(NodeLink, NodeLink.source_node_id == Node.id)
+            .where(
+                NodeLink.target_node_id == node_id,
+                Node.deleted_at.is_(None),
+            )
+            .order_by(Node.name)
+        )
+        .scalars()
+        .all()
+    )
 
 
 @router.post("/api/nodes/{node_id}/attachments", response_model=AttachmentRead, status_code=201)

--- a/api/tests/test_backlinks.py
+++ b/api/tests/test_backlinks.py
@@ -1,0 +1,432 @@
+"""Tests for backlinks: parser, save reconciliation, endpoint, and RBAC."""
+
+import json
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from marrow.auth import COOKIE_NAME, create_session_jwt, reset_oidc_config
+from marrow.links import extract_link_targets, reconcile_node_links
+from marrow.models import (
+    Node,
+    NodeLink,
+    Organization,
+    OrgMembership,
+    OrgRole,
+    Revision,
+    Space,
+    User,
+    Workspace,
+)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    reset_oidc_config()
+    yield
+    reset_oidc_config()
+
+
+@pytest.fixture
+def client():
+    from marrow.app import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _make_user(session, email: str) -> User:
+    user = User(
+        oidc_issuer="https://test.example.com",
+        oidc_subject=uuid.uuid4().hex,
+        email=email,
+        name="Test User",
+    )
+    session.add(user)
+    session.flush()
+    return user
+
+
+def _make_workspace(session) -> tuple:
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Test Org")
+    session.add(org)
+    session.flush()
+    ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="Test WS")
+    session.add(ws)
+    session.flush()
+    space = Space(workspace_id=ws.id, slug="main", name="Main")
+    session.add(space)
+    session.flush()
+    return org, ws, space
+
+
+def _add_membership(session, org, user, role: OrgRole) -> OrgMembership:
+    m = OrgMembership(org_id=org.id, user_id=user.id, email=user.email, role=role.value)
+    session.add(m)
+    session.flush()
+    return m
+
+
+def _auth_cookie(client, user):
+    token = create_session_jwt(user.id, user.email, user.name)
+    client.cookies.set(COOKIE_NAME, token)
+
+
+def _make_page(session, space, name: str, content: str = "") -> Node:
+    node = Node(
+        space_id=space.id,
+        type="page",
+        name=name,
+        slug=name.lower().replace(" ", "-"),
+        position="a0",
+    )
+    session.add(node)
+    session.flush()
+    rev = Revision(node_id=node.id, content=content, content_format="markdown")
+    session.add(rev)
+    session.flush()
+    node.current_revision_id = rev.id
+    session.flush()
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Parser (pure-function tests)
+# ---------------------------------------------------------------------------
+
+
+class TestExtract:
+    def test_markdown_link_with_workspace_url(self):
+        target = uuid.uuid4()
+        content = f"see [the page](/w/abc/pages/{target}) for details"
+        assert extract_link_targets(content, "markdown") == {target}
+
+    def test_markdown_link_with_node_url(self):
+        target = uuid.uuid4()
+        content = f"[foo](/nodes/{target})"
+        assert extract_link_targets(content, "markdown") == {target}
+
+    def test_multiple_links(self):
+        a, b = uuid.uuid4(), uuid.uuid4()
+        content = f"[a](/pages/{a}) and [b](/pages/{b}) and [a again](/pages/{a})"
+        assert extract_link_targets(content, "markdown") == {a, b}
+
+    def test_at_mention_uuid(self):
+        target = uuid.uuid4()
+        content = f"hello @{target} world"
+        assert target in extract_link_targets(content, "markdown")
+
+    def test_no_links(self):
+        assert extract_link_targets("just plain text", "markdown") == set()
+
+    def test_external_link_ignored(self):
+        assert extract_link_targets("[ext](https://example.com)", "markdown") == set()
+
+    def test_empty_content(self):
+        assert extract_link_targets("", "markdown") == set()
+        assert extract_link_targets(None, "markdown") == set()
+
+    def test_blocknote_json_link(self):
+        target = uuid.uuid4()
+        blocks = [
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "see "},
+                    {
+                        "type": "link",
+                        "href": f"/w/ws/pages/{target}",
+                        "content": [{"type": "text", "text": "page"}],
+                    },
+                ],
+            }
+        ]
+        assert extract_link_targets(json.dumps(blocks), "json") == {target}
+
+    def test_blocknote_json_node_mention(self):
+        target = uuid.uuid4()
+        blocks = [
+            {
+                "type": "paragraph",
+                "content": [
+                    {
+                        "type": "mention",
+                        "props": {"nodeId": str(target), "displayName": "X"},
+                    }
+                ],
+            }
+        ]
+        assert extract_link_targets(json.dumps(blocks), "json") == {target}
+
+    def test_blocknote_user_mention_ignored(self):
+        blocks = [
+            {
+                "type": "paragraph",
+                "content": [
+                    {
+                        "type": "mention",
+                        "props": {"userId": str(uuid.uuid4()), "displayName": "U"},
+                    }
+                ],
+            }
+        ]
+        assert extract_link_targets(json.dumps(blocks), "json") == set()
+
+    def test_blocknote_nested_children(self):
+        target = uuid.uuid4()
+        blocks = [
+            {
+                "type": "bulletListItem",
+                "content": [],
+                "children": [
+                    {
+                        "type": "paragraph",
+                        "content": [
+                            {
+                                "type": "link",
+                                "href": f"/pages/{target}",
+                                "content": [{"type": "text", "text": "x"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+        assert extract_link_targets(json.dumps(blocks), "json") == {target}
+
+
+# ---------------------------------------------------------------------------
+# reconcile_node_links — DB-level
+# ---------------------------------------------------------------------------
+
+
+class TestReconcile:
+    def test_reconcile_adds_links(self):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            _, _, space = _make_workspace(db)
+            src = _make_page(db, space, "src")
+            tgt = _make_page(db, space, "tgt")
+            db.commit()
+
+            reconcile_node_links(
+                db,
+                src.id,
+                f"[t](/w/x/pages/{tgt.id})",
+                "markdown",
+            )
+            db.commit()
+
+            links = db.query(NodeLink).filter_by(source_node_id=src.id).all()
+            assert len(links) == 1
+            assert links[0].target_node_id == tgt.id
+        finally:
+            db.rollback()
+
+    def test_reconcile_removes_stale_links(self):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            _, _, space = _make_workspace(db)
+            src = _make_page(db, space, "src")
+            t1 = _make_page(db, space, "t1")
+            t2 = _make_page(db, space, "t2")
+            db.commit()
+
+            reconcile_node_links(db, src.id, f"[a](/pages/{t1.id}) [b](/pages/{t2.id})", "markdown")
+            db.commit()
+            assert db.query(NodeLink).filter_by(source_node_id=src.id).count() == 2
+
+            # Re-save with only t1; t2 should be removed.
+            reconcile_node_links(db, src.id, f"[a](/pages/{t1.id})", "markdown")
+            db.commit()
+            remaining = db.query(NodeLink).filter_by(source_node_id=src.id).all()
+            assert len(remaining) == 1
+            assert remaining[0].target_node_id == t1.id
+        finally:
+            db.rollback()
+
+    def test_reconcile_skips_missing_target(self):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            _, _, space = _make_workspace(db)
+            src = _make_page(db, space, "src")
+            bogus = uuid.uuid4()
+            db.commit()
+
+            reconcile_node_links(db, src.id, f"[x](/pages/{bogus})", "markdown")
+            db.commit()
+            assert db.query(NodeLink).filter_by(source_node_id=src.id).count() == 0
+        finally:
+            db.rollback()
+
+    def test_reconcile_skips_self_link(self):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            _, _, space = _make_workspace(db)
+            src = _make_page(db, space, "src")
+            db.commit()
+
+            reconcile_node_links(db, src.id, f"[me](/pages/{src.id})", "markdown")
+            db.commit()
+            assert db.query(NodeLink).filter_by(source_node_id=src.id).count() == 0
+        finally:
+            db.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Endpoint + RBAC
+# ---------------------------------------------------------------------------
+
+
+class TestBacklinksEndpoint:
+    def test_returns_backlinks(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "v-bl@test.com")
+            org, _, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+
+            tgt = _make_page(db, space, "target")
+            src_a = _make_page(db, space, "src-a")
+            src_b = _make_page(db, space, "src-b")
+            db.commit()
+
+            reconcile_node_links(db, src_a.id, f"[t](/pages/{tgt.id})", "markdown")
+            reconcile_node_links(db, src_b.id, f"[t](/pages/{tgt.id})", "markdown")
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.get(f"/api/nodes/{tgt.id}/backlinks")
+            assert res.status_code == 200, res.text
+            ids = {n["id"] for n in res.json()}
+            assert ids == {str(src_a.id), str(src_b.id)}
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_trashed_source_excluded(self, client):
+        from datetime import datetime, timezone
+
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "v-bl-trash@test.com")
+            org, _, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+
+            tgt = _make_page(db, space, "target")
+            src = _make_page(db, space, "src")
+            db.commit()
+
+            reconcile_node_links(db, src.id, f"[t](/pages/{tgt.id})", "markdown")
+            db.commit()
+
+            src.deleted_at = datetime.now(timezone.utc)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.get(f"/api/nodes/{tgt.id}/backlinks")
+            assert res.status_code == 200
+            assert res.json() == []
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_rbac_non_member_403(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            outsider = _make_user(db, "outside-bl@test.com")
+            _, _, space = _make_workspace(db)
+            tgt = _make_page(db, space, "target")
+            db.commit()
+
+            _auth_cookie(client, outsider)
+            res = client.get(f"/api/nodes/{tgt.id}/backlinks")
+            assert res.status_code == 403
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestSavePathReconciles:
+    def test_create_page_with_link_creates_node_link(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "edit-save-bl@test.com")
+            org, _, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            tgt = _make_page(db, space, "target")
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(
+                f"/api/spaces/{space.id}/nodes",
+                json={
+                    "type": "page",
+                    "name": "Src",
+                    "content": f"see [t](/pages/{tgt.id})",
+                },
+            )
+            assert res.status_code == 201, res.text
+            src_id = uuid.UUID(res.json()["id"])
+
+            db.expire_all()
+            links = db.query(NodeLink).filter_by(source_node_id=src_id).all()
+            assert len(links) == 1
+            assert links[0].target_node_id == tgt.id
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_patch_updates_links(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "edit-patch-bl@test.com")
+            org, _, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            t1 = _make_page(db, space, "t1")
+            t2 = _make_page(db, space, "t2")
+            src = _make_page(db, space, "src", content=f"[a](/pages/{t1.id})")
+            db.commit()
+
+            reconcile_node_links(db, src.id, f"[a](/pages/{t1.id})", "markdown")
+            db.commit()
+            assert db.query(NodeLink).filter_by(source_node_id=src.id).count() == 1
+
+            _auth_cookie(client, user)
+            res = client.patch(
+                f"/api/nodes/{src.id}",
+                json={"content": f"[b](/pages/{t2.id})", "content_format": "markdown"},
+            )
+            assert res.status_code == 200, res.text
+
+            db.expire_all()
+            links = db.query(NodeLink).filter_by(source_node_id=src.id).all()
+            assert len(links) == 1
+            assert links[0].target_node_id == t2.id
+        finally:
+            db.rollback()
+            client.cookies.clear()


### PR DESCRIPTION
Closes #100.

## Summary
- New `node_links` table (unique `(source, target)`, cascading FKs, no-self-link CHECK).
- Parser handles markdown `[text](href)` links, BlockNote JSON `link` and node-style `mention` inline content, plus bare `@<uuid>` mentions. User mentions (`props.userId`) are intentionally ignored — they don't target a node.
- Reconcile on save (create + content patch): adds new, drops stale, skips self-links and links to missing/trashed nodes.
- `GET /api/nodes/{nid}/backlinks` (min role `viewer`), excludes trashed source nodes.
- 11 parser unit tests + DB reconcile tests + endpoint/RBAC tests + save-path integration tests.

## Notes
- Export/restore wiring for `node_links` (bundle v4) is intentionally not part of this PR — `marrow/export.py` and `marrow/restore.py` are pre-existing broken (NameErrors on Page/Collection) and are slated for rewrite in #132/#133 per CLAUDE.md. Backlinks are deterministically derivable from page content, so rebuilding the index on restore will just be a `reconcile_node_links` pass per page in the v4 restore.
- Frontend Backlinks drawer wiring is in #92.

_Created by swarm coordinator_