### PR TITLE
feat: #59 2.2a: Cloudflare R2 storage adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,13 @@ STORAGE_PATH=./storage       # resolves relative to api/ directory
 API_KEY=                     # optional; if set, enforces X-API-Key header on all routes
 CORS_ORIGINS=http://localhost:3000
 
+# Cloudflare R2 storage (optional — set STORAGE_BACKEND=r2 to use R2 instead of local disk)
+# STORAGE_BACKEND=r2
+# R2_ACCOUNT_ID=             # your Cloudflare account ID
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=
+# R2_BUCKET=
+
 # OIDC Authentication (optional — omit OIDC_ISSUER to disable)
 # OIDC_ISSUER=https://accounts.google.com
 # OIDC_CLIENT_ID=

--- a/api/.env.example
+++ b/api/.env.example
@@ -8,6 +8,13 @@ SECRET_KEY=changeme
 # Relative paths resolve from the api/ directory; absolute paths also work.
 STORAGE_PATH=./storage
 
+# Cloudflare R2 storage (optional — set STORAGE_BACKEND=r2 to use R2 instead of local disk)
+# STORAGE_BACKEND=r2
+# R2_ACCOUNT_ID=
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=
+# R2_BUCKET=
+
 # API key authentication (optional — omit to allow anonymous access in dev)
 # API_KEY=
 

--- a/api/marrow/storage.py
+++ b/api/marrow/storage.py
@@ -38,7 +38,7 @@ class LocalFilesystemAdapter(StorageAdapter):
 class R2StorageAdapter(StorageAdapter):
     """Reads/writes attachments in a Cloudflare R2 bucket (S3-compatible API).
 
-    Set STORAGE_BACKEND=r2 plus R2_ENDPOINT_URL, R2_ACCESS_KEY_ID,
+    Set STORAGE_BACKEND=r2 plus R2_ACCOUNT_ID, R2_ACCESS_KEY_ID,
     R2_SECRET_ACCESS_KEY, and R2_BUCKET to use this adapter.
     """
 
@@ -76,8 +76,10 @@ class R2StorageAdapter(StorageAdapter):
 def get_default_adapter() -> StorageAdapter:
     backend = os.getenv("STORAGE_BACKEND", "local").lower()
     if backend == "r2":
+        account_id = os.environ["R2_ACCOUNT_ID"]
+        endpoint_url = f"https://{account_id}.r2.cloudflarestorage.com"
         return R2StorageAdapter(
-            endpoint_url=os.environ["R2_ENDPOINT_URL"],
+            endpoint_url=endpoint_url,
             access_key_id=os.environ["R2_ACCESS_KEY_ID"],
             secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
             bucket=os.environ["R2_BUCKET"],


### PR DESCRIPTION
Closes #59.

## Changes

- `get_default_adapter()` now reads `R2_ACCOUNT_ID` and constructs the R2 endpoint URL (`https://{account_id}.r2.cloudflarestorage.com`) — matches the acceptance criteria in the issue (previously used `R2_ENDPOINT_URL`)
- `api/.env.example` documents `STORAGE_BACKEND`, `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`
- `CLAUDE.md` updated with R2 env vars in the backend env block

The `R2StorageAdapter` class, `boto3` dependency, and `moto[s3]` test dependency were already present; `test_storage.py` covers write/read round-trips via moto-mocked S3.

_Created by swarm coordinator_