### PR TITLE
feat: #129 2.0g: Workspace auto-create + creation UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,7 +265,9 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | POST | /api/orgs/{oid}/members | Invite member by email | owner |
 | PATCH | /api/orgs/{oid}/members/{mid} | Change member role | owner |
 | DELETE | /api/orgs/{oid}/members/{mid} | Remove member | owner |
-| GET/POST | /api/workspaces/ | List / create workspaces | viewer/editor |
+| POST | /api/orgs/{oid}/workspaces | Create workspace in org (#129) | editor |
+| GET | /api/workspaces/ | List workspaces | viewer |
+| POST | /api/workspaces/ | **410 Gone** — use POST /api/orgs/{oid}/workspaces | — |
 | GET/DELETE | /api/workspaces/{id} | Get / delete workspace | viewer/owner |
 | GET | /api/workspaces/{id}/tree | Full hierarchy (sidebar) | viewer |
 | GET | /api/workspaces/{id}/search?q= | Full-text search across workspace pages | viewer |

--- a/api/marrow/routers/organizations.py
+++ b/api/marrow/routers/organizations.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..dependencies import AuthContext, get_db, verify_auth
-from ..models import Organization, OrgMembership, OrgRole, User
+from ..models import Organization, OrgMembership, OrgRole, User, Workspace
 from ..rbac import require_org_role
 from ..schemas import (
     OrganizationCreate,
@@ -16,6 +16,8 @@ from ..schemas import (
     OrgMembershipCreate,
     OrgMembershipRead,
     OrgMembershipUpdate,
+    WorkspaceCreate,
+    WorkspaceRead,
 )
 from .billing import TIER_SEAT_LIMITS, _saas_mode
 
@@ -71,6 +73,25 @@ def create_org(
     db.commit()
     db.refresh(org)
     return org
+
+
+@router.post("/{org_id}/workspaces", response_model=WorkspaceRead, status_code=201)
+def create_workspace_in_org(
+    org_id: UUID,
+    body: WorkspaceCreate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_org_role(OrgRole.EDITOR)),
+):
+    """Create a workspace in the given org. Requires editor or owner role."""
+    ws = Workspace(org_id=org_id, slug=body.slug, name=body.name)
+    db.add(ws)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(409, f"Workspace slug '{body.slug}' already exists")
+    db.refresh(ws)
+    return ws
 
 
 @router.get("/{org_id}", response_model=OrganizationRead)

--- a/api/marrow/routers/workspaces.py
+++ b/api/marrow/routers/workspaces.py
@@ -11,18 +11,16 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..dependencies import AuthContext, get_db, get_search_backend, verify_auth
-from ..models import Node, OrgMembership, OrgRole, Space, Workspace
+from ..models import Node, OrgRole, Space, Workspace
 from ..rbac import require_workspace_role
 from ..schemas import (
     NodeTreeItem,
     SearchResponse,
     SearchResultItem,
     SpaceTreeItem,
-    WorkspaceCreate,
     WorkspaceRead,
     WorkspaceTree,
 )
@@ -79,38 +77,10 @@ def list_workspaces(
     )
 
 
-@router.post("", response_model=WorkspaceRead, status_code=201)
-def create_workspace(
-    body: WorkspaceCreate,
-    db: Session = Depends(get_db),
-    auth: AuthContext = Depends(verify_auth),
-):
-    org_id = body.org_id
-
-    # For session users without explicit org_id, use their first org
-    if org_id is None and auth.user_id is not None:
-        membership = db.execute(
-            select(OrgMembership)
-            .where(OrgMembership.user_id == auth.user_id)
-            .order_by(OrgMembership.created_at)
-        ).scalar_one_or_none()
-        if membership is None:
-            raise HTTPException(403, "You must belong to an organization to create a workspace")
-        org_id = membership.org_id
-
-    # For API key/anonymous, org_id is required
-    if org_id is None:
-        raise HTTPException(422, "org_id is required for API key or anonymous access")
-
-    ws = Workspace(org_id=org_id, slug=body.slug, name=body.name)
-    db.add(ws)
-    try:
-        db.commit()
-    except IntegrityError:
-        db.rollback()
-        raise HTTPException(status_code=409, detail=f"Workspace slug '{body.slug}' already exists")
-    db.refresh(ws)
-    return ws
+@router.post("", status_code=410)
+def create_workspace_deprecated():
+    """Deprecated: use POST /api/orgs/{org_id}/workspaces instead."""
+    raise HTTPException(410, "This endpoint has been removed. Use POST /api/orgs/{org_id}/workspaces instead.")
 
 
 @router.post("/restore", response_model=WorkspaceRead, status_code=201)

--- a/api/tests/test_nodes.py
+++ b/api/tests/test_nodes.py
@@ -456,3 +456,76 @@ class TestListSpaceRootNodes:
         finally:
             db.rollback()
             client.cookies.clear()
+
+
+class TestCreateWorkspaceInOrg:
+    def test_editor_can_create_workspace(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "editor-ws@test.com")
+            org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Test Org")
+            db.add(org)
+            db.flush()
+            _add_membership(db, org, user, OrgRole.EDITOR)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(
+                f"/api/orgs/{org.id}/workspaces",
+                json={"slug": "new-ws", "name": "New Workspace"},
+            )
+            assert res.status_code == 201, res.text
+            data = res.json()
+            assert data["slug"] == "new-ws"
+            assert data["org_id"] == str(org.id)
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_viewer_cannot_create_workspace(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "viewer-ws@test.com")
+            org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Test Org")
+            db.add(org)
+            db.flush()
+            _add_membership(db, org, user, OrgRole.VIEWER)
+            db.commit()
+
+            _auth_cookie(client, user)
+            res = client.post(
+                f"/api/orgs/{org.id}/workspaces",
+                json={"slug": "viewer-ws", "name": "Viewer Workspace"},
+            )
+            assert res.status_code == 403
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_old_create_workspace_route_returns_410(self, client):
+        res = client.post("/api/workspaces", json={"slug": "old", "name": "Old"})
+        assert res.status_code == 410
+
+    def test_slug_conflict_returns_409(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user = _make_user(db, "owner-ws@test.com")
+            org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Test Org")
+            db.add(org)
+            db.flush()
+            _add_membership(db, org, user, OrgRole.OWNER)
+            db.commit()
+
+            _auth_cookie(client, user)
+            client.post(f"/api/orgs/{org.id}/workspaces", json={"slug": "dupe", "name": "First"})
+            res = client.post(f"/api/orgs/{org.id}/workspaces", json={"slug": "dupe", "name": "Second"})
+            assert res.status_code == 409
+        finally:
+            db.rollback()
+            client.cookies.clear()

--- a/web/app/workspaces/page.tsx
+++ b/web/app/workspaces/page.tsx
@@ -6,8 +6,8 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ChevronRight, Settings } from "lucide-react";
-import { createWorkspace, getAuthStatus, listOrgs, listWorkspaces, logout, slugify } from "@/lib/api";
+import { ChevronRight, ChevronsUpDown, Settings } from "lucide-react";
+import { createWorkspaceInOrg, getAuthStatus, listOrgs, listWorkspaces, logout, slugify } from "@/lib/api";
 import type { AuthStatus, Organization, Workspace } from "@/lib/types";
 import { RestoreDialog } from "@/components/restore-dialog";
 
@@ -18,19 +18,31 @@ export default function WorkspacesPage() {
   const [auth, setAuth] = useState<AuthStatus | null>(null);
   const [name, setName] = useState("");
   const [creating, setCreating] = useState(false);
+  const [selectedOrgId, setSelectedOrgId] = useState<string | null>(null);
 
   useEffect(() => {
     listWorkspaces().then(setWorkspaces).catch(() => toast.error("Failed to load workspaces"));
-    listOrgs().then(setOrgs).catch(() => {});
+    listOrgs().then((loaded) => {
+      setOrgs(loaded);
+      if (loaded.length > 0 && !selectedOrgId) {
+        setSelectedOrgId(loaded[0].id);
+      }
+    }).catch(() => {});
     getAuthStatus().then(setAuth).catch(() => {});
   }, []);
+
+  const selectedOrg = orgs.find((o) => o.id === selectedOrgId) ?? orgs[0] ?? null;
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
     if (!name.trim()) return;
+    if (!selectedOrg) {
+      toast.error("No organization available to create workspace in");
+      return;
+    }
     setCreating(true);
     try {
-      const ws = await createWorkspace(slugify(name), name.trim());
+      const ws = await createWorkspaceInOrg(selectedOrg.id, slugify(name), name.trim());
       router.push(`/w/${ws.id}`);
     } catch (err) {
       toast.error(String(err));
@@ -113,7 +125,31 @@ export default function WorkspacesPage() {
         )}
 
         {/* Create workspace */}
-        <div className="rounded-lg border bg-card p-4">
+        <div className="rounded-lg border bg-card p-4 space-y-3">
+          {selectedOrg && (
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground">
+                Creating workspace in <span className="font-semibold text-foreground">{selectedOrg.name}</span>
+              </p>
+              {orgs.length > 1 && (
+                <div className="relative">
+                  <select
+                    value={selectedOrgId ?? ""}
+                    onChange={(e) => setSelectedOrgId(e.target.value)}
+                    className="appearance-none text-xs text-muted-foreground bg-transparent pr-5 cursor-pointer hover:text-foreground transition-colors focus:outline-none"
+                    disabled={creating}
+                  >
+                    {orgs.map((org) => (
+                      <option key={org.id} value={org.id}>
+                        {org.name}
+                      </option>
+                    ))}
+                  </select>
+                  <ChevronsUpDown className="pointer-events-none absolute right-0 top-0.5 h-3 w-3 text-muted-foreground" />
+                </div>
+              )}
+            </div>
+          )}
           <form onSubmit={handleCreate} className="flex gap-2">
             <Input
               placeholder="New workspace name"
@@ -121,7 +157,7 @@ export default function WorkspacesPage() {
               onChange={(e) => setName(e.target.value)}
               disabled={creating}
             />
-            <Button type="submit" disabled={creating || !name.trim()}>
+            <Button type="submit" disabled={creating || !name.trim() || !selectedOrg}>
               Create
             </Button>
           </form>

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -78,8 +78,16 @@ export function listWorkspaces(): Promise<Workspace[]> {
   return apiFetch("/api/workspaces");
 }
 
+/** @deprecated Use createWorkspaceInOrg instead. */
 export function createWorkspace(slug: string, name: string): Promise<Workspace> {
   return apiFetch("/api/workspaces", {
+    method: "POST",
+    body: JSON.stringify({ slug, name }),
+  });
+}
+
+export function createWorkspaceInOrg(orgId: string, slug: string, name: string): Promise<Workspace> {
+  return apiFetch(`/api/orgs/${orgId}/workspaces`, {
     method: "POST",
     body: JSON.stringify({ slug, name }),
   });


### PR DESCRIPTION
Closes #129.

## Changes

**Backend**
- `POST /api/orgs/{org_id}/workspaces` — new org-scoped workspace creation route; requires `editor` role or above
- `POST /api/workspaces` — returns **410 Gone** with a pointer to the new route

**Frontend**
- `createWorkspaceInOrg(orgId, slug, name)` added to `web/lib/api.ts`
- `workspaces/page.tsx`: org_id field removed from the create form; active org is shown as context ("Creating workspace in **Acme Corp**"); multi-org users get an inline org switcher; after creation the user is navigated directly into the new workspace

**Tests**
- `TestCreateWorkspaceInOrg` in `test_nodes.py`: covers editor can create, viewer cannot (403), slug conflict (409), deprecated route (410)

_Created by swarm coordinator_