### PR TITLE
feat: #42 2.4: Node properties system — typed key-value metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,8 @@ marrow/
 │   │       ├── c333d20a46d9_add_content_format_to_revisions.py
 │   │       ├── bd52bac0673f_node_tree_schema_collapse_collections_.py
 │   │       ├── 2b5326d2d299_add_rls_tenant_isolation.py
-│   │       └── fdf65c08ffa8_add_node_fts_triggers_and_gin_index.py
+│   │       ├── fdf65c08ffa8_add_node_fts_triggers_and_gin_index.py
+│   │       └── a7b91c4f8e23_add_node_properties.py
 │   ├── marrow/                       # Main package
 │   │   ├── app.py                    # FastAPI app factory, CORS + session middleware
 │   │   ├── auth.py                   # OIDC config, session JWT helpers, cookie params
@@ -239,6 +240,8 @@ organizations → org_memberships (user roles: owner/editor/viewer)
 | revisions | id, node_id (FK cascade — must reference type='page'), content (TEXT), content_format ('markdown'\|'json') — **immutable via PG trigger** |
 | attachments | id, node_id (FK cascade), filename, hash (SHA256), size_bytes |
 | users | id, oidc_issuer, oidc_subject (unique together), email, name, last_login_at |
+| node_property_schemas | id, node_id (folder FK), key, label, value_type, options (jsonb), required, position; unique (node_id, key) |
+| node_properties | id, node_id (FK), key, value_type ∈ {text,number,date,select,multi_select,checkbox}, value (jsonb); unique (node_id, key) |
 
 **Node shape constraint**: A CHECK constraint (`nodes_shape_by_type`) enforces that folder rows have `current_revision_id` and `search_vector` NULL, while page rows have `description` NULL. A second CHECK on `revisions` (`revisions_node_is_page`) ensures revisions only reference page-typed nodes.
 
@@ -274,6 +277,12 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | POST | /api/workspaces/restore | Restore a workspace from an uploaded export bundle zip | — |
 | GET/POST | /api/workspaces/{id}/spaces/ | List / create spaces | viewer/editor |
 | GET/DELETE | /api/workspaces/{id}/spaces/{sid} | Get / delete space | viewer/owner |
