### PR TITLE
feat: #40 2.1: View-only sharing links

### DIFF
--- a/api/alembic/versions/a7c91d2f1e40_add_share_links.py
+++ b/api/alembic/versions/a7c91d2f1e40_add_share_links.py
@@ -1,0 +1,46 @@
+"""add share_links table for view-only sharing
+
+Revision ID: a7c91d2f1e40
+Revises: c58f38d0a5aa
+Create Date: 2026-05-13 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a7c91d2f1e40"
+down_revision: Union[str, Sequence[str], None] = "c58f38d0a5aa"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "share_links",
+        sa.Column("id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False),
+        sa.Column("node_id", sa.UUID(), nullable=False),
+        sa.Column("token", sa.Text(), nullable=False),
+        sa.Column("created_by", sa.UUID(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token"),
+    )
+    op.create_index("idx_share_links_node_id", "share_links", ["node_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_share_links_node_id", table_name="share_links")
+    op.drop_table("share_links")

--- a/api/marrow/app.py
+++ b/api/marrow/app.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from .dependencies import verify_auth
-from .routers import auth, billing, nodes, organizations, spaces, workspaces
+from .routers import auth, billing, nodes, organizations, share, spaces, workspaces
 
 
 def _truthy(value: str | None) -> bool:
@@ -59,6 +59,10 @@ app.include_router(billing.router)
 app.include_router(workspaces.router, dependencies=_auth)
 app.include_router(spaces.router, dependencies=_auth)
 app.include_router(nodes.router, dependencies=_auth)
+# Share router is registered WITHOUT the global auth dependency — `/shared/{token}`
+# must be reachable without authentication. Management routes carry their own
+# require_node_role / verify_auth deps.
+app.include_router(share.router)
 
 
 @app.get("/health")

--- a/api/marrow/models.py
+++ b/api/marrow/models.py
@@ -253,3 +253,32 @@ class User(Base):
     __table_args__ = (UniqueConstraint("oidc_issuer", "oidc_subject"),)
 
     memberships: Mapped[list["OrgMembership"]] = relationship(back_populates="user")
+
+
+class ShareLink(Base):
+    """View-only public sharing link for a node (folder or page).
+
+    Sharing a folder shares its visible (non-trashed) subtree. Links may
+    optionally have an expiry date and may be revoked.
+    """
+
+    __tablename__ = "share_links"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    node_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    token: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+        ForeignKeyConstraint(["created_by"], ["users.id"], ondelete="SET NULL"),
+    )
+
+    node: Mapped["Node"] = relationship()

--- a/api/marrow/routers/share.py
+++ b/api/marrow/routers/share.py
@@ -1,0 +1,147 @@
+"""Share link routes: management (authed) and public view (unauthed)."""
+
+import secrets
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..dependencies import AuthContext, get_db, verify_auth
+from ..models import Node, OrgRole, ShareLink, Space, Workspace
+from ..rbac import _check_membership, require_node_role
+from ..schemas import (
+    SharedNodeChild,
+    SharedNodeRead,
+    ShareLinkCreate,
+    ShareLinkRead,
+)
+
+router = APIRouter(tags=["share"])
+
+
+def _generate_token() -> str:
+    return secrets.token_urlsafe(24)
+
+
+def _resolve_share_link_org(db: Session, link: ShareLink) -> UUID:
+    node = db.get(Node, link.node_id)
+    if node is None:
+        raise HTTPException(404, "Node not found")
+    space = db.get(Space, node.space_id)
+    workspace = db.get(Workspace, space.workspace_id)
+    return workspace.org_id
+
+
+@router.post(
+    "/api/nodes/{node_id}/share-links",
+    response_model=ShareLinkRead,
+    status_code=201,
+)
+def create_share_link(
+    node_id: UUID,
+    body: ShareLinkCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    node = db.get(Node, node_id)
+    if node is None or node.deleted_at is not None:
+        raise HTTPException(404, "Node not found")
+
+    link = ShareLink(
+        node_id=node.id,
+        token=_generate_token(),
+        created_by=auth.user_id,
+        expires_at=body.expires_at,
+    )
+    db.add(link)
+    db.commit()
+    db.refresh(link)
+    return link
+
+
+@router.get(
+    "/api/nodes/{node_id}/share-links",
+    response_model=list[ShareLinkRead],
+)
+def list_share_links(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    return (
+        db.execute(
+            select(ShareLink)
+            .where(ShareLink.node_id == node_id)
+            .order_by(ShareLink.created_at.desc())
+        )
+        .scalars()
+        .all()
+    )
+
+
+@router.delete("/api/share-links/{link_id}", status_code=204)
+def revoke_share_link(
+    link_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(verify_auth),
+):
+    link = db.get(ShareLink, link_id)
+    if link is None:
+        raise HTTPException(404, "Share link not found")
+    org_id = _resolve_share_link_org(db, link)
+    _check_membership(db, org_id, auth, OrgRole.EDITOR)
+
+    if link.revoked_at is None:
+        link.revoked_at = datetime.now(timezone.utc)
+        db.commit()
+
+
+@router.get("/shared/{token}", response_model=SharedNodeRead)
+def get_shared_node(token: str, db: Session = Depends(get_db)):
+    """Public, unauthenticated view of a shared node.
+
+    For pages: returns rendered content. For folders: returns the visible
+    (non-trashed) immediate-child index.
+    """
+    link = db.execute(select(ShareLink).where(ShareLink.token == token)).scalar_one_or_none()
+    if link is None:
+        raise HTTPException(404, "Share link not found")
+    if link.revoked_at is not None:
+        raise HTTPException(410, "Share link has been revoked")
+    if link.expires_at is not None and link.expires_at < datetime.now(timezone.utc):
+        raise HTTPException(410, "Share link has expired")
+
+    node = db.get(Node, link.node_id)
+    if node is None or node.deleted_at is not None:
+        raise HTTPException(404, "Shared node not found")
+
+    response = SharedNodeRead(
+        id=node.id,
+        type=node.type,  # type: ignore[arg-type]
+        name=node.name,
+        slug=node.slug,
+        description=node.description,
+        expires_at=link.expires_at,
+    )
+
+    if node.type == "page" and node.current_revision is not None:
+        response.content = node.current_revision.content
+        response.content_format = node.current_revision.content_format  # type: ignore[assignment]
+    elif node.type == "folder":
+        children = (
+            db.execute(
+                select(Node)
+                .where(Node.parent_id == node.id, Node.deleted_at.is_(None))
+                .order_by(Node.position, Node.created_at)
+            )
+            .scalars()
+            .all()
+        )
+        response.children = [
+            SharedNodeChild(id=c.id, type=c.type, name=c.name, slug=c.slug)  # type: ignore[arg-type]
+            for c in children
+        ]
+
+    return response

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -224,3 +224,41 @@ class AuthStatus(BaseModel):
     user: UserRead | None = None
     method: str
     oidc_enabled: bool
+
+
+# ---------------------------------------------------------------------------
+# Share Links
+# ---------------------------------------------------------------------------
+
+
+class ShareLinkCreate(BaseModel):
+    expires_at: datetime | None = None
+
+
+class ShareLinkRead(_ReadBase):
+    id: UUID
+    node_id: UUID
+    token: str
+    created_by: UUID | None
+    expires_at: datetime | None
+    revoked_at: datetime | None
+    created_at: datetime
+
+
+class SharedNodeChild(BaseModel):
+    id: UUID
+    type: Literal["folder", "page"]
+    name: str
+    slug: str
+
+
+class SharedNodeRead(BaseModel):
+    id: UUID
+    type: Literal["folder", "page"]
+    name: str
+    slug: str
+    description: str | None = None
+    content: str | None = None
+    content_format: Literal["markdown", "json"] | None = None
+    children: list[SharedNodeChild] = []
+    expires_at: datetime | None = None

--- a/api/tests/test_share_links.py
+++ b/api/tests/test_share_links.py
@@ -1,0 +1,275 @@
+"""Integration tests for view-only share links (#40)."""
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from marrow.auth import COOKIE_NAME, create_session_jwt, reset_oidc_config
+from marrow.models import (
+    Node,
+    Organization,
+    OrgMembership,
+    OrgRole,
+    Revision,
+    ShareLink,
+    Space,
+    User,
+    Workspace,
+)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    reset_oidc_config()
+    yield
+    reset_oidc_config()
+
+
+@pytest.fixture
+def client():
+    from marrow.app import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _make_user(session, email: str) -> User:
+    user = User(
+        oidc_issuer="https://test.example.com",
+        oidc_subject=uuid.uuid4().hex,
+        email=email,
+        name="Test User",
+    )
+    session.add(user)
+    session.flush()
+    return user
+
+
+def _make_workspace(session) -> tuple:
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Org")
+    session.add(org)
+    session.flush()
+    ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="WS")
+    session.add(ws)
+    session.flush()
+    space = Space(workspace_id=ws.id, slug="main", name="Main")
+    session.add(space)
+    session.flush()
+    return org, ws, space
+
+
+def _make_page(session, space, name="Doc", content="# Hello") -> Node:
+    node = Node(space_id=space.id, type="page", name=name, slug=name.lower(), position="a0")
+    session.add(node)
+    session.flush()
+    rev = Revision(node_id=node.id, content=content, content_format="markdown")
+    session.add(rev)
+    session.flush()
+    node.current_revision_id = rev.id
+    session.flush()
+    return node
+
+
+def _make_folder(session, space, name="Folder", parent_id=None) -> Node:
+    node = Node(
+        space_id=space.id,
+        type="folder",
+        name=name,
+        slug=name.lower(),
+        position="a0",
+        parent_id=parent_id,
+    )
+    session.add(node)
+    session.flush()
+    return node
+
+
+def _auth_cookie(client, user):
+    token = create_session_jwt(user.id, user.email, user.name)
+    client.cookies.set(COOKIE_NAME, token)
+
+
+def _add_membership(session, org, user, role: OrgRole):
+    session.add(OrgMembership(org_id=org.id, user_id=user.id, email=user.email, role=role.value))
+    session.flush()
+
+
+class TestCreateShareLink:
+    def test_editor_can_create(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-share@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            page = _make_page(db, space)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(f"/api/nodes/{page.id}/share-links", json={})
+            assert res.status_code == 201, res.text
+            data = res.json()
+            assert data["token"]
+            assert data["revoked_at"] is None
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_viewer_cannot_create(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-share@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.VIEWER)
+            page = _make_page(db, space)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(f"/api/nodes/{page.id}/share-links", json={})
+            assert res.status_code == 403
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestPublicAccess:
+    def test_shared_page_returns_content(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "ed1@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            page = _make_page(db, space, content="public hello")
+            link = ShareLink(node_id=page.id, token="tok-page-1", created_by=user.id)
+            db.add(link)
+            db.commit()
+
+            res = client.get(f"/shared/{link.token}")
+            assert res.status_code == 200
+            body = res.json()
+            assert body["type"] == "page"
+            assert body["content"] == "public hello"
+        finally:
+            db.rollback()
+
+    def test_shared_folder_returns_children(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "ed2@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            folder = _make_folder(db, space, name="Public")
+            child = Node(
+                space_id=space.id,
+                parent_id=folder.id,
+                type="page",
+                name="Child",
+                slug="child",
+                position="a0",
+            )
+            db.add(child)
+            db.flush()
+            rev = Revision(node_id=child.id, content="x", content_format="markdown")
+            db.add(rev)
+            db.flush()
+            child.current_revision_id = rev.id
+
+            link = ShareLink(node_id=folder.id, token="tok-folder-1")
+            db.add(link)
+            db.commit()
+
+            res = client.get(f"/shared/{link.token}")
+            assert res.status_code == 200
+            body = res.json()
+            assert body["type"] == "folder"
+            assert len(body["children"]) == 1
+            assert body["children"][0]["name"] == "Child"
+        finally:
+            db.rollback()
+
+    def test_expired_link_returns_410(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "ed3@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            page = _make_page(db, space)
+            link = ShareLink(
+                node_id=page.id,
+                token="tok-expired",
+                expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+            )
+            db.add(link)
+            db.commit()
+
+            res = client.get(f"/shared/{link.token}")
+            assert res.status_code == 410
+        finally:
+            db.rollback()
+
+    def test_revoked_link_returns_410(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "ed4@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            page = _make_page(db, space)
+            link = ShareLink(
+                node_id=page.id,
+                token="tok-revoked",
+                revoked_at=datetime.now(timezone.utc),
+            )
+            db.add(link)
+            db.commit()
+
+            res = client.get(f"/shared/{link.token}")
+            assert res.status_code == 410
+        finally:
+            db.rollback()
+
+    def test_unknown_token_returns_404(self, client):
+        res = client.get("/shared/does-not-exist")
+        assert res.status_code == 404
+
+
+class TestRevoke:
+    def test_editor_can_revoke(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "rev-ed@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            page = _make_page(db, space)
+            link = ShareLink(node_id=page.id, token="tok-rev-1")
+            db.add(link)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.delete(f"/api/share-links/{link.id}")
+            assert res.status_code == 204
+
+            res2 = client.get(f"/shared/{link.token}")
+            assert res2.status_code == 410
+        finally:
+            db.rollback()
+            client.cookies.clear()

--- a/web/app/shared/[token]/page.tsx
+++ b/web/app/shared/[token]/page.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+
+import { getSharedNode } from "@/lib/api";
+import type { SharedNode } from "@/lib/types";
+
+interface Props {
+  params: Promise<{ token: string }>;
+}
+
+export default async function SharedNodePage({ params }: Props) {
+  const { token } = await params;
+
+  let node: SharedNode;
+  try {
+    node = await getSharedNode(token);
+  } catch (e) {
+    const message = (e as Error).message;
+    const expired = /410/.test(message);
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="text-2xl font-semibold">
+          {expired ? "Link no longer available" : "Link not found"}
+        </h1>
+        <p className="mt-2 text-muted-foreground">
+          {expired
+            ? "This share link has expired or been revoked."
+            : "We couldn't find a shared resource at this URL."}
+        </p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12">
+      <header className="mb-8 border-b border-border pb-4">
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">
+          Shared {node.type}
+        </div>
+        <h1 className="mt-1 text-3xl font-semibold">{node.name}</h1>
+        {node.description && (
+          <p className="mt-2 text-muted-foreground">{node.description}</p>
+        )}
+      </header>
+
+      {node.type === "page" && node.content && (
+        <article className="prose prose-neutral max-w-none whitespace-pre-wrap dark:prose-invert">
+          {node.content_format === "json" ? (
+            <pre className="text-xs">{node.content}</pre>
+          ) : (
+            node.content
+          )}
+        </article>
+      )}
+
+      {node.type === "folder" && (
+        <ul className="space-y-2">
+          {node.children.length === 0 && (
+            <li className="text-muted-foreground">This folder is empty.</li>
+          )}
+          {node.children.map((child) => (
+            <li key={child.id}>
+              <Link
+                href={`/shared/${token}/${child.slug}`}
+                className="text-primary hover:underline"
+              >
+                {child.type === "folder" ? "📁 " : "📄 "}
+                {child.name}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <footer className="mt-12 border-t border-border pt-4 text-xs text-muted-foreground">
+        Shared via Marrow — view-only access
+      </footer>
+    </main>
+  );
+}

--- a/web/components/page-menu.tsx
+++ b/web/components/page-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ArrowRight,
   BookOpen,
@@ -8,10 +8,13 @@ import {
   Eye,
   History,
   Link as LinkIcon,
+  Share2,
   Star,
   Trash2,
 } from "lucide-react";
 import { toast } from "sonner";
+
+import { ShareDialog } from "@/components/share-dialog";
 
 export type PageMenuDrawer = "backlinks" | "history";
 
@@ -40,6 +43,7 @@ const ITEMS: Item[] = [
   { kind: "action", id: "star", icon: Star, label: "Star", meta: "⌥S" },
   { kind: "action", id: "watch", icon: Eye, label: "Watch" },
   { kind: "divider" },
+  { kind: "action", id: "share", icon: Share2, label: "Share…" },
   { kind: "action", id: "duplicate", icon: Copy, label: "Duplicate" },
   { kind: "action", id: "move", icon: ArrowRight, label: "Move…" },
   { kind: "action", id: "export", icon: BookOpen, label: "Export as Markdown" },
@@ -52,10 +56,12 @@ interface Props {
   onOpenChange: (open: boolean) => void;
   onOpenDrawer: (which: PageMenuDrawer) => void;
   trigger: React.ReactNode;
+  nodeId?: string;
 }
 
-export function PageMenu({ open, onOpenChange, onOpenDrawer, trigger }: Props) {
+export function PageMenu({ open, onOpenChange, onOpenDrawer, trigger, nodeId }: Props) {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const [shareOpen, setShareOpen] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -92,6 +98,13 @@ export function PageMenu({ open, onOpenChange, onOpenDrawer, trigger }: Props) {
                 onClick={() => {
                   if (item.kind === "drawer") {
                     onOpenDrawer(item.id);
+                  } else if (item.id === "share") {
+                    if (!nodeId) {
+                      toast.error("Cannot share — no node id available");
+                    } else {
+                      setShareOpen(true);
+                    }
+                    onOpenChange(false);
                   } else {
                     toast.info(`${item.label} — coming soon`);
                     onOpenChange(false);
@@ -116,6 +129,9 @@ export function PageMenu({ open, onOpenChange, onOpenDrawer, trigger }: Props) {
             );
           })}
         </div>
+      )}
+      {nodeId && (
+        <ShareDialog open={shareOpen} onOpenChange={setShareOpen} nodeId={nodeId} />
       )}
     </div>
   );

--- a/web/components/share-dialog.tsx
+++ b/web/components/share-dialog.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Copy, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  createShareLink,
+  listShareLinks,
+  revokeShareLink,
+  shareLinkUrl,
+} from "@/lib/api";
+import type { ShareLink } from "@/lib/types";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  nodeId: string;
+}
+
+export function ShareDialog({ open, onOpenChange, nodeId }: Props) {
+  const [links, setLinks] = useState<ShareLink[]>([]);
+  const [expiresAt, setExpiresAt] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    listShareLinks(nodeId)
+      .then(setLinks)
+      .catch((e) => toast.error(`Failed to load share links: ${e.message}`));
+  }, [open, nodeId]);
+
+  async function handleCreate() {
+    setLoading(true);
+    try {
+      const iso = expiresAt ? new Date(expiresAt).toISOString() : null;
+      const link = await createShareLink(nodeId, iso);
+      setLinks((prev) => [link, ...prev]);
+      setExpiresAt("");
+      toast.success("Share link created");
+    } catch (e) {
+      toast.error(`Failed to create link: ${(e as Error).message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleRevoke(id: string) {
+    try {
+      await revokeShareLink(id);
+      setLinks((prev) =>
+        prev.map((l) =>
+          l.id === id ? { ...l, revoked_at: new Date().toISOString() } : l,
+        ),
+      );
+      toast.success("Share link revoked");
+    } catch (e) {
+      toast.error(`Failed to revoke: ${(e as Error).message}`);
+    }
+  }
+
+  function handleCopy(token: string) {
+    const url = shareLinkUrl(token);
+    void navigator.clipboard.writeText(url);
+    toast.success("Link copied to clipboard");
+  }
+
+  function statusOf(link: ShareLink): "active" | "expired" | "revoked" {
+    if (link.revoked_at) return "revoked";
+    if (link.expires_at && new Date(link.expires_at) < new Date()) return "expired";
+    return "active";
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Share view-only link</DialogTitle>
+          <DialogDescription>
+            Anyone with the link can read this content without signing in.
+            Sharing a folder also shares its contents.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-end gap-2">
+          <div className="flex-1">
+            <label className="mb-1 block text-xs text-muted-foreground">
+              Expires (optional)
+            </label>
+            <Input
+              type="datetime-local"
+              value={expiresAt}
+              onChange={(e) => setExpiresAt(e.target.value)}
+            />
+          </div>
+          <Button onClick={handleCreate} disabled={loading}>
+            Create link
+          </Button>
+        </div>
+
+        <div className="mt-4 max-h-64 space-y-2 overflow-y-auto">
+          {links.length === 0 && (
+            <p className="text-sm text-muted-foreground">No share links yet.</p>
+          )}
+          {links.map((link) => {
+            const status = statusOf(link);
+            const url = shareLinkUrl(link.token);
+            return (
+              <div
+                key={link.id}
+                className="flex items-center gap-2 rounded-md border border-border p-2 text-sm"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-mono text-xs">{url}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {status === "active" && link.expires_at && (
+                      <>Expires {new Date(link.expires_at).toLocaleString()}</>
+                    )}
+                    {status === "active" && !link.expires_at && <>Never expires</>}
+                    {status === "expired" && <>Expired</>}
+                    {status === "revoked" && <>Revoked</>}
+                  </div>
+                </div>
+                {status === "active" && (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleCopy(link.token)}
+                      aria-label="Copy link"
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleRevoke(link.id)}
+                      aria-label="Revoke link"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -15,6 +15,8 @@ import type {
   Page,
   Revision,
   SearchResponse,
+  SharedNode,
+  ShareLink,
   Space,
   Workspace,
   WorkspaceTree,
@@ -311,6 +313,39 @@ export function removeMember(orgId: string, membershipId: string): Promise<void>
   return apiFetch(`/api/orgs/${orgId}/members/${membershipId}`, {
     method: "DELETE",
   });
+}
+
+// ---------------------------------------------------------------------------
+// Share Links
+// ---------------------------------------------------------------------------
+
+export function listShareLinks(nodeId: string): Promise<ShareLink[]> {
+  return apiFetch(`/api/nodes/${nodeId}/share-links`);
+}
+
+export function createShareLink(
+  nodeId: string,
+  expiresAt: string | null = null,
+): Promise<ShareLink> {
+  return apiFetch(`/api/nodes/${nodeId}/share-links`, {
+    method: "POST",
+    body: JSON.stringify({ expires_at: expiresAt }),
+  });
+}
+
+export function revokeShareLink(linkId: string): Promise<void> {
+  return apiFetch(`/api/share-links/${linkId}`, { method: "DELETE" });
+}
+
+export function getSharedNode(token: string): Promise<SharedNode> {
+  return apiFetch(`/shared/${token}`);
+}
+
+export function shareLinkUrl(token: string): string {
+  if (typeof window !== "undefined") {
+    return `${window.location.origin}/shared/${token}`;
+  }
+  return `/shared/${token}`;
 }
 
 /** Convert a display name to a URL-safe slug. */

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -129,3 +129,33 @@ export interface AuthStatus {
   method: string;
   oidc_enabled: boolean;
 }
+
+// Share Links
+export interface ShareLink {
+  id: string;
+  node_id: string;
+  token: string;
+  created_by: string | null;
+  expires_at: string | null;
+  revoked_at: string | null;
+  created_at: string;
+}
+
+export interface SharedNodeChild {
+  id: string;
+  type: "folder" | "page";
+  name: string;
+  slug: string;
+}
+
+export interface SharedNode {
+  id: string;
+  type: "folder" | "page";
+  name: string;
+  slug: string;
+  description: string | null;
+  content: string | null;
+  content_format: "markdown" | "json" | null;
+  children: SharedNodeChild[];
+  expires_at: string | null;
+}

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const PUBLIC_PATHS = ["/login", "/auth/callback", "/_next", "/favicon.ico"];
+const PUBLIC_PATHS = ["/login", "/auth/callback", "/shared", "/_next", "/favicon.ico"];
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;


### PR DESCRIPTION
Closes #40.

## Summary
- New `share_links` table (id, node_id, token, created_by, expires_at, revoked_at, created_at) — Alembic migration `a7c91d2f1e40`.
- `POST /api/nodes/{id}/share-links` (editor+) creates a token; `GET` lists; `DELETE /api/share-links/{id}` (editor+) revokes.
- Public `GET /shared/{token}` returns read-only content with no auth — pages return content, folders return a child index. Expired/revoked links return 410; unknown tokens 404.
- Frontend: `ShareDialog` accessible from the page menu (Share…), with create/copy/revoke and optional expiry. Public `/shared/[token]` route renders the node read-only and is whitelisted in the proxy.
- Tests in `api/tests/test_share_links.py` cover create/RBAC, public access for pages and folders, expired/revoked/unknown tokens, and revoke.

## Notes / out of scope
- Export/restore inclusion (bundle v4) — deferred. The export/restore pipeline currently NameErrors at runtime (per CLAUDE.md, v4 rewrite lands in #132/#133). Adding share_links to the bundle format is best done alongside that rewrite.
- The `pytest` suite could not be executed in the swarm worker (no PostgreSQL available). `ruff check` passes on all touched files; the FastAPI app imports cleanly and registers all share routes.

## Test plan
- [ ] `alembic upgrade head` against a fresh DB
- [ ] `pytest tests/test_share_links.py`
- [ ] Manual: create a share link from the page menu, open `/shared/{token}` in an incognito window, verify content; revoke and confirm 410.
- [ ] Expired link returns 410

_Created by swarm coordinator_