### PR TITLE
feat: #104 2.10: Watch nodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,8 @@ organizations → org_memberships (user roles: owner/editor/viewer)
 | users | id, oidc_issuer, oidc_subject (unique together), email, name, last_login_at |
 | share_links | id, node_id (FK cascade), token (unique), created_by (FK users, SET NULL), expires_at (nullable), created_at |
 | user_stars | id, user_id (FK cascade), node_id (FK cascade), created_at — unique on (user_id, node_id); per-user, **never exported** |
+| notifications | id, user_id (FK cascade), kind, payload (JSONB), read_at, created_at — Inbox feed item; **not exported** |
+| node_watches | id, user_id (FK cascade), node_id (FK cascade), unique on (user_id, node_id) — **not exported** |
 
 **Node shape constraint**: A CHECK constraint (`nodes_shape_by_type`) enforces that folder rows have `current_revision_id` and `search_vector` NULL, while page rows have `description` NULL. A second CHECK on `revisions` (`revisions_node_is_page`) ensures revisions only reference page-typed nodes.
 
@@ -311,6 +313,9 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | GET | /api/users/me/starred | List current user's starred nodes (trashed excluded) | session |
 | POST | /api/nodes/{nid}/star | Star a node (idempotent) | viewer |
 | DELETE | /api/nodes/{nid}/star | Unstar a node | viewer |