+| GET | /api/nodes/{id}/properties | List values + inherited folder schemas | viewer |
+| PUT | /api/nodes/{id}/properties/{key} | Set/replace a property value | editor |
+| DELETE | /api/nodes/{id}/properties/{key} | Clear a property value | editor |
+| GET | /api/nodes/{id}/property-schema | List folder-defined schema entries | viewer |
+| POST | /api/nodes/{id}/property-schema | Add schema entry (folder only) | editor |
+| PATCH/DELETE | /api/nodes/{id}/property-schema/{key} | Edit / remove schema entry (folder only) | editor |
 
 > **Note (#123 → #125):** v0.1's collection-scoped and global page routes were removed by the schema migration. Node CRUD/tree/attachment/revision routes land in #124 (2.0b) under `/api/nodes/...` and `/api/spaces/{sid}/nodes`. The workspace `/search` endpoint is node-aware as of #125 (2.0c). The `/tree`, `/export`, and `/restore` endpoints are still wired but their handlers will NameError at runtime until the node-aware rewrites land in #124, #132, and #133.
 >

--- a/api/alembic/versions/a7b91c4f8e23_add_node_properties.py
+++ b/api/alembic/versions/a7b91c4f8e23_add_node_properties.py
@@ -1,0 +1,288 @@
+"""add node properties and folder-defined schemas
+
+Revision ID: a7b91c4f8e23
+Revises: c58f38d0a5aa
+Create Date: 2026-05-13 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "a7b91c4f8e23"
+down_revision: Union[str, Sequence[str], None] = "c58f38d0a5aa"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+VALUE_TYPES = ("text", "number", "date", "select", "multi_select", "checkbox")
+
+
+def upgrade() -> None:
+    # Folder-defined property schema entries.
+    # Pages inherit property schemas from every ancestor folder.
+    op.create_table(
+        "node_property_schemas",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("node_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("key", sa.Text(), nullable=False),
+        sa.Column("label", sa.Text(), nullable=True),
+        sa.Column("value_type", sa.Text(), nullable=False),
+        sa.Column(
+            "options",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "required",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("position", sa.Text(), nullable=False, server_default="a0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("node_id", "key", name="uq_property_schema_node_key"),
+        sa.CheckConstraint(
+            f"value_type IN {VALUE_TYPES!r}",
+            name="node_property_schemas_value_type_valid",
+        ),
+    )
+    op.create_index(
+        "idx_node_property_schemas_node",
+        "node_property_schemas",
+        ["node_id"],
+    )
+
+    # Per-node property values. Primarily attached to pages, but also allowed
+    # on folders so a folder schema can carry its own metadata if desired.
+    op.create_table(
+        "node_properties",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("node_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("key", sa.Text(), nullable=False),
+        sa.Column("value_type", sa.Text(), nullable=False),
+        # Canonical storage: JSONB. text/number/date/checkbox store a scalar,
+        # multi_select stores an array of strings, select stores a string.
+        sa.Column(
+            "value",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("node_id", "key", name="uq_node_property_node_key"),
+        sa.CheckConstraint(
+            f"value_type IN {VALUE_TYPES!r}",
+            name="node_properties_value_type_valid",
+        ),
+    )
+    op.create_index(
+        "idx_node_properties_node",
+        "node_properties",
+        ["node_id"],
+    )
+
+    # ----- FTS integration -------------------------------------------------
+    # Helper: stringify a node's property values into a single text blob for
+    # tsvector indexing. Includes select/multi-select values and free text.
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION node_properties_text(p_node_id uuid)
+        RETURNS text LANGUAGE sql STABLE AS $$
+            SELECT COALESCE(
+                string_agg(
+                    CASE
+                        WHEN p.value_type IN ('text', 'select') AND
+                             jsonb_typeof(p.value) = 'string'
+                            THEN p.value #>> '{}'
+                        WHEN p.value_type = 'multi_select' AND
+                             jsonb_typeof(p.value) = 'array'
+                            THEN (
+                                SELECT string_agg(elem #>> '{}', ' ')
+                                FROM jsonb_array_elements(p.value) AS elem
+                            )
+                        WHEN p.value_type = 'number' AND p.value IS NOT NULL
+                            THEN p.value::text
+                        WHEN p.value_type = 'date' AND p.value IS NOT NULL
+                            THEN p.value #>> '{}'
+                        ELSE ''
+                    END,
+                    ' '
+                ),
+                ''
+            )
+            FROM node_properties p
+            WHERE p.node_id = p_node_id;
+        $$;
+        """
+    )
+
+    # Replace the revision-insert trigger function so it also folds property
+    # values into the node's search_vector with weight C.
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION update_node_search_vector()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            UPDATE nodes
+            SET search_vector =
+                setweight(to_tsvector('english', COALESCE(nodes.name, '')), 'A') ||
+                setweight(to_tsvector('english', COALESCE(NEW.content, '')), 'B') ||
+                setweight(
+                    to_tsvector('english', COALESCE(node_properties_text(NEW.node_id), '')),
+                    'C'
+                )
+            WHERE id = NEW.node_id
+              AND type = 'page';
+            RETURN NEW;
+        END;
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION update_node_search_vector_on_name_change()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            IF NEW.type = 'page' THEN
+                NEW.search_vector :=
+                    setweight(to_tsvector('english', COALESCE(NEW.name, '')), 'A') ||
+                    setweight(to_tsvector('english', COALESCE(
+                        (SELECT content FROM revisions WHERE id = NEW.current_revision_id),
+                        ''
+                    )), 'B') ||
+                    setweight(
+                        to_tsvector('english', COALESCE(node_properties_text(NEW.id), '')),
+                        'C'
+                    );
+            END IF;
+            RETURN NEW;
+        END;
+        $$;
+        """
+    )
+
+    # Recompute the affected page's search_vector when any of its properties
+    # are inserted, updated, or deleted.
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION refresh_node_search_vector_for_props()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        DECLARE
+            target_id uuid;
+        BEGIN
+            IF TG_OP = 'DELETE' THEN
+                target_id := OLD.node_id;
+            ELSE
+                target_id := NEW.node_id;
+            END IF;
+
+            UPDATE nodes n
+            SET search_vector =
+                setweight(to_tsvector('english', COALESCE(n.name, '')), 'A') ||
+                setweight(to_tsvector('english', COALESCE(
+                    (SELECT content FROM revisions WHERE id = n.current_revision_id),
+                    ''
+                )), 'B') ||
+                setweight(
+                    to_tsvector('english', COALESCE(node_properties_text(n.id), '')),
+                    'C'
+                )
+            WHERE n.id = target_id
+              AND n.type = 'page';
+
+            IF TG_OP = 'DELETE' THEN
+                RETURN OLD;
+            END IF;
+            RETURN NEW;
+        END;
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER trg_node_properties_refresh_fts
+        AFTER INSERT OR UPDATE OR DELETE ON node_properties
+        FOR EACH ROW EXECUTE FUNCTION refresh_node_search_vector_for_props();
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS trg_node_properties_refresh_fts ON node_properties")
+    op.execute("DROP FUNCTION IF EXISTS refresh_node_search_vector_for_props()")
+
+    # Restore pre-properties FTS trigger functions.
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION update_node_search_vector()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            UPDATE nodes
+            SET search_vector =
+                setweight(to_tsvector('english', COALESCE(nodes.name, '')), 'A') ||
+                setweight(to_tsvector('english', COALESCE(NEW.content, '')), 'B')
+            WHERE id = NEW.node_id
+              AND type = 'page';
+            RETURN NEW;
+        END;
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION update_node_search_vector_on_name_change()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            IF NEW.type = 'page' THEN
+                NEW.search_vector :=
+                    setweight(to_tsvector('english', COALESCE(NEW.name, '')), 'A') ||
+                    setweight(to_tsvector('english', COALESCE(
+                        (SELECT content FROM revisions WHERE id = NEW.current_revision_id),
+                        ''
+                    )), 'B');
+            END IF;
+            RETURN NEW;
+        END;
+        $$;
+        """
+    )
+    op.execute("DROP FUNCTION IF EXISTS node_properties_text(uuid)")
+
+    op.drop_index("idx_node_properties_node", table_name="node_properties")
+    op.drop_table("node_properties")
+    op.drop_index("idx_node_property_schemas_node", table_name="node_property_schemas")
+    op.drop_table("node_property_schemas")

