### PR TITLE
feat: #111 2.13: Multi-workspace switcher in avatar popover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,9 @@ marrow/
 │   │       ├── c333d20a46d9_add_content_format_to_revisions.py
 │   │       ├── bd52bac0673f_node_tree_schema_collapse_collections_.py
 │   │       ├── 2b5326d2d299_add_rls_tenant_isolation.py
-│   │       └── fdf65c08ffa8_add_node_fts_triggers_and_gin_index.py
+│   │       ├── fdf65c08ffa8_add_node_fts_triggers_and_gin_index.py
+│   │       ├── c58f38d0a5aa_add_billing_columns_to_organizations.py
+│   │       └── e3f7a92b1d05_add_members_can_create_spaces_to_orgs.py
 │   ├── marrow/                       # Main package
 │   │   ├── app.py                    # FastAPI app factory, CORS + session middleware
 │   │   ├── auth.py                   # OIDC config, session JWT helpers, cookie params
@@ -249,7 +251,7 @@ organizations → org_memberships (user roles: owner/editor/viewer)
 
 | Table | Key columns |
 | --- | --- |
-| organizations | id, slug (unique), name |
+| organizations | id, slug (unique), name, members_can_create_spaces (bool, default true) |
 | org_memberships | id, org_id (FK), user_id (FK, nullable for pending), email, role (owner/editor/viewer) |
 | workspaces | id, org_id (FK), slug (unique), name |
 | spaces | id, workspace_id (FK cascade), slug (unique per workspace), name |
@@ -288,6 +290,7 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | POST | /api/auth/logout | Clear session cookie | — |
 | GET/POST | /api/orgs | List user's orgs / create org | session |
 | GET | /api/orgs/{oid} | Get org details | viewer |
+| PATCH | /api/orgs/{oid} | Update org settings (members_can_create_spaces) | owner |
 | GET | /api/orgs/{oid}/members | List members (incl. pending) | viewer |
 | POST | /api/orgs/{oid}/members | Invite member by email | owner |
 | PATCH | /api/orgs/{oid}/members/{mid} | Change member role | owner |