+| GET | /api/nodes/{nid}/watching | Whether the current user watches this node | viewer |
+| POST | /api/nodes/{nid}/watch | Watch a node (idempotent) | viewer |
+| DELETE | /api/nodes/{nid}/watch | Stop watching a node | viewer |
 
 > **Share links (#40):** `share_links` grant view-only public access to a node.
 > `GET /shared/{token}` requires no account: a page returns its current
@@ -323,6 +328,8 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 > #132/#133 rewrites land — share links should be added to the bundle there.
 >
 > **Note (#123 → #125):** v0.1's collection-scoped and global page routes were removed by the schema migration. Node CRUD/tree/attachment/revision routes land in #124 (2.0b) under `/api/nodes/...` and `/api/spaces/{sid}/nodes`. The workspace `/search` endpoint is node-aware as of #125 (2.0c). The `/tree`, `/export`, and `/restore` endpoints are still wired but their handlers will NameError at runtime until the node-aware rewrites land in #124, #132, and #133.
+>
+> **Watches & notifications (#103/#104):** `notifications` is a user-scoped Inbox feed; `create_notification()` in `marrow/notifications.py` is the single insertion point. `marrow/watches.py` fans out `watch_event` notifications: on a page save (`update_node` revision create), every watcher of the page **or any ancestor folder** is notified, excluding the acting user. Both tables are deliberately excluded from export/restore (user-scoped, workspace-independent) — the round-trip guarantee is unaffected.
 >
 > **Search response shape (v0.2):** `SearchResultItem` fields are `node_id`, `name`, `snippet`, `space_id`, `space_name`, `node_path` (list of ancestor folder names, root→leaf), `rank`. The old `page_id`, `title`, `collection_id`, `collection_name` fields are gone.
 >

--- a/api/alembic/versions/94d64b4e6869_add_notifications_and_node_watches_.py
+++ b/api/alembic/versions/94d64b4e6869_add_notifications_and_node_watches_.py
@@ -1,0 +1,72 @@
+"""add notifications and node_watches tables
+
+Revision ID: 94d64b4e6869
+Revises: c58f38d0a5aa
+Create Date: 2026-05-16 21:37:04.638061
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '94d64b4e6869'
+down_revision: Union[str, Sequence[str], None] = 'c58f38d0a5aa'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'notifications',
+        sa.Column('id', sa.UUID(), server_default=sa.text('gen_random_uuid()'), nullable=False),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('kind', sa.Text(), nullable=False),
+        sa.Column(
+            'payload',
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default='{}',
+            nullable=False,
+        ),
+        sa.Column('read_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            'created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False
+        ),
+        sa.CheckConstraint(
+            "kind IN ('mention', 'comment_reply', 'share_request', 'watch_event')",
+            name='notifications_kind_valid',
+        ),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        'idx_notifications_user_unread',
+        'notifications',
+        ['user_id', 'created_at'],
+        postgresql_where=sa.text('read_at IS NULL'),
+    )
+    op.create_table(
+        'node_watches',
+        sa.Column('id', sa.UUID(), server_default=sa.text('gen_random_uuid()'), nullable=False),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('node_id', sa.UUID(), nullable=False),
+        sa.Column(
+            'created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False
+        ),
+        sa.ForeignKeyConstraint(['node_id'], ['nodes.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('user_id', 'node_id', name='uq_node_watches_user_node'),
+    )
+    op.create_index('idx_node_watches_node', 'node_watches', ['node_id'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('idx_node_watches_node', table_name='node_watches')
+    op.drop_table('node_watches')
+    op.drop_index('idx_notifications_user_unread', table_name='notifications')
+    op.drop_table('notifications')

--- a/api/marrow/models.py
+++ b/api/marrow/models.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
-from sqlalchemy.dialects.postgresql import TSVECTOR, UUID
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -378,4 +378,67 @@ class UserStar(Base):
         UniqueConstraint("user_id", "node_id", name="uq_user_stars_user_node"),
         ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
         ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+    )
+
+
+class NotificationKind(str, enum.Enum):
+    MENTION = "mention"
+    COMMENT_REPLY = "comment_reply"
+    SHARE_REQUEST = "share_request"
+    WATCH_EVENT = "watch_event"
+
+
+class Notification(Base):
+    """User-scoped activity feed item surfaced in the Inbox rail panel.
+
+    Not part of any export bundle — notifications are personal and
+    workspace-independent, so they are deliberately excluded from the
+    restore guarantee.
+    """
+
+    __tablename__ = "notifications"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
+    read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        CheckConstraint(
+            "kind IN ('mention', 'comment_reply', 'share_request', 'watch_event')",
+            name="notifications_kind_valid",
+        ),
+    )
+
+
+class NodeWatch(Base):
+    """A user's subscription to change notifications for a node.
+
+    Watching a folder fans out notifications on changes to any descendant
+    page node (resolved at notification time, not stored). User-scoped and
+    workspace-independent — never part of an export bundle.
+    """
+
+    __tablename__ = "node_watches"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    node_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        ForeignKeyConstraint(["node_id"], ["nodes.id"], ondelete="CASCADE"),
+        UniqueConstraint("user_id", "node_id", name="uq_node_watches_user_node"),
     )

--- a/api/marrow/notifications.py
+++ b/api/marrow/notifications.py
@@ -1,0 +1,27 @@
+"""Notification delivery helpers.
+
+The Inbox surfaces activity that needs a user's attention. This module owns
+the single insertion point (:func:`create_notification`) used by every
+notification source — ``@`` mentions, comment replies, share requests, and
+node-watch events (#104).
+"""
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+from .models import Notification
+
+
+def create_notification(
+    db: Session,
+    *,
+    user_id: uuid.UUID,
+    kind: str,
+    payload: dict,
+) -> Notification:
+    """Insert a single notification row. Caller owns the transaction."""
+    notification = Notification(user_id=user_id, kind=kind, payload=payload)
+    db.add(notification)
+    db.flush()
+    return notification

--- a/api/marrow/routers/nodes.py
+++ b/api/marrow/routers/nodes.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 from ..dependencies import AuthContext, get_db, get_storage, verify_auth
 from ..fractional_index import after as fi_after
 from ..links import reconcile_node_links
-from ..models import Attachment, Node, NodeLink, OrgRole, Revision, Space, UserStar, Workspace
+from ..models import Attachment, Node, NodeLink, NodeWatch, OrgRole, Revision, Space, UserStar, Workspace
 from ..rbac import _check_membership, require_node_role, require_space_role
 from ..schemas import (
     AttachmentRead,
@@ -22,7 +22,9 @@ from ..schemas import (
     NodeReadWithContent,
     NodeUpdate,
     RevisionRead,
+    WatchStatus,
 )
+from ..watches import fan_out_watch_event
 
 router = APIRouter(tags=["nodes"])
 
@@ -187,6 +189,7 @@ def update_node(
     if body.description is not None and node.type == "folder":
         node.description = body.description
 
+    saved_revision = False
     if body.content is not None and node.type == "page":
         rev = Revision(
             node_id=node.id,
@@ -197,8 +200,20 @@ def update_node(
         db.flush()
         node.current_revision_id = rev.id
         reconcile_node_links(db, node.id, body.content, body.content_format or "markdown")
+        saved_revision = True
 
     node.updated_at = datetime.now(timezone.utc)
+
+    if saved_revision:
+        # Notify watchers best-effort — must not block or fail the save.
+        # Use a savepoint so any partial notification rows are rolled back on
+        # failure rather than being committed by the db.commit() below.
+        sp = db.begin_nested()
+        try:
+            fan_out_watch_event(db, node=node, actor_user_id=auth.user_id, event="save")
+            sp.commit()
+        except Exception:
+            sp.rollback()
 
     try:
         db.commit()
@@ -464,3 +479,63 @@ def download_attachment(
         raise HTTPException(404, "Attachment not found")
     data = storage.read(str(attachment.id), attachment.filename)
     return Response(content=data, media_type="application/octet-stream")
+
+
+def _require_user(auth: AuthContext) -> UUID:
+    """Watches are user-scoped — API-key/anonymous callers have no identity."""
+    if auth.user_id is None:
+        raise HTTPException(401, "User authentication required to watch nodes")
+    return auth.user_id
+
+
+@router.get("/api/nodes/{node_id}/watching", response_model=WatchStatus)
+def get_watch_status(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    user_id = _require_user(auth)
+    _node_or_404(node_id, db)
+    watch = db.execute(
+        select(NodeWatch).where(
+            NodeWatch.node_id == node_id, NodeWatch.user_id == user_id
+        )
+    ).scalar_one_or_none()
+    return WatchStatus(watching=watch is not None)
+
+
+@router.post("/api/nodes/{node_id}/watch", response_model=WatchStatus, status_code=201)
+def watch_node(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    user_id = _require_user(auth)
+    _node_or_404(node_id, db)
+    existing = db.execute(
+        select(NodeWatch).where(
+            NodeWatch.node_id == node_id, NodeWatch.user_id == user_id
+        )
+    ).scalar_one_or_none()
+    if existing is None:
+        db.add(NodeWatch(node_id=node_id, user_id=user_id))
+        db.commit()
+    return WatchStatus(watching=True)
+
+
+@router.delete("/api/nodes/{node_id}/watch", status_code=204)
+def unwatch_node(
+    node_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_node_role(OrgRole.VIEWER)),
+):
+    user_id = _require_user(auth)
+    _node_or_404(node_id, db)
+    watch = db.execute(
+        select(NodeWatch).where(
+            NodeWatch.node_id == node_id, NodeWatch.user_id == user_id
+        )
+    ).scalar_one_or_none()
+    if watch is not None:
+        db.delete(watch)
+        db.commit()

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -305,3 +305,9 @@ class AuthStatus(BaseModel):
     user: UserRead | None = None
     method: str
     oidc_enabled: bool
+
+
+class WatchStatus(BaseModel):
+    """Whether the current user is watching a given node."""
+
+    watching: bool

--- a/api/marrow/watches.py
+++ b/api/marrow/watches.py
@@ -1,0 +1,72 @@
+"""Node-watch fan-out (#104).
+
+A user can watch a page or a folder. When a page node changes (a new
+revision is saved, or — once comments land — a new comment is posted), every
+watcher of that node *or any of its ancestor folders* receives a
+``watch_event`` notification through the Inbox pipeline. The acting user is
+never notified about their own change.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .models import Node, NodeWatch
+from .notifications import create_notification
+
+
+def _node_and_ancestor_ids(db: Session, node: Node) -> list[uuid.UUID]:
+    """Return the node's id plus every ancestor folder id, root-ward.
+
+    A folder watch fires on changes to any descendant page, so resolving the
+    ancestor chain is what makes folder subscriptions work.
+    """
+    ids: list[uuid.UUID] = [node.id]
+    parent_id = node.parent_id
+    seen: set[uuid.UUID] = {node.id}
+    while parent_id is not None and parent_id not in seen:
+        seen.add(parent_id)
+        ids.append(parent_id)
+        parent_id = db.execute(
+            select(Node.parent_id).where(Node.id == parent_id)
+        ).scalar_one_or_none()
+    return ids
+
+
+def fan_out_watch_event(
+    db: Session,
+    *,
+    node: Node,
+    actor_user_id: uuid.UUID | None,
+    event: str,
+) -> int:
+    """Notify every watcher of ``node`` or an ancestor folder.
+
+    ``event`` is a short verb stored in the notification payload (e.g.
+    ``"save"`` or ``"comment"``). The acting user is excluded. Caller owns
+    the transaction. Returns the number of notifications created.
+    """
+    target_ids = _node_and_ancestor_ids(db, node)
+
+    watcher_ids = set(
+        db.execute(select(NodeWatch.user_id).where(NodeWatch.node_id.in_(target_ids)))
+        .scalars()
+        .all()
+    )
+    if actor_user_id is not None:
+        watcher_ids.discard(actor_user_id)
+
+    for user_id in watcher_ids:
+        create_notification(
+            db,
+            user_id=user_id,
+            kind="watch_event",
+            payload={
+                "event": event,
+                "node_id": str(node.id),
+                "node_name": node.name,
+                "space_id": str(node.space_id),
+            },
+        )
+    return len(watcher_ids)

--- a/api/tests/test_watches.py
+++ b/api/tests/test_watches.py
@@ -1,0 +1,237 @@
+"""Integration tests for node watches and watch-event fan-out (#104)."""
+
+import os
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from marrow.auth import COOKIE_NAME, create_session_jwt, reset_oidc_config
+from marrow.models import (
+    Node,
+    Notification,
+    Organization,
+    OrgMembership,
+    OrgRole,
+    Revision,
+    Space,
+    User,
+    Workspace,
+)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    reset_oidc_config()
+    yield
+    reset_oidc_config()
+
+
+@pytest.fixture
+def client():
+    from marrow.app import app
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def db():
+    from marrow.dependencies import get_db
+
+    session = next(get_db())
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_user(session, email: str) -> User:
+    user = User(
+        oidc_issuer="https://test.example.com",
+        oidc_subject=uuid.uuid4().hex,
+        email=email,
+        name="Test User",
+    )
+    session.add(user)
+    session.flush()
+    return user
+
+
+def _make_workspace(session) -> tuple:
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Test Org")
+    session.add(org)
+    session.flush()
+    ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="Test WS")
+    session.add(ws)
+    session.flush()
+    space = Space(workspace_id=ws.id, slug="main", name="Main")
+    session.add(space)
+    session.flush()
+    return org, ws, space
+
+
+def _add_membership(session, org, user, role: OrgRole) -> OrgMembership:
+    m = OrgMembership(org_id=org.id, user_id=user.id, email=user.email, role=role.value)
+    session.add(m)
+    session.flush()
+    return m
+
+
+def _make_page(session, space, parent_id=None, name="Page") -> Node:
+    node = Node(
+        space_id=space.id,
+        parent_id=parent_id,
+        type="page",
+        name=name,
+        slug=f"{name.lower()}-{uuid.uuid4().hex[:6]}",
+        position="a0",
+    )
+    session.add(node)
+    session.flush()
+    rev = Revision(node_id=node.id, content="hello", content_format="markdown")
+    session.add(rev)
+    session.flush()
+    node.current_revision_id = rev.id
+    session.flush()
+    return node
+
+
+def _make_folder(session, space, parent_id=None, name="Folder") -> Node:
+    node = Node(
+        space_id=space.id,
+        parent_id=parent_id,
+        type="folder",
+        name=name,
+        slug=f"{name.lower()}-{uuid.uuid4().hex[:6]}",
+        position="a0",
+    )
+    session.add(node)
+    session.flush()
+    return node
+
+
+def _auth_cookie(client, user):
+    token = create_session_jwt(user.id, user.email, user.name)
+    client.cookies.set(COOKIE_NAME, token)
+
+
+def _watch_events(_db, user_id) -> list[Notification]:
+    # Fresh session so we read the request transaction's committed rows
+    # rather than a stale snapshot on the test's own session.
+    from marrow.dependencies import get_db
+
+    session = next(get_db())
+    try:
+        return (
+            session.query(Notification)
+            .filter(Notification.user_id == user_id, Notification.kind == "watch_event")
+            .all()
+        )
+    finally:
+        session.close()
+
+
+class TestWatchEndpoints:
+    def test_watch_unwatch_and_status(self, client, db):
+        user = _make_user(db, "watcher@test.com")
+        org, ws, space = _make_workspace(db)
+        _add_membership(db, org, user, OrgRole.VIEWER)
+        page = _make_page(db, space)
+        db.commit()
+        nid = str(page.id)
+
+        _auth_cookie(client, user)
+
+        r = client.get(f"/api/nodes/{nid}/watching")
+        assert r.status_code == 200
+        assert r.json() == {"watching": False}
+
+        r = client.post(f"/api/nodes/{nid}/watch")
+        assert r.status_code == 201
+        assert r.json() == {"watching": True}
+
+        # Idempotent — watching again is a no-op success.
+        assert client.post(f"/api/nodes/{nid}/watch").status_code == 201
+
+        assert client.get(f"/api/nodes/{nid}/watching").json() == {"watching": True}
+
+        assert client.delete(f"/api/nodes/{nid}/watch").status_code == 204
+        assert client.get(f"/api/nodes/{nid}/watching").json() == {"watching": False}
+
+    def test_non_member_forbidden(self, client, db):
+        user = _make_user(db, "outsider@test.com")
+        _org, _ws, space = _make_workspace(db)
+        page = _make_page(db, space)
+        db.commit()
+        nid = str(page.id)
+
+        _auth_cookie(client, user)
+        assert client.post(f"/api/nodes/{nid}/watch").status_code == 403
+
+    def test_api_key_has_no_inbox(self, client, db, monkeypatch):
+        _org, _ws, space = _make_workspace(db)
+        page = _make_page(db, space)
+        db.commit()
+        nid = str(page.id)
+
+        monkeypatch.setenv("API_KEY", "secret")
+        reset_oidc_config()
+        r = client.post(f"/api/nodes/{nid}/watch", headers={"X-API-Key": "secret"})
+        assert r.status_code == 401
+
+
+class TestWatchFanOut:
+    def test_save_notifies_watcher_excluding_actor(self, client, db):
+        watcher = _make_user(db, "fanout-watcher@test.com")
+        editor = _make_user(db, "fanout-editor@test.com")
+        org, ws, space = _make_workspace(db)
+        _add_membership(db, org, watcher, OrgRole.VIEWER)
+        _add_membership(db, org, editor, OrgRole.EDITOR)
+        page = _make_page(db, space)
+        db.commit()
+        nid = str(page.id)
+        watcher_id, editor_id = watcher.id, editor.id
+
+        _auth_cookie(client, watcher)
+        assert client.post(f"/api/nodes/{nid}/watch").status_code == 201
+        # The editor also watches but is the actor, so must not self-notify.
+        _auth_cookie(client, editor)
+        assert client.post(f"/api/nodes/{nid}/watch").status_code == 201
+
+        assert client.patch(f"/api/nodes/{nid}", json={"content": "updated"}).status_code == 200
+
+        watcher_notes = _watch_events(db, watcher_id)
+        assert len(watcher_notes) == 1
+        assert watcher_notes[0].payload["event"] == "save"
+        assert watcher_notes[0].payload["node_id"] == nid
+        assert _watch_events(db, editor_id) == []
+
+    def test_folder_watch_fires_on_descendant_save(self, client, db):
+        watcher = _make_user(db, "folder-watcher@test.com")
+        editor = _make_user(db, "folder-editor@test.com")
+        org, ws, space = _make_workspace(db)
+        _add_membership(db, org, watcher, OrgRole.VIEWER)
+        _add_membership(db, org, editor, OrgRole.EDITOR)
+        folder = _make_folder(db, space)
+        child = _make_page(db, space, parent_id=folder.id)
+        db.commit()
+        folder_id = str(folder.id)
+        child_id = str(child.id)
+        watcher_id = watcher.id
+
+        _auth_cookie(client, watcher)
+        assert client.post(f"/api/nodes/{folder_id}/watch").status_code == 201
+
+        _auth_cookie(client, editor)
+        assert (
+            client.patch(f"/api/nodes/{child_id}", json={"content": "changed"}).status_code == 200
+        )
+
+        notes = _watch_events(db, watcher_id)
+        assert len(notes) == 1
+        assert notes[0].payload["node_id"] == child_id

--- a/web/components/inset-header.tsx
+++ b/web/components/inset-header.tsx
@@ -100,6 +100,7 @@ export function EditorHeader({
       </button>
 
       <PageMenu
+        nodeId={collectionId}
         open={menuOpen}
         onOpenChange={setMenuOpen}
         starred={starred}

--- a/web/components/page-menu.tsx
+++ b/web/components/page-menu.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ArrowRight,
   BookOpen,
   Copy,
   Eye,
+  EyeOff,
   History,
   Link as LinkIcon,
   Star,
   Trash2,
 } from "lucide-react";
 import { toast } from "sonner";
+
+import { getWatchStatus, unwatchNode, watchNode } from "@/lib/api";
 
 export type PageMenuDrawer = "backlinks" | "history";
 
@@ -56,6 +59,8 @@ interface Props {
   starred?: boolean;
   /** Invoked when the user clicks Star/Unstar. */
   onToggleStar?: () => void;
+  /** Node (page or folder) this menu acts on; enables the Watch toggle. */
+  nodeId?: string;
 }
 
 export function PageMenu({
@@ -65,8 +70,44 @@ export function PageMenu({
   trigger,
   starred = false,
   onToggleStar,
+  nodeId,
 }: Props) {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const [watching, setWatching] = useState<boolean | null>(null);
+  const [watchBusy, setWatchBusy] = useState(false);
+
+  // Load the current watch state each time the menu opens so the toggle
+  // reflects reality (it may have changed in another tab/session).
+  useEffect(() => {
+    if (!open || !nodeId) return;
+    let cancelled = false;
+    getWatchStatus(nodeId)
+      .then((s) => !cancelled && setWatching(s.watching))
+      .catch(() => !cancelled && setWatching(null));
+    return () => {
+      cancelled = true;
+    };
+  }, [open, nodeId]);
+
+  async function toggleWatch() {
+    if (!nodeId || watchBusy) return;
+    setWatchBusy(true);
+    try {
+      if (watching) {
+        await unwatchNode(nodeId);
+        setWatching(false);
+        toast.success("Stopped watching");
+      } else {
+        await watchNode(nodeId);
+        setWatching(true);
+        toast.success("Watching — you'll be notified of changes");
+      }
+    } catch {
+      toast.error("Couldn't update watch status");
+    } finally {
+      setWatchBusy(false);
+    }
+  }
 
   useEffect(() => {
     if (!open) return;
@@ -90,6 +131,25 @@ export function PageMenu({
           {ITEMS.map((item, i) => {
             if (item.kind === "divider") {
               return <div key={`div-${i}`} className="my-1 h-px bg-border" />;
+            }
+
+            if (item.kind === "action" && item.id === "watch") {
+              const WatchIcon = watching ? EyeOff : Eye;
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  role="menuitem"
+                  disabled={!nodeId || watchBusy}
+                  onClick={toggleWatch}
+                  className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] text-foreground transition-colors hover:bg-accent disabled:opacity-50"
+                >
+                  <WatchIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <span className="flex-1">
+                    {watching ? "Unwatch" : "Watch"}
+                  </span>
+                </button>
+              );
             }
 
             const isStar = item.kind === "action" && item.id === "star";

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -20,6 +20,7 @@ import type {
   ShareLink,
   Space,
   StarredNode,
+  WatchStatus,
   Workspace,
   WorkspaceTree,
 } from "./types";
@@ -381,6 +382,20 @@ export function revokeShareLink(linkId: string): Promise<void> {
 /** Public, no-account URL a viewer opens to read shared content. */
 export function sharedLinkUrl(token: string): string {
   return `${getApiUrl()}/shared/${token}`;
+}
+
+// Node watches (#104) — subscribe to change notifications for a page or folder.
+
+export function getWatchStatus(nodeId: string): Promise<WatchStatus> {
+  return apiFetch(`/api/nodes/${nodeId}/watching`);
+}
+
+export function watchNode(nodeId: string): Promise<WatchStatus> {
+  return apiFetch(`/api/nodes/${nodeId}/watch`, { method: "POST" });
+}
+
+export function unwatchNode(nodeId: string): Promise<void> {
+  return apiFetch(`/api/nodes/${nodeId}/watch`, { method: "DELETE" });
 }
 
 /** Convert a display name to a URL-safe slug. */

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -166,3 +166,7 @@ export interface Comment {
   created_at: string;
   updated_at: string;
 }
+
+export interface WatchStatus {
+  watching: boolean;
+}


### PR DESCRIPTION
Closes #104.

## Summary
- New `node_watches` table (user_id, node_id, unique pair) + `notifications` Inbox table (the #103 pipeline this depends on; mirrored exactly so it merges consistently).
- `GET /api/nodes/{nid}/watching`, `POST /api/nodes/{nid}/watch`, `DELETE /api/nodes/{nid}/watch` — viewer-level RBAC; API-key/anonymous callers get 401 (no user inbox).
- On page save (`update_node` revision create), `marrow/watches.py` fans out `watch_event` notifications to every watcher of the page **or any ancestor folder**, excluding the acting user. (No comment model exists yet on the backend, so the comment hook lands with comments.)
- `PageMenu` Watch/Unwatch toggle wired to the API, reflecting current state on open.
- Watches/notifications are user-scoped and **not exported** — restore guarantee unaffected.
- Alembic migration `94d64b4e6869` (down/up cycle verified); new `tests/test_watches.py` (5 tests, all green) covering endpoints, RBAC, idempotency, actor-exclusion, and folder-descendant fan-out.

Note: pre-existing failures in test_export/test_restore/test_round_trip/test_rbac/test_migration_cycle stem from the #123 schema migration (documented in CLAUDE.md, land in #132/#133) and are unrelated to this change.

_Created by swarm coordinator_