### PR TITLE
feat: #126 2.0d: Soft-delete & trash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,9 +98,10 @@ cd api && alembic revision --autogenerate -m "description"
 cd api && alembic upgrade head
 cd api && alembic downgrade -1
 
-# CLI (export/restore)
+# CLI (export/restore/trash)
 cd api && marrow export --workspace <slug> --output <path>
 cd api && marrow restore <bundle.zip>
+cd api && marrow purge-trash --older-than-days 30   # hard-delete old trashed nodes (cron'able)
 
 # Frontend
 cd web && npm run dev
@@ -274,6 +275,9 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | POST | /api/workspaces/restore | Restore a workspace from an uploaded export bundle zip | — |
 | GET/POST | /api/workspaces/{id}/spaces/ | List / create spaces | viewer/editor |
 | GET/DELETE | /api/workspaces/{id}/spaces/{sid} | Get / delete space | viewer/owner |
+| GET | /api/workspaces/{id}/trash | List top-level trashed nodes | viewer |
+| POST | /api/nodes/{id}/restore | Restore a trashed node + subtree (422 if parent still trashed) | editor |
+| DELETE | /api/nodes/{id}/purge | Hard-delete a trashed node and its subtree | owner |
 
 > **Note (#123 → #125):** v0.1's collection-scoped and global page routes were removed by the schema migration. Node CRUD/tree/attachment/revision routes land in #124 (2.0b) under `/api/nodes/...` and `/api/spaces/{sid}/nodes`. The workspace `/search` endpoint is node-aware as of #125 (2.0c). The `/tree`, `/export`, and `/restore` endpoints are still wired but their handlers will NameError at runtime until the node-aware rewrites land in #124, #132, and #133.
 >

--- a/api/marrow/cli.py
+++ b/api/marrow/cli.py
@@ -89,5 +89,60 @@ def restore(
         raise typer.Exit(1)
 
 
+@app.command("purge-trash")
+def purge_trash(
+    older_than_days: int = typer.Option(
+        30, "--older-than-days", help="Purge trashed nodes older than N days"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Report what would be deleted without changing anything"
+    ),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="DATABASE_URL", help="PostgreSQL connection URL"
+    ),
+) -> None:
+    """Hard-delete trashed nodes older than the threshold.
+
+    Safe to run repeatedly — only nodes with ``deleted_at < NOW() - INTERVAL``
+    are affected. Children are removed via the existing ON DELETE CASCADE FKs,
+    so only top-level trashed ancestors need to be deleted explicitly.
+    """
+    load_dotenv()
+
+    from sqlalchemy import text
+
+    from .db import get_session
+
+    with get_session(database_url) as session:
+        # Only delete top-level trashed nodes (parent is NULL or live); children
+        # cascade via FK. Otherwise we'd attempt to delete already-cascaded rows.
+        rows = session.execute(
+            text("""
+                SELECT n.id FROM nodes n
+                LEFT JOIN nodes p ON p.id = n.parent_id
+                WHERE n.deleted_at IS NOT NULL
+                  AND n.deleted_at < NOW() - make_interval(days => :days)
+                  AND (n.parent_id IS NULL OR p.deleted_at IS NULL)
+            """),
+            {"days": older_than_days},
+        ).fetchall()
+        ids = [r[0] for r in rows]
+
+        if dry_run:
+            typer.echo(f"Would purge {len(ids)} top-level trashed node(s).")
+            return
+
+        if not ids:
+            typer.echo("No trashed nodes to purge.")
+            return
+
+        session.execute(
+            text("DELETE FROM nodes WHERE id = ANY(:ids)"),
+            {"ids": ids},
+        )
+        session.commit()
+        typer.echo(f"Purged {len(ids)} trashed node(s) (cascaded to descendants).")
+
+
 if __name__ == "__main__":
     app()

--- a/api/marrow/cli.py
+++ b/api/marrow/cli.py
@@ -109,9 +109,10 @@ def purge_trash(
     """
     load_dotenv()
 
-    from sqlalchemy import text
+    from sqlalchemy import delete, text
 
     from .db import get_session
+    from .models import Node
 
     with get_session(database_url) as session:
         # Only delete top-level trashed nodes (parent is NULL or live); children
@@ -136,10 +137,7 @@ def purge_trash(
             typer.echo("No trashed nodes to purge.")
             return
 
-        session.execute(
-            text("DELETE FROM nodes WHERE id = ANY(:ids)"),
-            {"ids": ids},
-        )
+        session.execute(delete(Node).where(Node.id.in_(ids)))
         session.commit()
         typer.echo(f"Purged {len(ids)} trashed node(s) (cascaded to descendants).")
 

--- a/api/marrow/rbac.py
+++ b/api/marrow/rbac.py
@@ -116,7 +116,11 @@ def require_node_role(min_role: OrgRole):
         if node is None or node.deleted_at is not None:
             raise HTTPException(404, "Node not found")
         space = db.get(Space, node.space_id)
+        if space is None:
+            raise HTTPException(404, "Space not found")
         workspace = db.get(Workspace, space.workspace_id)
+        if workspace is None:
+            raise HTTPException(404, "Workspace not found")
         _check_membership(db, workspace.org_id, auth, min_role)
         return auth
 

--- a/api/marrow/routers/nodes.py
+++ b/api/marrow/routers/nodes.py
@@ -47,7 +47,11 @@ def _trashed_node_or_404(node_id: UUID, db: Session) -> Node:
 def _authorize_node(db: Session, node: Node, auth: AuthContext, min_role: OrgRole) -> None:
     """Resolve node → org and enforce role. Works for soft-deleted nodes too."""
     space = db.get(Space, node.space_id)
+    if space is None:
+        raise HTTPException(404, "Space not found")
     workspace = db.get(Workspace, space.workspace_id)
+    if workspace is None:
+        raise HTTPException(404, "Workspace not found")
     _check_membership(db, workspace.org_id, auth, min_role)
 
 

--- a/api/marrow/routers/nodes.py
+++ b/api/marrow/routers/nodes.py
@@ -6,13 +6,13 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Response, UploadFile
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from ..dependencies import AuthContext, get_db, get_storage
-from ..models import Attachment, Node, OrgRole, Revision, Space
-from ..rbac import require_node_role, require_space_role
+from ..dependencies import AuthContext, get_db, get_storage, verify_auth
+from ..models import Attachment, Node, OrgRole, Revision, Space, Workspace
+from ..rbac import _check_membership, require_node_role, require_space_role
 from ..schemas import (
     AttachmentRead,
     NodeCreate,
@@ -34,6 +34,21 @@ def _node_or_404(node_id: UUID, db: Session) -> Node:
     if node is None or node.deleted_at is not None:
         raise HTTPException(404, "Node not found")
     return node
+
+
+def _trashed_node_or_404(node_id: UUID, db: Session) -> Node:
+    """Fetch a node (possibly soft-deleted) for trash operations."""
+    node = db.get(Node, node_id)
+    if node is None:
+        raise HTTPException(404, "Node not found")
+    return node
+
+
+def _authorize_node(db: Session, node: Node, auth: AuthContext, min_role: OrgRole) -> None:
+    """Resolve node → org and enforce role. Works for soft-deleted nodes too."""
+    space = db.get(Space, node.space_id)
+    workspace = db.get(Workspace, space.workspace_id)
+    _check_membership(db, workspace.org_id, auth, min_role)
 
 
 def _with_content(node: Node) -> NodeReadWithContent:
@@ -169,17 +184,80 @@ def delete_node(
     db: Session = Depends(get_db),
     auth: AuthContext = Depends(require_node_role(OrgRole.OWNER)),
 ):
-    node = _node_or_404(node_id, db)
-    now = datetime.now(timezone.utc)
+    """Soft-delete a node and all descendants in a single transaction."""
+    _node_or_404(node_id, db)
+    db.execute(
+        text("""
+            WITH RECURSIVE subtree(id) AS (
+                SELECT id FROM nodes WHERE id = :root AND deleted_at IS NULL
+                UNION ALL
+                SELECT n.id FROM nodes n
+                JOIN subtree s ON n.parent_id = s.id
+                WHERE n.deleted_at IS NULL
+            )
+            UPDATE nodes SET deleted_at = NOW()
+            WHERE id IN (SELECT id FROM subtree)
+        """),
+        {"root": node_id},
+    )
+    db.commit()
 
-    def _soft_delete(n: Node) -> None:
-        n.deleted_at = now
-        for child in db.execute(
-            select(Node).where(Node.parent_id == n.id, Node.deleted_at.is_(None))
-        ).scalars():
-            _soft_delete(child)
 
-    _soft_delete(node)
+@router.post("/api/nodes/{node_id}/restore", response_model=NodeRead)
+def restore_node(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(verify_auth),
+):
+    """Restore a soft-deleted node and its trashed subtree.
+
+    422 if the node's parent is itself trashed (no live ancestor to attach to)."""
+    node = _trashed_node_or_404(node_id, db)
+    _authorize_node(db, node, auth, OrgRole.EDITOR)
+
+    if node.deleted_at is None:
+        raise HTTPException(409, "Node is not trashed")
+
+    if node.parent_id is not None:
+        parent = db.get(Node, node.parent_id)
+        if parent is None or parent.deleted_at is not None:
+            raise HTTPException(
+                422, "Cannot restore: parent node is missing or trashed"
+            )
+
+    db.execute(
+        text("""
+            WITH RECURSIVE subtree(id) AS (
+                SELECT id FROM nodes WHERE id = :root AND deleted_at IS NOT NULL
+                UNION ALL
+                SELECT n.id FROM nodes n
+                JOIN subtree s ON n.parent_id = s.id
+                WHERE n.deleted_at IS NOT NULL
+            )
+            UPDATE nodes SET deleted_at = NULL
+            WHERE id IN (SELECT id FROM subtree)
+        """),
+        {"root": node_id},
+    )
+    db.commit()
+    db.refresh(node)
+    return node
+
+
+@router.delete("/api/nodes/{node_id}/purge", status_code=204)
+def purge_node(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(verify_auth),
+):
+    """Hard-delete a trashed node and its subtree (owners only)."""
+    node = _trashed_node_or_404(node_id, db)
+    _authorize_node(db, node, auth, OrgRole.OWNER)
+
+    if node.deleted_at is None:
+        raise HTTPException(409, "Node must be trashed before it can be purged")
+
+    db.delete(node)
     db.commit()
 
 

--- a/api/marrow/routers/workspaces.py
+++ b/api/marrow/routers/workspaces.py
@@ -18,6 +18,7 @@ from ..dependencies import AuthContext, get_db, get_search_backend, verify_auth
 from ..models import Node, OrgMembership, OrgRole, Space, Workspace
 from ..rbac import require_workspace_role
 from ..schemas import (
+    NodeRead,
     NodeTreeItem,
     SearchResponse,
     SearchResultItem,
@@ -199,6 +200,41 @@ def get_workspace_tree(
             )
             for s in spaces
         ],
+    )
+
+
+@router.get("/{workspace_id}/trash", response_model=list[NodeRead])
+def list_workspace_trash(
+    workspace_id: UUID,
+    db: Session = Depends(get_db),
+    _: AuthContext = Depends(require_workspace_role(OrgRole.VIEWER)),
+):
+    """List top-level trashed nodes — those whose nearest non-trashed ancestor
+    is the space (either a root node, or a node whose parent is still live)."""
+    space_ids = [
+        sid
+        for (sid,) in db.execute(
+            select(Space.id).where(Space.workspace_id == workspace_id)
+        ).all()
+    ]
+    if not space_ids:
+        return []
+
+    # Trashed node is "top-level" iff parent_id is NULL or parent.deleted_at IS NULL.
+    parent = Node.__table__.alias("parent")
+    return (
+        db.execute(
+            select(Node)
+            .outerjoin(parent, parent.c.id == Node.parent_id)
+            .where(
+                Node.space_id.in_(space_ids),
+                Node.deleted_at.is_not(None),
+                (Node.parent_id.is_(None)) | (parent.c.deleted_at.is_(None)),
+            )
+            .order_by(Node.deleted_at.desc())
+        )
+        .scalars()
+        .all()
     )
 
 

--- a/api/tests/test_nodes.py
+++ b/api/tests/test_nodes.py
@@ -299,6 +299,297 @@ class TestDeleteNode:
             client.cookies.clear()
 
 
+class TestTrash:
+    def test_delete_cascade_then_restore_subtree(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "owner-trash@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.OWNER)
+
+            parent = Node(
+                space_id=space.id, type="folder", name="P", slug="p", position="a0"
+            )
+            db.add(parent)
+            db.flush()
+            child = Node(
+                space_id=space.id,
+                parent_id=parent.id,
+                type="folder",
+                name="C",
+                slug="c",
+                position="a0",
+            )
+            db.add(child)
+            db.flush()
+            grandchild = Node(
+                space_id=space.id,
+                parent_id=child.id,
+                type="page",
+                name="GC",
+                slug="gc",
+                position="a0",
+            )
+            db.add(grandchild)
+            db.commit()
+
+            _auth_cookie(client, user)
+
+            res = client.delete(f"/api/nodes/{parent.id}")
+            assert res.status_code == 204
+
+            db.expire_all()
+            db.refresh(parent)
+            db.refresh(child)
+            db.refresh(grandchild)
+            assert parent.deleted_at is not None
+            assert child.deleted_at is not None
+            assert grandchild.deleted_at is not None
+
+            res = client.post(f"/api/nodes/{parent.id}/restore")
+            assert res.status_code == 200, res.text
+
+            db.expire_all()
+            db.refresh(parent)
+            db.refresh(child)
+            db.refresh(grandchild)
+            assert parent.deleted_at is None
+            assert child.deleted_at is None
+            assert grandchild.deleted_at is None
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_workspace_trash_lists_top_level(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-trash@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.OWNER)
+
+            parent = Node(
+                space_id=space.id, type="folder", name="P", slug="p", position="a0"
+            )
+            db.add(parent)
+            db.flush()
+            child = Node(
+                space_id=space.id,
+                parent_id=parent.id,
+                type="page",
+                name="C",
+                slug="c",
+                position="a0",
+            )
+            db.add(child)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.delete(f"/api/nodes/{parent.id}")
+            assert res.status_code == 204
+
+            res = client.get(f"/api/workspaces/{ws.id}/trash")
+            assert res.status_code == 200
+            items = res.json()
+            ids = {item["id"] for item in items}
+            assert str(parent.id) in ids
+            # child is trashed but its parent is also trashed → not top-level
+            assert str(child.id) not in ids
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_restore_with_trashed_parent_rejected(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-rejrestore@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.OWNER)
+
+            parent = Node(
+                space_id=space.id, type="folder", name="P", slug="p", position="a0"
+            )
+            db.add(parent)
+            db.flush()
+            child = Node(
+                space_id=space.id,
+                parent_id=parent.id,
+                type="page",
+                name="C",
+                slug="c",
+                position="a0",
+            )
+            db.add(child)
+            db.commit()
+
+            _auth_cookie(client, user)
+            client.delete(f"/api/nodes/{parent.id}")
+
+            # child alone cannot be restored — its parent is still trashed
+            res = client.post(f"/api/nodes/{child.id}/restore")
+            assert res.status_code == 422
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_search_excludes_trashed_pages(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-trash-search@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.OWNER)
+
+            node = Node(
+                space_id=space.id,
+                type="page",
+                name="findme-trash-target",
+                slug="findme",
+                position="a0",
+            )
+            db.add(node)
+            db.flush()
+            rev = Revision(
+                node_id=node.id,
+                content="findme-trash-target body",
+                content_format="markdown",
+            )
+            db.add(rev)
+            db.flush()
+            node.current_revision_id = rev.id
+            db.commit()
+
+            _auth_cookie(client, user)
+
+            res = client.get(
+                f"/api/workspaces/{ws.id}/search", params={"q": "findme-trash-target"}
+            )
+            assert res.status_code == 200
+            assert any(r["node_id"] == str(node.id) for r in res.json()["results"])
+
+            client.delete(f"/api/nodes/{node.id}")
+
+            res = client.get(
+                f"/api/workspaces/{ws.id}/search", params={"q": "findme-trash-target"}
+            )
+            assert res.status_code == 200
+            assert not any(r["node_id"] == str(node.id) for r in res.json()["results"])
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_purge_endpoint_hard_deletes(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "owner-purge@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.OWNER)
+
+            node = Node(
+                space_id=space.id, type="folder", name="Z", slug="z", position="a0"
+            )
+            db.add(node)
+            db.commit()
+            node_id = node.id
+
+            _auth_cookie(client, user)
+            client.delete(f"/api/nodes/{node_id}")
+
+            res = client.delete(f"/api/nodes/{node_id}/purge")
+            assert res.status_code == 204
+
+            db.expire_all()
+            assert db.get(Node, node_id) is None
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_purge_rejects_live_node(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "owner-purge-live@test.com")
+            org, ws, space = _make_workspace(db)
+            _add_membership(db, org, user, OrgRole.OWNER)
+
+            node = Node(
+                space_id=space.id, type="folder", name="L", slug="l", position="a0"
+            )
+            db.add(node)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.delete(f"/api/nodes/{node.id}/purge")
+            assert res.status_code == 409
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_cli_purge_trash_respects_threshold(self):
+        """CLI purge-trash deletes only nodes older than the threshold."""
+        from datetime import datetime, timedelta, timezone
+
+        from typer.testing import CliRunner
+
+        from marrow.cli import app as cli_app
+        from marrow.dependencies import get_db
+
+        runner = CliRunner()
+
+        db = next(get_db())
+        try:
+            _user = _make_user(db, "cli-purge@test.com")
+            org, ws, space = _make_workspace(db)
+
+            old = Node(
+                space_id=space.id,
+                type="folder",
+                name="Old",
+                slug="old",
+                position="a0",
+                deleted_at=datetime.now(timezone.utc) - timedelta(days=40),
+            )
+            db.add(old)
+            recent = Node(
+                space_id=space.id,
+                type="folder",
+                name="Rec",
+                slug="rec",
+                position="b0",
+                deleted_at=datetime.now(timezone.utc) - timedelta(days=5),
+            )
+            db.add(recent)
+            db.commit()
+            old_id = old.id
+            recent_id = recent.id
+        finally:
+            db.close()
+
+        # Use the same env DATABASE_URL the test session uses.
+        result = runner.invoke(cli_app, ["purge-trash", "--older-than-days", "30"])
+        assert result.exit_code == 0, result.output
+
+        db = next(get_db())
+        try:
+            assert db.get(Node, old_id) is None
+            assert db.get(Node, recent_id) is not None
+            # Cleanup
+            n = db.get(Node, recent_id)
+            db.delete(n)
+            db.commit()
+        finally:
+            db.close()
+
+
 class TestRevisions:
     def test_list_revisions_multiple_entries(self, client):
         from marrow.dependencies import get_db


### PR DESCRIPTION
Closes #126.

## Summary
- `DELETE /api/nodes/{id}` now soft-deletes the node and its entire subtree in one transaction via a recursive CTE.
- New endpoints:
  - `GET /api/workspaces/{id}/trash` — lists top-level trashed nodes (those whose nearest non-trashed ancestor is the space).
  - `POST /api/nodes/{id}/restore` — restores a trashed node and its trashed descendants (422 if the parent is still trashed).
  - `DELETE /api/nodes/{id}/purge` — hard-deletes a trashed node and cascades to its descendants (owners only).
- `marrow purge-trash --older-than-days 30` CLI for scheduled cleanup; safe to re-run; only deletes top-level trashed roots and lets ON DELETE CASCADE clean up descendants.
- Test coverage: cascade soft-delete, cascade restore, trash listing top-level only, search excludes trashed pages, restore-with-trashed-parent 422, CLI threshold respect, purge rejects live nodes.

_Created by swarm coordinator_