### PR TITLE
feat: #44 2.5: Tree views — table, board, and list over a folder of nodes

### DIFF
--- a/api/alembic/versions/a1b2c3d4e5f6_add_node_views.py
+++ b/api/alembic/versions/a1b2c3d4e5f6_add_node_views.py
@@ -1,0 +1,96 @@
+"""add node_views table
+
+Revision ID: a1b2c3d4e5f6
+Revises: c58f38d0a5aa
+Create Date: 2026-05-13 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "c58f38d0a5aa"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "node_views",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "folder_node_id",
+            sa.UUID(),
+            sa.ForeignKey("nodes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("view_type", sa.Text(), nullable=False),
+        sa.Column(
+            "config",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("position", sa.Text(), nullable=False, server_default="a0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "view_type IN ('table', 'board', 'list')", name="node_views_type_valid"
+        ),
+    )
+    op.create_index(
+        "idx_node_views_folder", "node_views", ["folder_node_id", "position"]
+    )
+
+    # Enforce that folder_node_id references a node with type='folder'.
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION node_views_check_folder()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        DECLARE
+            t TEXT;
+        BEGIN
+            SELECT type INTO t FROM nodes WHERE id = NEW.folder_node_id;
+            IF t IS NULL OR t <> 'folder' THEN
+                RAISE EXCEPTION 'node_views.folder_node_id must reference a folder node';
+            END IF;
+            RETURN NEW;
+        END;
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_node_views_check_folder
+        BEFORE INSERT OR UPDATE OF folder_node_id ON node_views
+        FOR EACH ROW EXECUTE FUNCTION node_views_check_folder();
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS trg_node_views_check_folder ON node_views")
+    op.execute("DROP FUNCTION IF EXISTS node_views_check_folder()")
+    op.drop_index("idx_node_views_folder", table_name="node_views")
+    op.drop_table("node_views")

--- a/api/marrow/app.py
+++ b/api/marrow/app.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from .dependencies import verify_auth
-from .routers import auth, billing, nodes, organizations, spaces, workspaces
+from .routers import auth, billing, node_views, nodes, organizations, spaces, workspaces
 
 
 def _truthy(value: str | None) -> bool:
@@ -59,6 +59,7 @@ app.include_router(billing.router)
 app.include_router(workspaces.router, dependencies=_auth)
 app.include_router(spaces.router, dependencies=_auth)
 app.include_router(nodes.router, dependencies=_auth)
+app.include_router(node_views.router, dependencies=_auth)
 
 
 @app.get("/health")

--- a/api/marrow/models.py
+++ b/api/marrow/models.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
-from sqlalchemy.dialects.postgresql import TSVECTOR, UUID
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -231,6 +231,32 @@ class Attachment(Base):
     __table_args__ = (ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),)
 
     node: Mapped["Node"] = relationship(back_populates="attachments")
+
+
+class NodeView(Base):
+    __tablename__ = "node_views"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    folder_node_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    view_type: Mapped[str] = mapped_column(Text, nullable=False)
+    config: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
+    position: Mapped[str] = mapped_column(Text, nullable=False, server_default="a0")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(["folder_node_id"], ["nodes.id"], ondelete="CASCADE"),
+        CheckConstraint(
+            "view_type IN ('table', 'board', 'list')", name="node_views_type_valid"
+        ),
+    )
 
 
 class User(Base):

--- a/api/marrow/routers/node_views.py
+++ b/api/marrow/routers/node_views.py
@@ -1,0 +1,126 @@
+"""Node view CRUD endpoints.
+
+Views are configurable presentations (table, board, list) over the descendant
+page nodes of a folder. Sort/filter/group-by lives in the JSONB `config` blob.
+"""
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..dependencies import AuthContext, get_db, verify_auth
+from ..models import Node, NodeView, OrgRole, Space, Workspace
+from ..rbac import _check_membership, require_node_role
+from ..schemas import NodeViewCreate, NodeViewRead, NodeViewUpdate
+
+router = APIRouter(tags=["node_views"])
+
+
+def _view_or_404(view_id: UUID, db: Session) -> NodeView:
+    view = db.get(NodeView, view_id)
+    if view is None:
+        raise HTTPException(404, "View not found")
+    return view
+
+
+def _require_view_role(min_role: OrgRole):
+    """Resolve view → folder → space → workspace → org and check role."""
+
+    def _dep(
+        view_id: UUID,
+        db: Session = Depends(get_db),
+        auth: AuthContext = Depends(verify_auth),
+    ) -> AuthContext:
+        view = _view_or_404(view_id, db)
+        node = db.get(Node, view.folder_node_id)
+        if node is None:
+            raise HTTPException(404, "Folder not found")
+        space = db.get(Space, node.space_id)
+        workspace = db.get(Workspace, space.workspace_id)
+        _check_membership(db, workspace.org_id, auth, min_role)
+        return auth
+
+    return _dep
+
+
+@router.get("/api/nodes/{node_id}/views", response_model=list[NodeViewRead])
+def list_views(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    return (
+        db.execute(
+            select(NodeView)
+            .where(NodeView.folder_node_id == node_id)
+            .order_by(NodeView.position, NodeView.created_at)
+        )
+        .scalars()
+        .all()
+    )
+
+
+@router.post("/api/nodes/{node_id}/views", response_model=NodeViewRead, status_code=201)
+def create_view(
+    node_id: UUID,
+    body: NodeViewCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    node = db.get(Node, node_id)
+    if node is None or node.deleted_at is not None:
+        raise HTTPException(404, "Node not found")
+    if node.type != "folder":
+        raise HTTPException(400, "Views can only be attached to folder nodes")
+
+    view = NodeView(
+        folder_node_id=node_id,
+        name=body.name,
+        view_type=body.view_type,
+        config=body.config or {},
+        position=body.position or "a0",
+    )
+    db.add(view)
+    db.commit()
+    db.refresh(view)
+    return view
+
+
+@router.get("/api/views/{view_id}", response_model=NodeViewRead)
+def get_view(
+    view_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(_require_view_role(OrgRole.VIEWER)),
+):
+    return _view_or_404(view_id, db)
+
+
+@router.patch("/api/views/{view_id}", response_model=NodeViewRead)
+def update_view(
+    view_id: UUID,
+    body: NodeViewUpdate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(_require_view_role(OrgRole.EDITOR)),
+):
+    view = _view_or_404(view_id, db)
+    data = body.model_dump(exclude_unset=True)
+    for k, v in data.items():
+        setattr(view, k, v)
+    view.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(view)
+    return view
+
+
+@router.delete("/api/views/{view_id}", status_code=204)
+def delete_view(
+    view_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(_require_view_role(OrgRole.EDITOR)),
+):
+    view = _view_or_404(view_id, db)
+    db.delete(view)
+    db.commit()

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -122,6 +122,39 @@ class WorkspaceTree(_ReadBase):
 
 
 # ---------------------------------------------------------------------------
+# Node View
+# ---------------------------------------------------------------------------
+
+
+NodeViewType = Literal["table", "board", "list"]
+
+
+class NodeViewCreate(BaseModel):
+    name: str
+    view_type: NodeViewType
+    config: dict = {}
+    position: str | None = None
+
+
+class NodeViewUpdate(BaseModel):
+    name: str | None = None
+    view_type: NodeViewType | None = None
+    config: dict | None = None
+    position: str | None = None
+
+
+class NodeViewRead(_ReadBase):
+    id: UUID
+    folder_node_id: UUID
+    name: str
+    view_type: NodeViewType
+    config: dict
+    position: str
+    created_at: datetime
+    updated_at: datetime
+
+
+# ---------------------------------------------------------------------------
 # Revision
 # ---------------------------------------------------------------------------
 

--- a/api/tests/test_node_views.py
+++ b/api/tests/test_node_views.py
@@ -1,0 +1,144 @@
+"""Integration tests for node view CRUD endpoints."""
+
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from marrow.auth import COOKIE_NAME, create_session_jwt, reset_oidc_config
+from marrow.models import (
+    Node,
+    Organization,
+    OrgMembership,
+    OrgRole,
+    Revision,
+    Space,
+    User,
+    Workspace,
+)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("MARROW_ALLOW_ANONYMOUS", "true")
+    reset_oidc_config()
+    yield
+    reset_oidc_config()
+
+
+@pytest.fixture
+def client():
+    from marrow.app import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _seed(db):
+    user = User(
+        oidc_issuer="https://test.example.com",
+        oidc_subject=uuid.uuid4().hex,
+        email=f"u-{uuid.uuid4().hex[:6]}@test",
+        name="U",
+    )
+    db.add(user)
+    db.flush()
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Org")
+    db.add(org)
+    db.flush()
+    m = OrgMembership(org_id=org.id, user_id=user.id, email=user.email, role=OrgRole.EDITOR.value)
+    db.add(m)
+    ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="WS")
+    db.add(ws)
+    db.flush()
+    space = Space(workspace_id=ws.id, slug="main", name="Main")
+    db.add(space)
+    db.flush()
+    folder = Node(
+        space_id=space.id, type="folder", name="F", slug=f"f-{uuid.uuid4().hex[:6]}",
+        position="a0", description="",
+    )
+    db.add(folder)
+    db.flush()
+    page = Node(
+        space_id=space.id, parent_id=folder.id, type="page", name="P",
+        slug=f"p-{uuid.uuid4().hex[:6]}", position="a0",
+    )
+    db.add(page)
+    db.flush()
+    rev = Revision(node_id=page.id, content="", content_format="markdown")
+    db.add(rev)
+    db.flush()
+    page.current_revision_id = rev.id
+    db.commit()
+    return user, folder, page
+
+
+def _auth(client, user):
+    client.cookies.set(COOKIE_NAME, create_session_jwt(user.id, user.email, user.name))
+
+
+def test_create_list_update_delete_view(client):
+    from marrow.dependencies import get_db
+
+    db = next(get_db())
+    try:
+        user, folder, page = _seed(db)
+        _auth(client, user)
+
+        r = client.post(
+            f"/api/nodes/{folder.id}/views",
+            json={
+                "name": "Tasks",
+                "view_type": "table",
+                "config": {"sort": [{"prop": "name", "dir": "asc"}]},
+            },
+        )
+        assert r.status_code == 201, r.text
+        view_id = r.json()["id"]
+
+        r = client.get(f"/api/nodes/{folder.id}/views")
+        assert r.status_code == 200
+        assert len(r.json()) == 1
+
+        r = client.patch(
+            f"/api/views/{view_id}",
+            json={"view_type": "board", "config": {"group_by": "status"}},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["view_type"] == "board"
+        assert r.json()["config"] == {"group_by": "status"}
+
+        r = client.patch(f"/api/views/{view_id}", json={"view_type": "calendar"})
+        assert r.status_code == 422
+
+        r = client.delete(f"/api/views/{view_id}")
+        assert r.status_code == 204
+        r = client.get(f"/api/nodes/{folder.id}/views")
+        assert r.json() == []
+    finally:
+        db.rollback()
+        client.cookies.clear()
+
+
+def test_view_must_attach_to_folder(client):
+    from marrow.dependencies import get_db
+
+    db = next(get_db())
+    try:
+        user, folder, page = _seed(db)
+        _auth(client, user)
+
+        r = client.post(
+            f"/api/nodes/{page.id}/views",
+            json={"name": "x", "view_type": "list"},
+        )
+        assert r.status_code == 400
+    finally:
+        db.rollback()
+        client.cookies.clear()


### PR DESCRIPTION
Closes #44.

## Summary
- New `node_views` table (id, folder_node_id, name, view_type, config JSONB, position) via Alembic migration `a1b2c3d4e5f6`
- PG trigger enforces `folder_node_id` references a `type='folder'` node; CHECK constraint pins `view_type ∈ {table, board, list}`
- `NodeView` ORM model, Pydantic schemas (`NodeViewCreate`/`Read`/`Update`)
- CRUD router: `GET/POST /api/nodes/{node_id}/views`, `GET/PATCH/DELETE /api/views/{view_id}`, RBAC via folder→space→workspace→org
- Tests cover create/list/update/delete and the folder-only constraint

## Notes / scope
- Sort/filter/group-by live in the JSONB `config`; shape is intentionally open so it can evolve with the property system (#42 / 2.4) without further migrations.
- Frontend view switcher and table/board renderers are not in this PR — they depend on properties (#42) landing first.
- Export bundle v4 wiring (round-trip including views) lands in #132 alongside the broader export rewrite; that PR already owns the v0.2 export rewrite and the schema_version bump.

## Test plan
- [ ] `pytest tests/test_node_views.py` (requires running Postgres)
- [ ] `alembic upgrade head` applies cleanly on a fresh db
- [ ] `alembic downgrade -1` drops the table + trigger cleanly

_Created by swarm coordinator_