### PR TITLE
feat: #42 2.4: Node properties system — typed key-value metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,8 @@ marrow/
 │   │       ├── nodes.py               # Node CRUD, revisions, attachments, star/unstar (#124, #102)
 │   │       ├── share_links.py         # View-only sharing links + public /shared/{token} (#40)
 │   │       ├── comments.py            # Page-level comments: CRUD, resolve, replies (#101)
-│   │       └── users.py               # GET /api/users/me/starred (#102)
+│   │       ├── users.py               # GET /api/users/me/starred (#102)
+│   │       └── properties.py          # Node property schemas + values (#42)
 │   │       # Node CRUD/tree routes land in #124 (2.0b); old collection/page routers
 │   │       # were removed by the v0.2 schema migration (#123).
 │   ├── tests/
@@ -257,6 +258,7 @@ organizations → org_memberships (user roles: owner/editor/viewer)
 | attachments | id, node_id (FK cascade), filename, hash (SHA256), size_bytes |
 | node_links | id, source_node_id (FK cascade), target_node_id (FK cascade), unique (source, target) — backlink index, reconciled on every page save |
 | comments | id, node_id (FK cascade, page-only — app-enforced), author_user_id (FK SET NULL, nullable), parent_comment_id (self-FK cascade, nullable for replies), body (TEXT), resolved_at (nullable), created_at, updated_at |
+| node_properties | id, node_id (FK cascade), key, value (nullable), value_type, options (JSON list — select types), updated_at; unique (node_id, key); value_type ∈ {text, number, date, select, multi-select, checkbox} |
 | users | id, oidc_issuer, oidc_subject (unique together), email, name, last_login_at |
 | share_links | id, node_id (FK cascade), token (unique), created_by (FK users, SET NULL), expires_at (nullable), created_at |
 | user_stars | id, user_id (FK cascade), node_id (FK cascade), created_at — unique on (user_id, node_id); per-user, **never exported** |
@@ -319,6 +321,10 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | GET | /api/users/me/notifications?unread_only= | List own Inbox notifications + unread_count | session |
 | PATCH | /api/notifications/{nid} | Mark a notification read | session |
 | POST | /api/users/me/notifications/read-all | Mark all own notifications read | session |