--- a/api/marrow/app.py
+++ b/api/marrow/app.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from .dependencies import verify_auth
-from .routers import auth, billing, nodes, organizations, spaces, workspaces
+from .routers import auth, billing, nodes, organizations, properties, spaces, workspaces
 
 
 def _truthy(value: str | None) -> bool:
@@ -59,6 +59,7 @@ app.include_router(billing.router)
 app.include_router(workspaces.router, dependencies=_auth)
 app.include_router(spaces.router, dependencies=_auth)
 app.include_router(nodes.router, dependencies=_auth)
+app.include_router(properties.router, dependencies=_auth)
 
 
 @app.get("/health")

--- a/api/marrow/models.py
+++ b/api/marrow/models.py
@@ -13,6 +13,7 @@ from datetime import datetime
 
 from sqlalchemy import (
     BigInteger,
+    Boolean,
     CheckConstraint,
     DateTime,
     ForeignKeyConstraint,
@@ -20,7 +21,7 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
-from sqlalchemy.dialects.postgresql import TSVECTOR, UUID
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -191,6 +192,77 @@ class Node(Base):
     attachments: Mapped[list["Attachment"]] = relationship(
         back_populates="node", passive_deletes=True
     )
+    properties: Mapped[list["NodeProperty"]] = relationship(
+        back_populates="node", passive_deletes=True, cascade="all, delete-orphan"
+    )
+    property_schemas: Mapped[list["NodePropertySchema"]] = relationship(
+        back_populates="node", passive_deletes=True, cascade="all, delete-orphan"
+    )
+
+
+PROPERTY_VALUE_TYPES = ("text", "number", "date", "select", "multi_select", "checkbox")
+
+
+class NodePropertySchema(Base):
+    """Folder-defined property schema. Pages inherit from ancestor folders."""
+
+    __tablename__ = "node_property_schemas"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    node_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    key: Mapped[str] = mapped_column(Text, nullable=False)
+    label: Mapped[str | None] = mapped_column(Text, nullable=True)
+    value_type: Mapped[str] = mapped_column(Text, nullable=False)
+    options: Mapped[list] = mapped_column(JSONB, nullable=False, server_default="[]")
+    required: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
+    position: Mapped[str] = mapped_column(Text, nullable=False, server_default="a0")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+        UniqueConstraint("node_id", "key", name="uq_property_schema_node_key"),
+        CheckConstraint(
+            "value_type IN ('text', 'number', 'date', 'select', 'multi_select', 'checkbox')",
+            name="node_property_schemas_value_type_valid",
+        ),
+    )
+
+    node: Mapped["Node"] = relationship(back_populates="property_schemas")
+
+
+class NodeProperty(Base):
+    """Typed key-value property attached to a node."""
+
+    __tablename__ = "node_properties"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    node_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    key: Mapped[str] = mapped_column(Text, nullable=False)
+    value_type: Mapped[str] = mapped_column(Text, nullable=False)
+    value: Mapped[object | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+        UniqueConstraint("node_id", "key", name="uq_node_property_node_key"),
+        CheckConstraint(
+            "value_type IN ('text', 'number', 'date', 'select', 'multi_select', 'checkbox')",
+            name="node_properties_value_type_valid",
+        ),
+    )
+
+    node: Mapped["Node"] = relationship(back_populates="properties")
 
 
 class Revision(Base):