--- a/api/alembic/versions/e3f7a92b1d05_add_members_can_create_spaces_to_orgs.py
+++ b/api/alembic/versions/e3f7a92b1d05_add_members_can_create_spaces_to_orgs.py
@@ -1,0 +1,33 @@
+"""add members_can_create_spaces to organizations
+
+Revision ID: e3f7a92b1d05
+Revises: c58f38d0a5aa
+Create Date: 2026-05-14 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'e3f7a92b1d05'
+down_revision: Union[str, Sequence[str], None] = 'c58f38d0a5aa'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'organizations',
+        sa.Column(
+            'members_can_create_spaces',
+            sa.Boolean(),
+            server_default='true',
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('organizations', 'members_can_create_spaces')

--- a/api/marrow/models.py
+++ b/api/marrow/models.py
@@ -53,6 +53,11 @@ class Organization(Base):
     stripe_subscription_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True)
     self_hosted_license: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # Permissions
+    members_can_create_spaces: Mapped[bool] = mapped_column(
+        nullable=False, server_default="true"
+    )
+
     memberships: Mapped[list["OrgMembership"]] = relationship(
         back_populates="organization", passive_deletes=True
     )

--- a/api/marrow/routers/organizations.py
+++ b/api/marrow/routers/organizations.py
@@ -13,6 +13,7 @@ from ..rbac import require_org_role
 from ..schemas import (
     OrganizationCreate,
     OrganizationRead,
+    OrganizationUpdate,
     OrgMembershipCreate,
     OrgMembershipRead,
     OrgMembershipUpdate,
@@ -103,6 +104,24 @@ def get_org(
     org = db.get(Organization, org_id)
     if org is None:
         raise HTTPException(404, "Organization not found")
+    return org
+
+
+@router.patch("/{org_id}", response_model=OrganizationRead)
+def update_org(
+    org_id: UUID,
+    body: OrganizationUpdate,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_org_role(OrgRole.OWNER)),
+):
+    """Update org-level settings. Requires owner role."""
+    org = db.get(Organization, org_id)
+    if org is None:
+        raise HTTPException(404, "Organization not found")
+    if body.members_can_create_spaces is not None:
+        org.members_can_create_spaces = body.members_can_create_spaces
+    db.commit()
+    db.refresh(org)
     return org
 
 

--- a/api/marrow/routers/spaces.py
+++ b/api/marrow/routers/spaces.py
@@ -3,11 +3,12 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..dependencies import AuthContext, get_db
-from ..models import OrgRole, Space, Workspace
+from ..models import OrgMembership, OrgRole, Organization, Space, Workspace
 from ..rbac import require_workspace_role
 from ..schemas import SpaceCreate, SpaceRead
 
@@ -38,7 +39,19 @@ def create_space(
     db: Session = Depends(get_db),
     auth: AuthContext = Depends(require_workspace_role(OrgRole.EDITOR)),
 ):
-    _get_workspace_or_404(workspace_id, db)
+    ws = _get_workspace_or_404(workspace_id, db)
+
+    # If the org restricts space creation to owners only, enforce that here
+    if auth.user_id is not None:
+        org = db.get(Organization, ws.org_id)
+        if org is not None and not org.members_can_create_spaces:
+            membership = db.execute(
+                select(OrgMembership)
+                .where(OrgMembership.org_id == ws.org_id, OrgMembership.user_id == auth.user_id)
+            ).scalar_one_or_none()
+            if membership is None or membership.role != OrgRole.OWNER:
+                raise HTTPException(403, "Only org owners can create spaces in this workspace")
+
     space = Space(workspace_id=workspace_id, slug=body.slug, name=body.name)
     db.add(space)
     try:

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -310,6 +310,11 @@ class OrganizationRead(_ReadBase):
     slug: str
     name: str
     created_at: datetime
+    members_can_create_spaces: bool = True
+
+
+class OrganizationUpdate(BaseModel):
+    members_can_create_spaces: bool | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/web/app/orgs/[orgId]/settings/page.tsx
+++ b/web/app/orgs/[orgId]/settings/page.tsx
@@ -13,6 +13,7 @@ import {
   inviteMember,
   updateMemberRole,
   removeMember,
+  updateOrg,
 } from "@/lib/api";
 import type { Organization, OrgMembership } from "@/lib/types";
 
@@ -25,6 +26,7 @@ export default function OrgSettingsPage() {
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState<string>("editor");
   const [busy, setBusy] = useState(false);
+  const [savingPermission, setSavingPermission] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -146,6 +148,38 @@ export default function OrgSettingsPage() {
           {members.length === 0 && (
             <p className="px-4 py-3 text-sm text-muted-foreground">No members</p>
           )}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Permissions</h2>
+        <div className="flex items-center justify-between rounded-md border px-4 py-3">
+          <div className="space-y-0.5">
+            <p className="text-sm font-medium">Allow members to create spaces</p>
+            <p className="text-xs text-muted-foreground">
+              When off, only owners can create spaces in this org&apos;s workspaces.
+            </p>
+          </div>
+          <input
+            type="checkbox"
+            disabled={savingPermission}
+            checked={org.members_can_create_spaces}
+            onChange={async (e) => {
+              setSavingPermission(true);
+              try {
+                const updated = await updateOrg(orgId, {
+                  members_can_create_spaces: e.target.checked,
+                });
+                setOrg(updated);
+                toast.success("Setting saved");
+              } catch (err) {
+                toast.error(String(err));
+              } finally {
+                setSavingPermission(false);
+              }
+            }}
+            className="h-4 w-4 cursor-pointer accent-primary"
+          />
         </div>
       </section>
 

--- a/web/app/w/[workspaceId]/layout.tsx
+++ b/web/app/w/[workspaceId]/layout.tsx
@@ -20,14 +20,16 @@ export default async function WorkspaceLayout({ children, params }: Props) {
     throw e;
   }
 
-  const auth = await getAuthStatus().catch(() => null);
-  const members = await listOrgMembers(tree.org_id).catch(() => null);
-  const memberCount = members ? members.length : null;
-
-  const [orgs, workspaces] = await Promise.all([
+  const [auth, members, orgs, workspaces] = await Promise.all([
+    getAuthStatus().catch(() => null),
+    listOrgMembers(tree.org_id).catch(() => null),
     listOrgs().catch(() => null),
-    listWorkspaces().catch(() => null),
+    listWorkspaces().catch(() => [] as Awaited<ReturnType<typeof listWorkspaces>>),
   ]);
+
+  const memberCount = members ? members.length : null;
+  const userMembership = members?.find((m) => m.user_id === auth?.user?.id) ?? null;
+  const userRole = userMembership?.role ?? null;
 
   // Hide org settings for solo users (exactly 1 org, that org has exactly 1 workspace).
   // Show as soon as user has 2+ orgs OR any org has 2+ workspaces.
@@ -39,7 +41,14 @@ export default async function WorkspaceLayout({ children, params }: Props) {
   })();
 
   return (
-    <WorkspaceShell tree={tree} user={auth?.user ?? null} memberCount={memberCount} showOrgSettings={showOrgSettings}>
+    <WorkspaceShell
+      tree={tree}
+      user={auth?.user ?? null}
+      memberCount={memberCount}
+      showOrgSettings={showOrgSettings}
+      workspaces={workspaces ?? []}
+      userRole={userRole}
+    >
       {children}
     </WorkspaceShell>
   );

--- a/web/components/app-rail.tsx
+++ b/web/components/app-rail.tsx
@@ -1,22 +1,25 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { FolderClosed, Search, Star, Inbox, LogOut } from "lucide-react";
+import { FolderClosed, Search, Star, Inbox, LogOut, Plus, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SettingsDialog } from "@/components/settings-dialog";
 import { logout } from "@/lib/api";
-import type { User } from "@/lib/types";
+import type { User, Workspace } from "@/lib/types";
 
 export type RailPanel = "pages" | "search" | "starred" | "inbox";
 
 interface Props {
   workspaceName: string;
+  currentWorkspaceId: string;
   panel: RailPanel;
   onPanelChange: (panel: RailPanel) => void;
   sidebarOpen: boolean;
   onSidebarToggle: () => void;
   user?: User | null;
   inboxUnread?: number;
+  workspaces: Workspace[];
+  userRole: string | null;
 }
 
 const TABS: Array<{ id: RailPanel; label: string; Icon: typeof FolderClosed }> = [
@@ -35,12 +38,15 @@ function initials(name?: string | null) {
 
 export function AppRail({
   workspaceName,
+  currentWorkspaceId,
   panel,
   onPanelChange,
   sidebarOpen,
   onSidebarToggle,
   user,
   inboxUnread = 0,
+  workspaces,
+  userRole,
 }: Props) {
   return (
     <div className="flex w-14 shrink-0 flex-col items-center gap-1 border-r border-sidebar-border bg-sidebar py-3.5">
@@ -94,14 +100,33 @@ export function AppRail({
         iconClassName="h-4 w-4"
       />
 
-      {user && <UserMenu user={user} />}
+      {user && (
+        <UserMenu
+          user={user}
+          workspaces={workspaces}
+          currentWorkspaceId={currentWorkspaceId}
+          userRole={userRole}
+        />
+      )}
     </div>
   );
 }
 
-function UserMenu({ user }: { user: User }) {
+function UserMenu({
+  user,
+  workspaces,
+  currentWorkspaceId,
+  userRole,
+}: {
+  user: User;
+  workspaces: Workspace[];
+  currentWorkspaceId: string;
+  userRole: string | null;
+}) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+
+  const canCreateWorkspace = userRole === "owner" || userRole === null;
 
   useEffect(() => {
     if (!open) return;
@@ -127,13 +152,63 @@ function UserMenu({ user }: { user: User }) {
       {open && (
         <div
           role="menu"
-          className="absolute bottom-0 left-[calc(100%+8px)] z-50 w-60 rounded-md border border-border bg-popover py-1 shadow-lg"
+          className="absolute bottom-0 left-[calc(100%+8px)] z-50 w-64 rounded-md border border-border bg-popover py-1 shadow-lg"
         >
+          {/* User identity */}
           <div className="px-3 py-2">
             <p className="truncate text-sm font-medium text-foreground">{user.name}</p>
             <p className="truncate text-xs text-muted-foreground">{user.email}</p>
           </div>
+
           <div className="my-1 border-t border-border" />
+
+          {/* Workspace switcher */}
+          {workspaces.length > 0 && (
+            <>
+              <p className="px-3 pb-1 pt-0.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                Workspaces
+              </p>
+              <div className="max-h-48 overflow-y-auto">
+                {workspaces.map((ws) => {
+                  const isCurrent = ws.id === currentWorkspaceId;
+                  return (
+                    <a
+                      key={ws.id}
+                      href={`/w/${ws.id}`}
+                      role="menuitem"
+                      onClick={() => setOpen(false)}
+                      className={cn(
+                        "flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent",
+                        isCurrent ? "text-foreground" : "text-foreground/80",
+                      )}
+                    >
+                      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-primary/10 text-[10px] font-semibold text-primary">
+                        {ws.name[0]?.toUpperCase()}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate">{ws.name}</span>
+                      {isCurrent && <Check className="h-3.5 w-3.5 shrink-0 text-primary" />}
+                    </a>
+                  );
+                })}
+              </div>
+
+              {canCreateWorkspace && (
+                <a
+                  href="/workspaces"
+                  role="menuitem"
+                  onClick={() => setOpen(false)}
+                  className="flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Create workspace
+                </a>
+              )}
+
+              <div className="my-1 border-t border-border" />
+            </>
+          )}
+
+          {/* Sign out */}
           <button
             type="button"
             role="menuitem"

--- a/web/components/workspace-shell.tsx
+++ b/web/components/workspace-shell.tsx
@@ -6,17 +6,19 @@ import { AppRail, type RailPanel } from "@/components/app-rail";
 import { AppSidebar } from "@/components/app-sidebar";
 import { WorkspaceTreeProvider } from "@/components/workspace-tree-context";
 import { listNotifications } from "@/lib/api";
-import type { User, WorkspaceTree } from "@/lib/types";
+import type { User, Workspace, WorkspaceTree } from "@/lib/types";
 
 interface Props {
   tree: WorkspaceTree;
   user: User | null;
   memberCount: number | null;
   showOrgSettings: boolean;
+  workspaces: Workspace[];
+  userRole: string | null;
   children: React.ReactNode;
 }
 
-export function WorkspaceShell({ tree, user, memberCount, showOrgSettings, children }: Props) {
+export function WorkspaceShell({ tree, user, memberCount, showOrgSettings, workspaces, userRole, children }: Props) {
   const [panel, setPanel] = useState<RailPanel>("pages");
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [inboxUnread, setInboxUnread] = useState(0);
@@ -58,12 +60,15 @@ export function WorkspaceShell({ tree, user, memberCount, showOrgSettings, child
       <div className="flex h-svh w-full overflow-hidden bg-background text-foreground">
         <AppRail
           workspaceName={tree.name}
+          currentWorkspaceId={tree.id}
           panel={panel}
           onPanelChange={setPanel}
           sidebarOpen={sidebarOpen}
           onSidebarToggle={() => setSidebarOpen((v) => !v)}
           user={user}
           inboxUnread={inboxUnread}
+          workspaces={workspaces}
+          userRole={userRole}
         />
         {sidebarOpen && (
           <AppSidebar

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -331,6 +331,16 @@ export function getOrg(orgId: string): Promise<Organization> {
   return apiFetch(`/api/orgs/${orgId}`);
 }
 
+export function updateOrg(
+  orgId: string,
+  patch: { members_can_create_spaces?: boolean }
+): Promise<Organization> {
+  return apiFetch(`/api/orgs/${orgId}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+}
+
 export function listOrgMembers(orgId: string): Promise<OrgMembership[]> {
   return apiFetch(`/api/orgs/${orgId}/members`);
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -5,6 +5,7 @@ export interface Organization {
   slug: string;
   name: string;
   created_at: string;
+  members_can_create_spaces: boolean;
 }
 
 export interface OrgMembership {


### PR DESCRIPTION
Closes #111.

## What's in this PR

**Backend**
- `PATCH /api/orgs/{id}` — new endpoint for owners to update org settings; currently exposes `members_can_create_spaces`
- `POST /api/workspaces` — now requires `owner` role for session-authenticated users (API key / anonymous bypass retained for backward compat)
- `POST /api/workspaces/{id}/spaces` — when `org.members_can_create_spaces = false`, enforces `owner` role instead of the default `editor`
- `GET /api/workspaces/{id}/tree` — now returns `org_id` in the response (was missing, causing the workspace layout's `listOrgMembers` call to hit `/api/orgs/undefined/members`)
- Alembic migration `e3f7a92b1d05` adds `members_can_create_spaces boolean NOT NULL DEFAULT true` to `organizations`

**Frontend**
- Avatar popover (`UserMenu` in `app-rail.tsx`) now shows a workspace switcher — all workspaces the user has access to, with the current one checked; "Create workspace" link appears only for owners
- Workspace layout fetches the workspace list and resolves the user's role in the current org, passing both down to `AppRail`
- Org settings page (`/orgs/[orgId]/settings`) has a new "Permissions" section with a checkbox to toggle `members_can_create_spaces`

**Tests / housekeeping**
- `test_migration_cycle.py` updated to reference the `nodes` table (v0.2 schema) and assert that full downgrade raises `NotImplementedError` (the v0.2 collapse migration is intentionally one-way)

_Created by swarm coordinator_