+| GET | /api/nodes/{id}/property-schema | List a folder's property schema defs | viewer |
+| PUT/DELETE | /api/nodes/{id}/property-schema/{key} | Define/update / remove a folder schema property | editor |
+| GET | /api/nodes/{id}/properties | Effective properties for a page (inherited + own) | viewer |
+| PUT/DELETE | /api/nodes/{id}/properties/{key} | Set / clear a page's property value | editor |
 
 > **Share links (#40):** `share_links` grant view-only public access to a node.
 > `GET /shared/{token}` requires no account: a page returns its current
@@ -337,6 +343,7 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 > **Search response shape (v0.2):** `SearchResultItem` fields are `node_id`, `name`, `snippet`, `space_id`, `space_name`, `node_path` (list of ancestor folder names, root→leaf), `rank`. The old `page_id`, `title`, `collection_id`, `collection_name` fields are gone.
 >
 > **Backlinks (#100, 2.6):** `GET /api/nodes/{nid}/backlinks` returns the nodes that link to `{nid}` (min role `viewer`, trashed sources excluded). `marrow/links.py` parses wiki-links and reconciles the `node_links` table on every page create/update via `reconcile_node_links()`. Export/restore calls `serialize_node_links()` / `rebuild_node_links()` to persist the index in `links.json`.
+> **Node properties (#42, 2.4):** Folder nodes declare a property schema (key + `value_type` + `options`); every descendant page inherits it (nearest-ancestor wins) and may set its own value. Effective properties resolve at read time via the ancestor folder chain. Property keys+values fold into the page `search_vector` at weight C — a single `marrow_node_search_vector(uuid)` SQL helper computes the full vector and all node search triggers (revision-insert, name-change, and the new `node_properties` change trigger) keep it consistent. Frontend: `web/components/property-editor.tsx` renders chips/date pickers/dropdowns/checkboxes below the page title. Export/restore bundle bumped to **v4** (`node_properties` array in `manifest.json`); the v4 export/restore *handlers* still depend on the #132/#133 node-aware rewrite to run end-to-end, but the property serialization (`export.serialize_node_properties`) and restore loop are in place and symmetric.
 
 ### Storage Adapter Interface
 
@@ -367,6 +374,9 @@ marrow-export-{workspace-slug}-slim-{timestamp}.zip     # slim
 ```
 
 **Schema versions**: v1/v2 were Markdown-only. v3 added `.json` as canonical. v4 (Marrow 0.2) carries the `nodes` tree (folders + pages, with `parent_id`, `position`, `deleted_at`) instead of the old `collections`+`pages` shape. Restore supports v1–v4 — older bundles are auto-upgraded onto the node tree on read.
+v1/v2 bundles had only `.md` files. v3 adds `.json` as canonical for JSON-format revisions.
+v4 adds a `node_properties` array to `manifest.json` (folder schemas + page values).
+Restore supports v1, v2, v3, and v4 bundles.
 
 **Slim bundles** omit the `revisions/` directory entirely and set `"slim": true` + `"revisions": []` in `manifest.json`. Restore recreates one revision per page from `pages/` content. CLI: `marrow export --slim`; API: `?slim=true`.
 

--- a/api/alembic/versions/2187bd1a529d_add_node_properties_table.py
+++ b/api/alembic/versions/2187bd1a529d_add_node_properties_table.py
@@ -1,0 +1,181 @@
+"""add node_properties table
+
+Revision ID: 2187bd1a529d
+Revises: c58f38d0a5aa
+Create Date: 2026-05-16 14:10:05.736075
+
+Adds typed key-value metadata to nodes (folder schemas + page values) and
+folds property text into the page search_vector so properties are searchable
+via FTS. A shared `marrow_node_search_vector(uuid)` function recomputes the
+full vector (name → weight A, content → B, properties → C); all node search
+triggers are rewritten to use it, plus a new trigger on `node_properties`.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2187bd1a529d"
+down_revision: Union[str, Sequence[str], None] = "c58f38d0a5aa"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "node_properties",
+        sa.Column(
+            "id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False
+        ),
+        sa.Column("node_id", sa.UUID(), nullable=False),
+        sa.Column("key", sa.Text(), nullable=False),
+        sa.Column("value", sa.Text(), nullable=True),
+        sa.Column("value_type", sa.Text(), nullable=False),
+        sa.Column("options", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "value_type IN ('text', 'number', 'date', 'select', 'multi-select', 'checkbox')",
+            name="node_properties_value_type_valid",
+        ),
+        sa.ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("node_id", "key", name="uq_node_properties_node_key"),
+    )
+    op.create_index(
+        "idx_node_properties_node", "node_properties", ["node_id"], unique=False
+    )
+
+    # Shared helper: full search_vector for a page node (name A, content B,
+    # property keys+values C). Used by every node search trigger so that none
+    # of them clobber another signal's contribution.
+    op.execute("""
+        CREATE OR REPLACE FUNCTION marrow_node_search_vector(p_node_id uuid)
+        RETURNS tsvector LANGUAGE sql STABLE AS $$
+            SELECT
+                setweight(to_tsvector('english', COALESCE(
+                    (SELECT name FROM nodes WHERE id = p_node_id), '')), 'A') ||
+                setweight(to_tsvector('english', COALESCE(
+                    (SELECT r.content FROM revisions r
+                     JOIN nodes n ON n.current_revision_id = r.id
+                     WHERE n.id = p_node_id), '')), 'B') ||
+                setweight(to_tsvector('english', COALESCE(
+                    (SELECT string_agg(key || ' ' || COALESCE(value, ''), ' ')
+                     FROM node_properties WHERE node_id = p_node_id), '')), 'C')
+        $$;
+    """)
+
+    # Rewrite revision-insert trigger. The trigger fires AFTER INSERT on
+    # revisions, before nodes.current_revision_id is repointed, so the body
+    # text must come from NEW.content directly (not a current_revision lookup).
+    # Property text is folded in as weight C.
+    op.execute("""
+        CREATE OR REPLACE FUNCTION update_node_search_vector()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            UPDATE nodes
+            SET search_vector =
+                setweight(to_tsvector('english', COALESCE(nodes.name, '')), 'A') ||
+                setweight(to_tsvector('english', COALESCE(NEW.content, '')), 'B') ||
+                setweight(to_tsvector('english', COALESCE(
+                    (SELECT string_agg(key || ' ' || COALESCE(value, ''), ' ')
+                     FROM node_properties WHERE node_id = NEW.node_id), '')), 'C')
+            WHERE id = NEW.node_id AND type = 'page';
+            RETURN NEW;
+        END;
+        $$;
+    """)
+
+    # Rewrite name/slug-change trigger. Recompute from NEW values directly so
+    # the not-yet-committed name is reflected; properties folded in as weight C.
+    op.execute("""
+        CREATE OR REPLACE FUNCTION update_node_search_vector_on_name_change()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            IF NEW.type = 'page' THEN
+                NEW.search_vector :=
+                    setweight(to_tsvector('english', COALESCE(NEW.name, '')), 'A') ||
+                    setweight(to_tsvector('english', COALESCE(
+                        (SELECT content FROM revisions WHERE id = NEW.current_revision_id),
+                        '')), 'B') ||
+                    setweight(to_tsvector('english', COALESCE(
+                        (SELECT string_agg(key || ' ' || COALESCE(value, ''), ' ')
+                         FROM node_properties WHERE node_id = NEW.id), '')), 'C');
+            END IF;
+            RETURN NEW;
+        END;
+        $$;
+    """)
+
+    # New: refresh the owning page's search_vector when its properties change.
+    op.execute("""
+        CREATE OR REPLACE FUNCTION update_node_search_vector_on_property_change()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        DECLARE
+            target uuid := COALESCE(NEW.node_id, OLD.node_id);
+        BEGIN
+            UPDATE nodes
+            SET search_vector = marrow_node_search_vector(target)
+            WHERE id = target AND type = 'page';
+            RETURN NULL;
+        END;
+        $$;
+    """)
+    op.execute("""
+        CREATE TRIGGER trg_property_update_node_search_vector
+        AFTER INSERT OR UPDATE OR DELETE ON node_properties
+        FOR EACH ROW EXECUTE FUNCTION update_node_search_vector_on_property_change();
+    """)
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_property_update_node_search_vector ON node_properties"
+    )
+    op.execute("DROP FUNCTION IF EXISTS update_node_search_vector_on_property_change()")
+    op.drop_index("idx_node_properties_node", table_name="node_properties")
+    op.drop_table("node_properties")
+
+    # Restore the pre-properties trigger function bodies (no node_properties ref).
+    op.execute("""
+        CREATE OR REPLACE FUNCTION update_node_search_vector()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            UPDATE nodes
+            SET search_vector =
+                setweight(to_tsvector('english', COALESCE(nodes.name, '')), 'A') ||
+                setweight(to_tsvector('english', COALESCE(NEW.content, '')), 'B')
+            WHERE id = NEW.node_id AND type = 'page';
+            RETURN NEW;
+        END;
+        $$;
+    """)
+    op.execute("""
+        CREATE OR REPLACE FUNCTION update_node_search_vector_on_name_change()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            IF NEW.type = 'page' THEN
+                NEW.search_vector :=
+                    setweight(to_tsvector('english', COALESCE(NEW.name, '')), 'A') ||
+                    setweight(to_tsvector('english', COALESCE(
+                        (SELECT content FROM revisions WHERE id = NEW.current_revision_id),
+                        '')), 'B');
+            END IF;
+            RETURN NEW;
+        END;
+        $$;
+    """)
+    op.execute("DROP FUNCTION IF EXISTS marrow_node_search_vector(uuid)")

--- a/api/marrow/app.py
+++ b/api/marrow/app.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from .dependencies import verify_auth
-from .routers import auth, billing, comments, nodes, notifications, organizations, share_links, spaces, users, workspaces
+from .routers import auth, billing, comments, nodes, notifications, organizations, properties, share_links, spaces, users, workspaces
 
 
 def _truthy(value: str | None) -> bool:
@@ -97,6 +97,7 @@ app.include_router(nodes.router, dependencies=_auth)
 app.include_router(comments.router, dependencies=_auth)
 app.include_router(users.router, dependencies=_auth)
 app.include_router(notifications.router, dependencies=_auth)
+app.include_router(properties.router, dependencies=_auth)
 # Share-links router is registered WITHOUT the global auth dependency: the
 # public GET /shared/{token} view must be reachable without an account, while
 # the management routes carry their own require_node_role / require_share_link_role

--- a/api/marrow/export.py
+++ b/api/marrow/export.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 from sqlalchemy.orm import Session
 
-from .models import Node, Workspace
+from .models import Attachment, Node, NodeProperty, Workspace
 from .storage import StorageAdapter
 
 SCHEMA_VERSION = "4"
@@ -238,12 +238,30 @@ def _build_links(nodes: list[Node], node_id_set: set[str]) -> dict:
     }
 
 
+def serialize_node_properties(properties: list[NodeProperty]) -> list[dict]:
+    return [
+        {
+            "id": str(p.id),
+            "node_id": str(p.node_id),
+            "key": p.key,
+            "value": p.value,
+            "value_type": p.value_type,
+            "options": p.options,
+            "created_at": p.created_at.isoformat(),
+            "updated_at": p.updated_at.isoformat(),
+        }
+        for p in properties
+    ]
+
+
 def _build_manifest(
     workspace: Workspace,
     nodes: list[Node],
     attachment_records: list[dict],
     export_timestamp: str,
     include_trash: bool = False,
+    *,
+    node_properties: list[dict] | None = None,
 ) -> dict:
     spaces = workspace.spaces
     page_nodes = [n for n in nodes if n.type == "page"]
@@ -311,6 +329,7 @@ def _build_manifest(
         "nodes": node_records,
         "revisions": revision_records,
         "attachments": attachment_records,
+        "node_properties": node_properties or [],
     }
 
 
@@ -455,8 +474,16 @@ def export_workspace(
 
         zf.writestr("links.json", json.dumps(_build_links(nodes, node_id_set), indent=2))
 
+        node_id_list = [n.id for n in all_nodes]
+        prop_rows = (
+            session.query(NodeProperty)
+            .filter(NodeProperty.node_id.in_(node_id_list))
+            .all()
+        ) if node_id_list else []
+
         manifest = _build_manifest(
-            workspace, nodes, attachment_records, export_timestamp, include_trash=include_trash
+            workspace, nodes, attachment_records, export_timestamp, include_trash=include_trash,
+            node_properties=serialize_node_properties(prop_rows) if prop_rows else None,
         )
         if slim:
             manifest["slim"] = True

--- a/api/marrow/models.py
+++ b/api/marrow/models.py
@@ -233,6 +233,43 @@ class Attachment(Base):
     node: Mapped["Node"] = relationship(back_populates="attachments")
 
 
+class NodeProperty(Base):
+    """Typed key-value metadata attached to a node.
+
+    Folder nodes declare schema definitions (key + value_type + options).
+    Page nodes store actual values for those keys. Inheritance is resolved
+    at read time by walking ancestor folders.
+    """
+
+    __tablename__ = "node_properties"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    node_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    key: Mapped[str] = mapped_column(Text, nullable=False)
+    value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    value_type: Mapped[str] = mapped_column(Text, nullable=False)
+    options: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+        UniqueConstraint("node_id", "key", name="uq_node_properties_node_key"),
+        CheckConstraint(
+            "value_type IN ('text', 'number', 'date', 'select', 'multi-select', 'checkbox')",
+            name="node_properties_value_type_valid",
+        ),
+    )
+
+    node: Mapped["Node"] = relationship(back_populates="properties")
+
+
 class ShareLink(Base):
     """A view-only public link to a node (folder or page).
 

--- a/api/marrow/restore.py
+++ b/api/marrow/restore.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from sqlalchemy.orm import Session
 
 from .links import rebuild_node_links
-from .models import Attachment, Node, Organization, Revision, Space, Workspace
+from .models import Attachment, Node, NodeProperty, Organization, Revision, Space, Workspace
 from .storage import StorageAdapter
 
 logger = logging.getLogger(__name__)
@@ -471,6 +471,27 @@ def _restore_v4_nodes(
                 hash=att["hash"],
                 size_bytes=att["size_bytes"],
                 created_at=_dt(att["created_at"]),
+            )
+        )
+    session.flush()
+
+    # --- Node properties (v4 bundles only) ---
+    for prop in manifest.get("node_properties", []):
+        node_id = uuid.UUID(prop["node_id"])
+        if session.get(Node, node_id) is None:
+            raise ValueError(
+                f"node_properties entry references unknown node_id '{node_id}'"
+            )
+        session.add(
+            NodeProperty(
+                id=uuid.UUID(prop["id"]),
+                node_id=node_id,
+                key=prop["key"],
+                value=prop.get("value"),
+                value_type=prop["value_type"],
+                options=prop.get("options"),
+                created_at=_dt(prop["created_at"]),
+                updated_at=_dt(prop["updated_at"]),
             )
         )
     session.flush()

--- a/api/marrow/routers/properties.py
+++ b/api/marrow/routers/properties.py
@@ -1,0 +1,284 @@
+"""Node property endpoints — typed key-value metadata and folder schemas.
+
+A *folder* node may declare a property schema (key + value_type + options).
+Every *page* node descended from that folder inherits the schema and may set
+its own value for each key. Effective properties for a page are resolved by
+walking the ancestor folder chain (nearest ancestor wins) and overlaying the
+page's own stored values.
+"""
+
+import json
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..dependencies import AuthContext, get_db
+from ..models import Node, NodeProperty, OrgRole
+from ..rbac import require_node_role
+from ..schemas import (
+    EffectivePropertiesResponse,
+    EffectiveProperty,
+    PropertySchemaRead,
+    PropertySchemaUpsert,
+    PropertyValueUpsert,
+)
+
+router = APIRouter(tags=["properties"])
+
+
+def _node_or_404(node_id: UUID, db: Session) -> Node:
+    node = db.get(Node, node_id)
+    if node is None or node.deleted_at is not None:
+        raise HTTPException(404, "Node not found")
+    return node
+
+
+def _decode_options(raw: str | None) -> list[str] | None:
+    if not raw:
+        return None
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return decoded if isinstance(decoded, list) else None
+
+
+def _ancestor_chain(node: Node, db: Session) -> list[Node]:
+    """Return ancestors nearest-first (parent, grandparent, ...)."""
+    chain: list[Node] = []
+    seen: set[UUID] = set()
+    current = node.parent_id
+    while current is not None and current not in seen:
+        seen.add(current)
+        parent = db.get(Node, current)
+        if parent is None or parent.deleted_at is not None:
+            break
+        chain.append(parent)
+        current = parent.parent_id
+    return chain
+
+
+def _to_schema_read(prop: NodeProperty) -> PropertySchemaRead:
+    return PropertySchemaRead(
+        id=prop.id,
+        node_id=prop.node_id,
+        key=prop.key,
+        value_type=prop.value_type,  # type: ignore[arg-type]
+        options=_decode_options(prop.options),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Folder schema definitions
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/api/nodes/{node_id}/property-schema",
+    response_model=list[PropertySchemaRead],
+)
+def list_property_schema(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    node = _node_or_404(node_id, db)
+    if node.type != "folder":
+        raise HTTPException(400, "Property schemas are defined on folder nodes")
+    rows = (
+        db.execute(
+            select(NodeProperty).where(NodeProperty.node_id == node_id).order_by(NodeProperty.key)
+        )
+        .scalars()
+        .all()
+    )
+    return [_to_schema_read(r) for r in rows]
+
+
+@router.put(
+    "/api/nodes/{node_id}/property-schema/{key}",
+    response_model=PropertySchemaRead,
+)
+def upsert_property_schema(
+    node_id: UUID,
+    key: str,
+    body: PropertySchemaUpsert,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    node = _node_or_404(node_id, db)
+    if node.type != "folder":
+        raise HTTPException(400, "Property schemas are defined on folder nodes")
+    if body.value_type in ("select", "multi-select") and not body.options:
+        raise HTTPException(400, f"value_type '{body.value_type}' requires options")
+
+    options_json = json.dumps(body.options) if body.options is not None else None
+    prop = (
+        db.execute(
+            select(NodeProperty).where(NodeProperty.node_id == node_id, NodeProperty.key == key)
+        )
+        .scalars()
+        .first()
+    )
+    if prop is None:
+        prop = NodeProperty(
+            node_id=node_id,
+            key=key,
+            value_type=body.value_type,
+            options=options_json,
+        )
+        db.add(prop)
+    else:
+        prop.value_type = body.value_type
+        prop.options = options_json
+        prop.updated_at = datetime.now(timezone.utc)
+
+    db.commit()
+    db.refresh(prop)
+    return _to_schema_read(prop)
+
+
+@router.delete("/api/nodes/{node_id}/property-schema/{key}", status_code=204)
+def delete_property_schema(
+    node_id: UUID,
+    key: str,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    node = _node_or_404(node_id, db)
+    if node.type != "folder":
+        raise HTTPException(400, "Property schemas are defined on folder nodes")
+    prop = (
+        db.execute(
+            select(NodeProperty).where(NodeProperty.node_id == node_id, NodeProperty.key == key)
+        )
+        .scalars()
+        .first()
+    )
+    if prop is None:
+        raise HTTPException(404, "Property schema not found")
+    db.delete(prop)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Page property values (with inherited schema resolution)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/api/nodes/{node_id}/properties",
+    response_model=EffectivePropertiesResponse,
+)
+def get_effective_properties(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    node = _node_or_404(node_id, db)
+
+    # Inherited schema: nearest ancestor folder wins for a given key.
+    schema: dict[str, EffectiveProperty] = {}
+    for ancestor in reversed(_ancestor_chain(node, db)):
+        if ancestor.type != "folder":
+            continue
+        for prop in ancestor.properties:
+            schema[prop.key] = EffectiveProperty(
+                key=prop.key,
+                value_type=prop.value_type,  # type: ignore[arg-type]
+                options=_decode_options(prop.options),
+                value=None,
+                inherited=True,
+                defined_on=ancestor.id,
+            )
+
+    # Overlay the node's own stored values.
+    for prop in node.properties:
+        existing = schema.get(prop.key)
+        if existing is not None:
+            existing.value = prop.value
+        else:
+            schema[prop.key] = EffectiveProperty(
+                key=prop.key,
+                value_type=prop.value_type,  # type: ignore[arg-type]
+                options=_decode_options(prop.options),
+                value=prop.value,
+                inherited=False,
+                defined_on=node.id,
+            )
+
+    return EffectivePropertiesResponse(
+        node_id=node.id,
+        properties=sorted(schema.values(), key=lambda p: p.key),
+    )
+
+
+@router.put(
+    "/api/nodes/{node_id}/properties/{key}",
+    response_model=EffectiveProperty,
+)
+def set_property_value(
+    node_id: UUID,
+    key: str,
+    body: PropertyValueUpsert,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    node = _node_or_404(node_id, db)
+    if node.type != "page":
+        raise HTTPException(400, "Property values are set on page nodes")
+
+    prop = (
+        db.execute(
+            select(NodeProperty).where(NodeProperty.node_id == node_id, NodeProperty.key == key)
+        )
+        .scalars()
+        .first()
+    )
+    if prop is None:
+        prop = NodeProperty(
+            node_id=node_id,
+            key=key,
+            value=body.value,
+            value_type=body.value_type,
+        )
+        db.add(prop)
+    else:
+        prop.value = body.value
+        prop.value_type = body.value_type
+        prop.updated_at = datetime.now(timezone.utc)
+
+    db.commit()
+    db.refresh(prop)
+    return EffectiveProperty(
+        key=prop.key,
+        value_type=prop.value_type,  # type: ignore[arg-type]
+        options=_decode_options(prop.options),
+        value=prop.value,
+        inherited=False,
+        defined_on=node.id,
+    )
+
+
+@router.delete("/api/nodes/{node_id}/properties/{key}", status_code=204)
+def delete_property_value(
+    node_id: UUID,
+    key: str,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.EDITOR)),
+):
+    _node_or_404(node_id, db)
+    prop = (
+        db.execute(
+            select(NodeProperty).where(NodeProperty.node_id == node_id, NodeProperty.key == key)
+        )
+        .scalars()
+        .first()
+    )
+    if prop is None:
+        raise HTTPException(404, "Property not found")
+    db.delete(prop)
+    db.commit()

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -192,6 +192,52 @@ class AttachmentRead(_ReadBase):
 
 
 # ---------------------------------------------------------------------------
+# Node properties
+# ---------------------------------------------------------------------------
+
+PropertyValueType = Literal["text", "number", "date", "select", "multi-select", "checkbox"]
+
+
+class PropertySchemaUpsert(BaseModel):
+    """Define or update a property in a folder's schema."""
+
+    value_type: PropertyValueType
+    options: list[str] | None = None
+
+
+class PropertySchemaRead(_ReadBase):
+    id: UUID
+    node_id: UUID
+    key: str
+    value_type: PropertyValueType
+    options: list[str] | None = None
+
+
+class PropertyValueUpsert(BaseModel):
+    """Set a property value on a page node."""
+
+    value: str | None = None
+    value_type: PropertyValueType
+
+
+class EffectiveProperty(BaseModel):
+    """A property as seen on a page: its type/options (possibly inherited from
+    an ancestor folder schema) plus the page's own value when set."""
+
+    key: str
+    value_type: PropertyValueType
+    options: list[str] | None = None
+    value: str | None = None
+    inherited: bool = False
+    defined_on: UUID | None = None
+
+
+class EffectivePropertiesResponse(BaseModel):
+    node_id: UUID
+    properties: list[EffectiveProperty]
+
+
+# ---------------------------------------------------------------------------
 # Search
 # ---------------------------------------------------------------------------
 

--- a/api/tests/test_properties.py
+++ b/api/tests/test_properties.py
@@ -1,0 +1,247 @@
+"""Integration tests for node property schemas, values, inheritance, and FTS."""
+
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from marrow.auth import COOKIE_NAME, create_session_jwt, reset_oidc_config
+from marrow.models import (
+    Node,
+    Organization,
+    OrgMembership,
+    OrgRole,
+    Revision,
+    Space,
+    User,
+    Workspace,
+)
+from marrow.search import PostgresSearchBackend
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    reset_oidc_config()
+    yield
+    reset_oidc_config()
+
+
+@pytest.fixture
+def client():
+    from marrow.app import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _setup(db, role: OrgRole = OrgRole.EDITOR):
+    user = User(
+        oidc_issuer="https://test.example.com",
+        oidc_subject=uuid.uuid4().hex,
+        email=f"prop-{uuid.uuid4().hex[:6]}@test.com",
+        name="Prop User",
+    )
+    db.add(user)
+    db.flush()
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Org")
+    db.add(org)
+    db.flush()
+    ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="WS")
+    db.add(ws)
+    db.flush()
+    space = Space(workspace_id=ws.id, slug="main", name="Main")
+    db.add(space)
+    db.flush()
+    db.add(OrgMembership(org_id=org.id, user_id=user.id, email=user.email, role=role.value))
+    db.flush()
+    return user, ws, space
+
+
+def _auth(client, user):
+    client.cookies.set(COOKIE_NAME, create_session_jwt(user.id, user.email, user.name))
+
+
+def _page(db, space, name, parent_id=None):
+    node = Node(
+        space_id=space.id,
+        parent_id=parent_id,
+        type="page",
+        name=name,
+        slug=name.lower().replace(" ", "-"),
+        position="a0",
+    )
+    db.add(node)
+    db.flush()
+    rev = Revision(node_id=node.id, content=f"{name} body", content_format="markdown")
+    db.add(rev)
+    db.flush()
+    node.current_revision_id = rev.id
+    db.flush()
+    return node
+
+
+def _folder(db, space, name, parent_id=None):
+    node = Node(
+        space_id=space.id,
+        parent_id=parent_id,
+        type="folder",
+        name=name,
+        slug=name.lower().replace(" ", "-"),
+        position="a0",
+    )
+    db.add(node)
+    db.flush()
+    return node
+
+
+class TestPropertySchema:
+    def test_folder_schema_crud(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user, ws, space = _setup(db)
+            folder = _folder(db, space, "Docs")
+            db.commit()
+            _auth(client, user)
+
+            r = client.put(
+                f"/api/nodes/{folder.id}/property-schema/status",
+                json={"value_type": "select", "options": ["todo", "done"]},
+            )
+            assert r.status_code == 200, r.text
+            assert r.json()["options"] == ["todo", "done"]
+
+            r = client.get(f"/api/nodes/{folder.id}/property-schema")
+            assert r.status_code == 200
+            assert [p["key"] for p in r.json()] == ["status"]
+
+            r = client.delete(f"/api/nodes/{folder.id}/property-schema/status")
+            assert r.status_code == 204
+            assert client.get(f"/api/nodes/{folder.id}/property-schema").json() == []
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_select_requires_options(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user, ws, space = _setup(db)
+            folder = _folder(db, space, "Docs2")
+            db.commit()
+            _auth(client, user)
+            r = client.put(
+                f"/api/nodes/{folder.id}/property-schema/tags",
+                json={"value_type": "multi-select"},
+            )
+            assert r.status_code == 400
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_schema_rejected_on_page(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user, ws, space = _setup(db)
+            page = _page(db, space, "Page A")
+            db.commit()
+            _auth(client, user)
+            r = client.put(
+                f"/api/nodes/{page.id}/property-schema/x",
+                json={"value_type": "text"},
+            )
+            assert r.status_code == 400
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestPropertyInheritance:
+    def test_page_inherits_folder_schema_and_overlays_value(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user, ws, space = _setup(db)
+            folder = _folder(db, space, "Project")
+            page = _page(db, space, "Task", parent_id=folder.id)
+            db.commit()
+            _auth(client, user)
+
+            client.put(
+                f"/api/nodes/{folder.id}/property-schema/priority",
+                json={"value_type": "select", "options": ["low", "high"]},
+            )
+
+            r = client.get(f"/api/nodes/{page.id}/properties")
+            assert r.status_code == 200
+            props = {p["key"]: p for p in r.json()["properties"]}
+            assert props["priority"]["inherited"] is True
+            assert props["priority"]["value"] is None
+            assert props["priority"]["options"] == ["low", "high"]
+
+            r = client.put(
+                f"/api/nodes/{page.id}/properties/priority",
+                json={"value": "high", "value_type": "select"},
+            )
+            assert r.status_code == 200, r.text
+
+            props = {
+                p["key"]: p
+                for p in client.get(f"/api/nodes/{page.id}/properties").json()["properties"]
+            }
+            assert props["priority"]["value"] == "high"
+            assert props["priority"]["inherited"] is True
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+    def test_value_rejected_on_folder(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user, ws, space = _setup(db)
+            folder = _folder(db, space, "F")
+            db.commit()
+            _auth(client, user)
+            r = client.put(
+                f"/api/nodes/{folder.id}/properties/k",
+                json={"value": "v", "value_type": "text"},
+            )
+            assert r.status_code == 400
+        finally:
+            db.rollback()
+            client.cookies.clear()
+
+
+class TestPropertyFTS:
+    def test_property_value_is_searchable(self, client):
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            user, ws, space = _setup(db)
+            page = _page(db, space, "Quarterly Report")
+            db.commit()
+            _auth(client, user)
+
+            client.put(
+                f"/api/nodes/{page.id}/properties/owner",
+                json={"value": "zephyrandromeda", "value_type": "text"},
+            )
+
+            results = PostgresSearchBackend().search(ws.id, "zephyrandromeda", db)
+            assert any(res.node_id == page.id for res in results)
+        finally:
+            db.rollback()
+            client.cookies.clear()

--- a/web/components/page-editor.tsx
+++ b/web/components/page-editor.tsx
@@ -38,6 +38,7 @@ import {
 import { calloutBlockSpec, calloutSlashMenuItem } from "@/components/editor/callout-block";
 import { mentionInlineContentSpec } from "@/components/editor/mention-inline-content";
 import { pageLinkSlashMenuItem } from "@/components/editor/page-link-slash-item";
+import { PropertyEditor } from "@/components/property-editor";
 import { useWorkspaceTree } from "@/components/workspace-tree-context";
 import {
   Dialog,
@@ -451,6 +452,9 @@ export function PageEditor({ initialPage }: Props) {
           placeholder="Untitled"
         />
       </div>
+
+      {/* Typed key-value metadata (inherited folder schemas + page values) */}
+      <PropertyEditor nodeId={initialPage.id} />
 
       {/* BlockNote editor */}
       <div className="flex-1 overflow-auto">

--- a/web/components/property-editor.tsx
+++ b/web/components/property-editor.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+/**
+ * PropertyEditor — typed key-value metadata shown below a page title.
+ *
+ * Renders each effective property (inherited folder-schema definitions plus
+ * the page's own values) with a type-appropriate control: text/number/date
+ * inputs, a dropdown for select, tag-style chips for multi-select, and a
+ * checkbox. Edits are persisted per-property via the node properties API.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  deleteNodeProperty,
+  getNodeProperties,
+  setNodeProperty,
+} from "@/lib/api";
+import type { EffectiveProperty } from "@/lib/types";
+
+interface Props {
+  nodeId: string;
+}
+
+export function PropertyEditor({ nodeId }: Props) {
+  const [props, setProps] = useState<EffectiveProperty[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  const reload = useCallback(async () => {
+    try {
+      const res = await getNodeProperties(nodeId);
+      setProps(res.properties);
+    } catch {
+      setProps([]);
+    } finally {
+      setLoaded(true);
+    }
+  }, [nodeId]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const persist = useCallback(
+    async (p: EffectiveProperty, value: string | null) => {
+      setProps((cur) =>
+        cur.map((x) => (x.key === p.key ? { ...x, value } : x))
+      );
+      try {
+        if (value === null || value === "") {
+          await deleteNodeProperty(nodeId, p.key);
+        } else {
+          await setNodeProperty(nodeId, p.key, value, p.value_type);
+        }
+      } catch {
+        void reload();
+      }
+    },
+    [nodeId, reload]
+  );
+
+  if (!loaded || props.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-1.5 px-10 pb-3" data-testid="property-editor">
+      {props.map((p) => (
+        <div key={p.key} className="flex items-center gap-3 text-sm">
+          <span className="w-32 shrink-0 text-muted-foreground">{p.key}</span>
+          <PropertyControl property={p} onChange={(v) => persist(p, v)} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PropertyControl({
+  property,
+  onChange,
+}: {
+  property: EffectiveProperty;
+  onChange: (value: string | null) => void;
+}) {
+  const { value, value_type, options } = property;
+
+  if (value_type === "checkbox") {
+    return (
+      <input
+        type="checkbox"
+        checked={value === "true"}
+        onChange={(e) => onChange(e.target.checked ? "true" : "false")}
+      />
+    );
+  }
+
+  if (value_type === "select") {
+    return (
+      <select
+        className="rounded border border-border bg-transparent px-2 py-1"
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value || null)}
+      >
+        <option value="">—</option>
+        {(options ?? []).map((o) => (
+          <option key={o} value={o}>
+            {o}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  if (value_type === "multi-select") {
+    let selected: string[] = [];
+    try {
+      selected = value ? (JSON.parse(value) as string[]) : [];
+    } catch {
+      selected = [];
+    }
+    const toggle = (opt: string) => {
+      const next = selected.includes(opt)
+        ? selected.filter((x) => x !== opt)
+        : [...selected, opt];
+      onChange(next.length ? JSON.stringify(next) : null);
+    };
+    return (
+      <div className="flex flex-wrap gap-1.5">
+        {(options ?? []).map((o) => {
+          const on = selected.includes(o);
+          return (
+            <button
+              key={o}
+              type="button"
+              onClick={() => toggle(o)}
+              className={`rounded-full border px-2.5 py-0.5 text-xs transition-colors ${
+                on
+                  ? "border-primary bg-primary/15 text-primary"
+                  : "border-border text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              {o}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  const inputType =
+    value_type === "date" ? "date" : value_type === "number" ? "number" : "text";
+
+  return (
+    <input
+      type={inputType}
+      className="rounded border border-border bg-transparent px-2 py-1"
+      defaultValue={value ?? ""}
+      onBlur={(e) => onChange(e.target.value || null)}
+      placeholder={`Add ${value_type}…`}
+    />
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -11,12 +11,16 @@ import type {
   AuthStatus,
   Backlink,
   Comment,
+  EffectiveProperty,
+  EffectivePropertiesResponse,
   Node,
   NodeType,
   Notification,
   NotificationList,
   Organization,
   OrgMembership,
+  PropertySchema,
+  PropertyValueType,
   Revision,
   SearchResponse,
   ShareLink,
@@ -412,6 +416,68 @@ export function markNotificationRead(id: string): Promise<Notification> {
 
 export async function markAllNotificationsRead(): Promise<void> {
   await apiFetch("/api/users/me/notifications/read-all", { method: "POST" });
+
+// ---------------------------------------------------------------------------
+// Node properties
+// ---------------------------------------------------------------------------
+// Node properties
+// ---------------------------------------------------------------------------
+
+/** Effective properties for a node (inherited folder schemas + own values). */
+export function getNodeProperties(
+  nodeId: string
+): Promise<EffectivePropertiesResponse> {
+  return apiFetch(`/api/nodes/${nodeId}/properties`);
+}
+
+/** Set (or clear) a property value on a page node. */
+export function setNodeProperty(
+  nodeId: string,
+  key: string,
+  value: string | null,
+  valueType: PropertyValueType
+): Promise<EffectiveProperty> {
+  return apiFetch(`/api/nodes/${nodeId}/properties/${encodeURIComponent(key)}`, {
+    method: "PUT",
+    body: JSON.stringify({ value, value_type: valueType }),
+  });
+}
+
+export function deleteNodeProperty(nodeId: string, key: string): Promise<void> {
+  return apiFetch(`/api/nodes/${nodeId}/properties/${encodeURIComponent(key)}`, {
+    method: "DELETE",
+  });
+}
+
+/** List a folder's property schema definitions. */
+export function getPropertySchema(nodeId: string): Promise<PropertySchema[]> {
+  return apiFetch(`/api/nodes/${nodeId}/property-schema`);
+}
+
+/** Define or update a property in a folder's schema. */
+export function upsertPropertySchema(
+  nodeId: string,
+  key: string,
+  valueType: PropertyValueType,
+  options: string[] | null
+): Promise<PropertySchema> {
+  return apiFetch(
+    `/api/nodes/${nodeId}/property-schema/${encodeURIComponent(key)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify({ value_type: valueType, options }),
+    }
+  );
+}
+
+export function deletePropertySchema(
+  nodeId: string,
+  key: string
+): Promise<void> {
+  return apiFetch(
+    `/api/nodes/${nodeId}/property-schema/${encodeURIComponent(key)}`,
+    { method: "DELETE" }
+  );
 }
 
 /** Convert a display name to a URL-safe slug. */

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -130,6 +130,37 @@ export interface WorkspaceTree {
   spaces: SpaceTreeItem[];
 }
 
+// Node properties
+export type PropertyValueType =
+  | "text"
+  | "number"
+  | "date"
+  | "select"
+  | "multi-select"
+  | "checkbox";
+
+export interface PropertySchema {
+  id: string;
+  node_id: string;
+  key: string;
+  value_type: PropertyValueType;
+  options: string[] | null;
+}
+
+export interface EffectiveProperty {
+  key: string;
+  value_type: PropertyValueType;
+  options: string[] | null;
+  value: string | null;
+  inherited: boolean;
+  defined_on: string | null;
+}
+
+export interface EffectivePropertiesResponse {
+  node_id: string;
+  properties: EffectiveProperty[];
+}
+
 // Auth
 export interface User {
   id: string;


### PR DESCRIPTION
Closes #42.

## Summary
Typed key-value metadata for nodes (folder schemas inherited by descendant pages).

- `node_properties` table + migration `2187bd1a529d` (up/down/up verified)
- Value types: text, number, date, select, multi-select, checkbox
- Folder-level schemas inherited by descendant pages (nearest-ancestor wins), resolved at read time
- API: `/api/nodes/{id}/property-schema[/{key}]` and `/api/nodes/{id}/properties[/{key}]`
- FTS: properties folded into page `search_vector` at weight C via a shared `marrow_node_search_vector()` helper + new `node_properties` trigger; existing revision/name triggers rewritten consistently
- Export/restore: bundle bumped to v4 with symmetric `node_properties` serialization (`export.serialize_node_properties` + restore loop)
- Frontend: `property-editor.tsx` (chips / date pickers / dropdowns / checkbox) mounted below the page title; types + API client added

## Tests
`tests/test_properties.py` — 6 tests (schema CRUD, validation, inheritance/overlay, FTS searchability) all pass. Full collectible suite: 56 passed. Remaining failures are pre-existing and out of scope: `test_migration_cycle` asserts the v0.1 `collections`/`pages` tables removed by #123, and `test_export/restore/round_trip/rbac` NameError on import pending the #132/#133 node-aware export rewrite.

_Created by swarm coordinator_