--- a/api/marrow/routers/properties.py
+++ b/api/marrow/routers/properties.py
@@ -1,0 +1,309 @@
+"""Node properties — typed key-value metadata.
+
+Two related resources:
+
+* ``node_properties`` — per-node values (the data a user enters on a page).
+* ``node_property_schemas`` — folder-defined schema entries that page nodes
+  descended from that folder inherit. Pages can carry property values whose
+  key is defined either by their own schema entry or by any ancestor folder.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ..dependencies import AuthContext, get_db
+from ..models import Node, NodeProperty, NodePropertySchema, OrgRole
+from ..rbac import require_node_role
+from ..schemas import (
+    InheritedPropertySchema,
+    NodePropertiesView,
+    NodePropertyRead,
+    NodePropertySchemaCreate,
+    NodePropertySchemaRead,
+    NodePropertySchemaUpdate,
+    NodePropertyWrite,
+)
+
+router = APIRouter(tags=["properties"])
+
+
+def _node_or_404(node_id: UUID, db: Session) -> Node:
+    node = db.get(Node, node_id)
+    if node is None or node.deleted_at is not None:
+        raise HTTPException(404, "Node not found")
+    return node
+
+
+def _ancestor_ids(node: Node, db: Session) -> list[UUID]:
+    """Return ancestor folder ids in root → leaf order, excluding *node* itself."""
+    ids: list[UUID] = []
+    current = node
+    while current.parent_id is not None:
+        parent = db.get(Node, current.parent_id)
+        if parent is None or parent.deleted_at is not None:
+            break
+        ids.append(parent.id)
+        current = parent
+    ids.reverse()
+    return ids
+
+
+def _validate_value(value_type: str, value: Any) -> Any:
+    """Coerce/validate a property value. Returns the normalized value."""
+    if value is None:
+        return None
+    if value_type == "text":
+        if not isinstance(value, str):
+            raise HTTPException(400, "text property requires a string value")
+        return value
+    if value_type == "number":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise HTTPException(400, "number property requires a numeric value")
+        return value
+    if value_type == "date":
+        if not isinstance(value, str):
+            raise HTTPException(400, "date property requires an ISO date string")
+        return value
+    if value_type == "checkbox":
+        if not isinstance(value, bool):
+            raise HTTPException(400, "checkbox property requires a boolean value")
+        return value
+    if value_type == "select":
+        if not isinstance(value, str):
+            raise HTTPException(400, "select property requires a string value")
+        return value
+    if value_type == "multi_select":
+        if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+            raise HTTPException(400, "multi_select property requires a list of strings")
+        return value
+    raise HTTPException(400, f"Unsupported value_type: {value_type}")
+
+
+# ---------------------------------------------------------------------------
+# Per-node property values
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/nodes/{node_id}/properties", response_model=NodePropertiesView)
+def list_node_properties(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    node = _node_or_404(node_id, db)
+    props = (
+        db.execute(
+            select(NodeProperty).where(NodeProperty.node_id == node_id).order_by(NodeProperty.key)
+        )
+        .scalars()
+        .all()
+    )
+
+    inherited: list[InheritedPropertySchema] = []
+    seen_keys: set[str] = set()
+    ancestor_ids = _ancestor_ids(node, db)
+    for anc_id in ancestor_ids:
+        rows = (
+            db.execute(
+                select(NodePropertySchema)
+                .where(NodePropertySchema.node_id == anc_id)
+                .order_by(NodePropertySchema.position, NodePropertySchema.key)
+            )
+            .scalars()
+            .all()
+        )
+        for s in rows:
+            if s.key in seen_keys:
+                continue
+            seen_keys.add(s.key)
+            inherited.append(
+                InheritedPropertySchema(
+                    key=s.key,
+                    label=s.label,
+                    value_type=s.value_type,  # type: ignore[arg-type]
+                    options=list(s.options or []),
+                    required=s.required,
+                    source_node_id=s.node_id,
+                )
+            )
+
+    return NodePropertiesView(
+        properties=[NodePropertyRead.model_validate(p) for p in props],
+        inherited_schema=inherited,
+    )
+
+
+@router.put("/api/nodes/{node_id}/properties/{key}", response_model=NodePropertyRead)
+def set_node_property(
+    node_id: UUID,
+    key: str,
+    body: NodePropertyWrite,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    _node_or_404(node_id, db)
+    normalized = _validate_value(body.value_type, body.value)
+
+    existing = db.execute(
+        select(NodeProperty).where(NodeProperty.node_id == node_id, NodeProperty.key == key)
+    ).scalar_one_or_none()
+
+    if existing is None:
+        prop = NodeProperty(
+            node_id=node_id,
+            key=key,
+            value_type=body.value_type,
+            value=normalized,
+        )
+        db.add(prop)
+    else:
+        existing.value_type = body.value_type
+        existing.value = normalized
+        existing.updated_at = datetime.now(timezone.utc)
+        prop = existing
+
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(409, "Property conflict")
+    db.refresh(prop)
+    return prop
+
+
+@router.delete("/api/nodes/{node_id}/properties/{key}", status_code=204)
+def delete_node_property(
+    node_id: UUID,
+    key: str,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    _node_or_404(node_id, db)
+    prop = db.execute(
+        select(NodeProperty).where(NodeProperty.node_id == node_id, NodeProperty.key == key)
+    ).scalar_one_or_none()
+    if prop is None:
+        raise HTTPException(404, "Property not found")
+    db.delete(prop)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Folder-defined property schemas
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/api/nodes/{node_id}/property-schema",
+    response_model=list[NodePropertySchemaRead],
+)
+def list_property_schemas(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    _node_or_404(node_id, db)
+    return (
+        db.execute(
+            select(NodePropertySchema)
+            .where(NodePropertySchema.node_id == node_id)
+            .order_by(NodePropertySchema.position, NodePropertySchema.key)
+        )
+        .scalars()
+        .all()
+    )
+
+
+@router.post(
+    "/api/nodes/{node_id}/property-schema",
+    response_model=NodePropertySchemaRead,
+    status_code=201,
+)
+def create_property_schema(
+    node_id: UUID,
+    body: NodePropertySchemaCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    node = _node_or_404(node_id, db)
+    if node.type != "folder":
+        raise HTTPException(400, "Property schemas can only be defined on folder nodes")
+
+    entry = NodePropertySchema(
+        node_id=node_id,
+        key=body.key,
+        label=body.label,
+        value_type=body.value_type,
+        options=body.options,
+        required=body.required,
+        position=body.position or "a0",
+    )
+    db.add(entry)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(409, f"Schema key '{body.key}' already exists on this folder")
+    db.refresh(entry)
+    return entry
+
+
+@router.patch(
+    "/api/nodes/{node_id}/property-schema/{key}",
+    response_model=NodePropertySchemaRead,
+)
+def update_property_schema(
+    node_id: UUID,
+    key: str,
+    body: NodePropertySchemaUpdate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    _node_or_404(node_id, db)
+    entry = db.execute(
+        select(NodePropertySchema).where(
+            NodePropertySchema.node_id == node_id, NodePropertySchema.key == key
+        )
+    ).scalar_one_or_none()
+    if entry is None:
+        raise HTTPException(404, "Schema entry not found")
+
+    if body.label is not None:
+        entry.label = body.label
+    if body.value_type is not None:
+        entry.value_type = body.value_type
+    if body.options is not None:
+        entry.options = body.options
+    if body.required is not None:
+        entry.required = body.required
+    if body.position is not None:
+        entry.position = body.position
+
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+@router.delete("/api/nodes/{node_id}/property-schema/{key}", status_code=204)
+def delete_property_schema(
+    node_id: UUID,
+    key: str,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    _node_or_404(node_id, db)
+    entry = db.execute(
+        select(NodePropertySchema).where(
+            NodePropertySchema.node_id == node_id, NodePropertySchema.key == key
+        )
+    ).scalar_one_or_none()
+    if entry is None:
+        raise HTTPException(404, "Schema entry not found")
+    db.delete(entry)
+    db.commit()

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -1,10 +1,12 @@
 """Pydantic request/response schemas for the Marrow REST API."""
 
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
+
+PropertyValueType = Literal["text", "number", "date", "select", "multi_select", "checkbox"]
 
 
 class _ReadBase(BaseModel):
@@ -146,6 +148,73 @@ class AttachmentRead(_ReadBase):
     hash: str
     size_bytes: int
     created_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+class NodePropertySchemaCreate(BaseModel):
+    key: str
+    value_type: PropertyValueType
+    label: str | None = None
+    options: list[str] = []
+    required: bool = False
+    position: str | None = None
+
+
+class NodePropertySchemaUpdate(BaseModel):
+    label: str | None = None
+    value_type: PropertyValueType | None = None
+    options: list[str] | None = None
+    required: bool | None = None
+    position: str | None = None
+
+
+class NodePropertySchemaRead(_ReadBase):
+    id: UUID
+    node_id: UUID
+    key: str
+    label: str | None
+    value_type: PropertyValueType
+    options: list[str]
+    required: bool
+    position: str
+    created_at: datetime
+
+
+class NodePropertyWrite(BaseModel):
+    value_type: PropertyValueType
+    value: Any = None
+
+
+class NodePropertyRead(_ReadBase):
+    id: UUID
+    node_id: UUID
+    key: str
+    value_type: PropertyValueType
+    value: Any = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class InheritedPropertySchema(BaseModel):
+    """A property schema entry inherited from an ancestor folder."""
+
+    key: str
+    label: str | None
+    value_type: PropertyValueType
+    options: list[str]
+    required: bool
+    source_node_id: UUID
+
+
+class NodePropertiesView(BaseModel):
+    """Combined view: this node's values + inherited schemas from ancestors."""
+
+    properties: list[NodePropertyRead]
+    inherited_schema: list[InheritedPropertySchema]
 
 
 # ---------------------------------------------------------------------------

--- a/web/components/page-editor.tsx
+++ b/web/components/page-editor.tsx
@@ -60,6 +60,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { EditorHeader } from "@/components/inset-header";
+import { PropertyEditor } from "@/components/property-editor";
 import { SideDrawer, type SideDrawerKind } from "@/components/side-drawer";
 import { CommentsDrawer } from "@/components/comments-drawer";
 import { CommentBubbleFab } from "@/components/comment-bubble-fab";
@@ -418,6 +419,9 @@ export function PageEditor({ initialPage }: Props) {
           placeholder="Untitled"
         />
       </div>
+
+      {/* Typed key-value metadata */}
+      <PropertyEditor nodeId={initialPage.id} />
 
       {/* BlockNote editor */}
       <div className="flex-1 overflow-auto">

--- a/web/components/property-editor.tsx
+++ b/web/components/property-editor.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+/**
+ * PropertyEditor — typed key-value metadata strip rendered below a page title.
+ *
+ * Shows properties already set on the node plus any property keys inherited
+ * from ancestor folders' schemas. Tag-style chips for select/multi-select,
+ * native date pickers for dates, checkbox + number/text inputs otherwise.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  deleteNodeProperty,
+  listNodeProperties,
+  setNodeProperty,
+  type InheritedPropertySchema,
+  type NodeProperty,
+  type PropertyValueType,
+} from "@/lib/api";
+
+interface Props {
+  nodeId: string;
+}
+
+interface Row {
+  key: string;
+  label: string;
+  value_type: PropertyValueType;
+  options: string[];
+  value: unknown;
+  inherited: boolean;
+}
+
+function defaultValueFor(t: PropertyValueType): unknown {
+  switch (t) {
+    case "text":
+    case "select":
+      return "";
+    case "number":
+      return null;
+    case "date":
+      return "";
+    case "checkbox":
+      return false;
+    case "multi_select":
+      return [];
+  }
+}
+
+export function PropertyEditor({ nodeId }: Props) {
+  const [props, setProps] = useState<NodeProperty[]>([]);
+  const [inherited, setInherited] = useState<InheritedPropertySchema[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const view = await listNodeProperties(nodeId);
+      setProps(view.properties);
+      setInherited(view.inherited_schema);
+    } catch (err) {
+      toast.error(`Failed to load properties: ${String(err)}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [nodeId]);
+
+  useEffect(() => {
+    setLoading(true);
+    void refresh();
+  }, [refresh]);
+
+  const rows = useMemo<Row[]>(() => {
+    const byKey = new Map<string, NodeProperty>();
+    for (const p of props) byKey.set(p.key, p);
+
+    const result: Row[] = [];
+    const seen = new Set<string>();
+
+    for (const s of inherited) {
+      seen.add(s.key);
+      const existing = byKey.get(s.key);
+      result.push({
+        key: s.key,
+        label: s.label || s.key,
+        value_type: s.value_type,
+        options: s.options,
+        value: existing ? existing.value : defaultValueFor(s.value_type),
+        inherited: true,
+      });
+    }
+
+    for (const p of props) {
+      if (seen.has(p.key)) continue;
+      result.push({
+        key: p.key,
+        label: p.key,
+        value_type: p.value_type,
+        options: [],
+        value: p.value,
+        inherited: false,
+      });
+    }
+    return result;
+  }, [props, inherited]);
+
+  const save = useCallback(
+    async (row: Row, nextValue: unknown) => {
+      try {
+        await setNodeProperty(nodeId, row.key, row.value_type, nextValue);
+        await refresh();
+      } catch (err) {
+        toast.error(`Failed to save '${row.key}': ${String(err)}`);
+      }
+    },
+    [nodeId, refresh]
+  );
+
+  const remove = useCallback(
+    async (row: Row) => {
+      try {
+        await deleteNodeProperty(nodeId, row.key);
+        await refresh();
+      } catch (err) {
+        toast.error(`Failed to clear '${row.key}': ${String(err)}`);
+      }
+    },
+    [nodeId, refresh]
+  );
+
+  const addAdHoc = useCallback(async () => {
+    const key = window.prompt("Property key (e.g. status, tags, due)")?.trim();
+    if (!key) return;
+    const t = (window.prompt(
+      "Type: text, number, date, select, multi_select, checkbox",
+      "text"
+    ) || "text").trim() as PropertyValueType;
+    if (
+      !["text", "number", "date", "select", "multi_select", "checkbox"].includes(t)
+    ) {
+      toast.error(`Unknown type: ${t}`);
+      return;
+    }
+    try {
+      await setNodeProperty(nodeId, key, t, defaultValueFor(t));
+      await refresh();
+    } catch (err) {
+      toast.error(`Failed to add property: ${String(err)}`);
+    }
+  }, [nodeId, refresh]);
+
+  if (loading) return null;
+  if (rows.length === 0) {
+    return (
+      <div className="px-10 pt-1 pb-3 text-xs text-muted-foreground">
+        <button
+          type="button"
+          onClick={addAdHoc}
+          className="hover:text-foreground transition"
+        >
+          + Add property
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-start gap-x-6 gap-y-2 px-10 pt-1 pb-3 text-sm">
+      {rows.map((row) => (
+        <PropertyRow
+          key={row.key}
+          row={row}
+          onSave={(v) => save(row, v)}
+          onClear={() => remove(row)}
+        />
+      ))}
+      <button
+        type="button"
+        onClick={addAdHoc}
+        className="text-xs text-muted-foreground hover:text-foreground transition self-center"
+      >
+        + Add property
+      </button>
+    </div>
+  );
+}
+
+interface RowProps {
+  row: Row;
+  onSave: (value: unknown) => void;
+  onClear: () => void;
+}
+
+function PropertyRow({ row, onSave, onClear }: RowProps) {
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      <span className="text-xs uppercase tracking-wide text-muted-foreground shrink-0">
+        {row.label}
+      </span>
+      <ValueControl row={row} onSave={onSave} />
+      {!row.inherited && (
+        <button
+          type="button"
+          aria-label={`Clear ${row.key}`}
+          className="text-xs text-muted-foreground hover:text-foreground"
+          onClick={onClear}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ValueControl({ row, onSave }: { row: Row; onSave: (v: unknown) => void }) {
+  const baseInput =
+    "rounded border border-border bg-background px-2 py-0.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+
+  switch (row.value_type) {
+    case "text":
+      return (
+        <input
+          type="text"
+          defaultValue={(row.value as string) ?? ""}
+          onBlur={(e) => {
+            if (e.target.value !== row.value) onSave(e.target.value);
+          }}
+          className={baseInput}
+        />
+      );
+    case "number":
+      return (
+        <input
+          type="number"
+          defaultValue={row.value == null ? "" : String(row.value)}
+          onBlur={(e) => {
+            const v = e.target.value === "" ? null : Number(e.target.value);
+            if (v !== row.value) onSave(v);
+          }}
+          className={`${baseInput} w-24`}
+        />
+      );
+    case "date":
+      return (
+        <input
+          type="date"
+          defaultValue={(row.value as string) ?? ""}
+          onChange={(e) => onSave(e.target.value || null)}
+          className={baseInput}
+        />
+      );
+    case "checkbox":
+      return (
+        <input
+          type="checkbox"
+          checked={Boolean(row.value)}
+          onChange={(e) => onSave(e.target.checked)}
+        />
+      );
+    case "select":
+      return (
+        <select
+          value={(row.value as string) ?? ""}
+          onChange={(e) => onSave(e.target.value || null)}
+          className={baseInput}
+        >
+          <option value="">—</option>
+          {row.options.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      );
+    case "multi_select": {
+      const current = Array.isArray(row.value) ? (row.value as string[]) : [];
+      const toggle = (opt: string) => {
+        const next = current.includes(opt)
+          ? current.filter((v) => v !== opt)
+          : [...current, opt];
+        onSave(next);
+      };
+      return (
+        <div className="flex flex-wrap gap-1">
+          {row.options.length === 0 && current.length === 0 && (
+            <span className="text-xs text-muted-foreground italic">
+              no options
+            </span>
+          )}
+          {row.options.map((opt) => {
+            const active = current.includes(opt);
+            return (
+              <button
+                type="button"
+                key={opt}
+                onClick={() => toggle(opt)}
+                className={`rounded-full border px-2 py-0.5 text-xs transition ${
+                  active
+                    ? "bg-foreground text-background border-foreground"
+                    : "border-border text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {opt}
+              </button>
+            );
+          })}
+        </div>
+      );
+    }
+  }
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -321,3 +321,121 @@ export function slugify(name: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "");
 }
+
+// ---------------------------------------------------------------------------
+// Node properties (2.4)
+// ---------------------------------------------------------------------------
+
+export type PropertyValueType =
+  | "text"
+  | "number"
+  | "date"
+  | "select"
+  | "multi_select"
+  | "checkbox";
+
+export interface NodeProperty {
+  id: string;
+  node_id: string;
+  key: string;
+  value_type: PropertyValueType;
+  value: unknown;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface InheritedPropertySchema {
+  key: string;
+  label: string | null;
+  value_type: PropertyValueType;
+  options: string[];
+  required: boolean;
+  source_node_id: string;
+}
+
+export interface NodePropertiesView {
+  properties: NodeProperty[];
+  inherited_schema: InheritedPropertySchema[];
+}
+
+export interface NodePropertySchemaEntry {
+  id: string;
+  node_id: string;
+  key: string;
+  label: string | null;
+  value_type: PropertyValueType;
+  options: string[];
+  required: boolean;
+  position: string;
+  created_at: string;
+}
+
+export function listNodeProperties(nodeId: string): Promise<NodePropertiesView> {
+  return apiFetch(`/api/nodes/${nodeId}/properties`);
+}
+
+export function setNodeProperty(
+  nodeId: string,
+  key: string,
+  value_type: PropertyValueType,
+  value: unknown
+): Promise<NodeProperty> {
+  return apiFetch(`/api/nodes/${nodeId}/properties/${encodeURIComponent(key)}`, {
+    method: "PUT",
+    body: JSON.stringify({ value_type, value }),
+  });
+}
+
+export function deleteNodeProperty(nodeId: string, key: string): Promise<void> {
+  return apiFetch(`/api/nodes/${nodeId}/properties/${encodeURIComponent(key)}`, {
+    method: "DELETE",
+  });
+}
+
+export function listPropertySchema(nodeId: string): Promise<NodePropertySchemaEntry[]> {
+  return apiFetch(`/api/nodes/${nodeId}/property-schema`);
+}
+
+export function createPropertySchemaEntry(
+  nodeId: string,
+  entry: {
+    key: string;
+    value_type: PropertyValueType;
+    label?: string;
+    options?: string[];
+    required?: boolean;
+    position?: string;
+  }
+): Promise<NodePropertySchemaEntry> {
+  return apiFetch(`/api/nodes/${nodeId}/property-schema`, {
+    method: "POST",
+    body: JSON.stringify(entry),
+  });
+}
+
+export function updatePropertySchemaEntry(
+  nodeId: string,
+  key: string,
+  patch: Partial<{
+    label: string;
+    value_type: PropertyValueType;
+    options: string[];
+    required: boolean;
+    position: string;
+  }>
+): Promise<NodePropertySchemaEntry> {
+  return apiFetch(
+    `/api/nodes/${nodeId}/property-schema/${encodeURIComponent(key)}`,
+    { method: "PATCH", body: JSON.stringify(patch) }
+  );
+}
+
+export function deletePropertySchemaEntry(
+  nodeId: string,
+  key: string
+): Promise<void> {
+  return apiFetch(
+    `/api/nodes/${nodeId}/property-schema/${encodeURIComponent(key)}`,
+    { method: "DELETE" }
+  );
+}


### PR DESCRIPTION
Closes #42.

## Summary
- New tables `node_properties` (per-node values) and `node_property_schemas` (folder-defined schemas inherited by descendant pages).
- Six supported value types: text, number, date, select, multi_select, checkbox. Stored as JSONB with a `value_type` discriminator.
- API: CRUD endpoints for both resources under `/api/nodes/{id}/properties` and `/api/nodes/{id}/property-schema` (folder-only).
- FTS: property text folded into the node search_vector at weight C; a trigger on `node_properties` keeps the parent page's vector fresh on insert/update/delete.
- Frontend: `PropertyEditor` strip below page title with typed controls (chip toggles for multi-select, native date/checkbox/number inputs).

## Deferred
Export/restore integration ships with bundle v4 in #132 (2.0j) and #133 (2.0k). The current `export.py`/`restore.py` modules still reference the removed v0.1 Page/Collection ORM classes (see CLAUDE.md note on `routers/__init__`) and would NameError if touched. The SQLAlchemy relationships (`Node.properties`, `Node.property_schemas`) are wired up with `passive_deletes` and ready for those rewrites to serialize/deserialize.

_Created by swarm coordinator_