### PR TITLE
fix: resolve critical bugs and lint errors from swarm PR merge

### DIFF
--- a/api/marrow/app.py
+++ b/api/marrow/app.py
@@ -7,7 +7,20 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from .dependencies import verify_auth
-from .routers import auth, billing, comments, nodes, notifications, organizations, properties, share_links, spaces, users, views, workspaces
+from .routers import (
+    auth,
+    billing,
+    comments,
+    nodes,
+    notifications,
+    organizations,
+    properties,
+    share_links,
+    spaces,
+    users,
+    views,
+    workspaces,
+)
 
 
 def _truthy(value: str | None) -> bool:

--- a/api/marrow/export.py
+++ b/api/marrow/export.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 from sqlalchemy.orm import Session
 
-from .models import Attachment, Node, NodeProperty, Workspace
+from .models import Node, NodeProperty, Workspace
 from .storage import StorageAdapter
 
 SCHEMA_VERSION = "4"
@@ -474,7 +474,7 @@ def export_workspace(
 
         zf.writestr("links.json", json.dumps(_build_links(nodes, node_id_set), indent=2))
 
-        node_id_list = [n.id for n in all_nodes]
+        node_id_list = [n.id for n in nodes]
         prop_rows = (
             session.query(NodeProperty)
             .filter(NodeProperty.node_id.in_(node_id_list))

--- a/api/marrow/links.py
+++ b/api/marrow/links.py
@@ -18,12 +18,12 @@ import logging
 import re
 import uuid
 
-logger = logging.getLogger(__name__)
-
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from .models import Node, NodeLink
+
+logger = logging.getLogger(__name__)
 
 # A canonical UUID, optionally followed by a trailing path/query/fragment.
 _UUID = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"

--- a/api/marrow/rbac.py
+++ b/api/marrow/rbac.py
@@ -172,6 +172,10 @@ def require_comment_role(min_role: OrgRole):
             raise HTTPException(404, "Comment not found")
         space = db.get(Space, node.space_id)
         workspace = db.get(Workspace, space.workspace_id)
+        _check_membership(db, workspace.org_id, auth, min_role)
+        return auth
+
+    return _dep
 
 
 def require_view_role(min_role: OrgRole):

--- a/api/marrow/restore.py
+++ b/api/marrow/restore.py
@@ -277,7 +277,8 @@ def _restore_v3_nodes(
             node_id = page_to_node_id.get(page_id)
             if node_id is None:
                 raise ValueError(
-                    f"Revision '{rev_id}' references unknown page '{page_id}' — bundle may be corrupt."
+                    f"Revision '{rev_id}' references unknown page"
+                    f" '{page_id}' — bundle may be corrupt."
                 )
             session.add(
                 Revision(
@@ -462,7 +463,9 @@ def _restore_v4_nodes(
 
         storage.write(att_id, att["filename"], data)
         if "node_id" not in att:
-            raise ValueError(f"Attachment '{att_id}' is missing 'node_id' — v4 bundle may be corrupt.")
+            raise ValueError(
+                f"Attachment '{att_id}' is missing 'node_id' — v4 bundle may be corrupt."
+            )
         session.add(
             Attachment(
                 id=uuid.UUID(att_id),

--- a/api/marrow/routers/nodes.py
+++ b/api/marrow/routers/nodes.py
@@ -13,7 +13,17 @@ from sqlalchemy.orm import Session
 from ..dependencies import AuthContext, get_db, get_storage, verify_auth
 from ..fractional_index import after as fi_after
 from ..links import reconcile_node_links
-from ..models import Attachment, Node, NodeLink, NodeWatch, OrgRole, Revision, Space, UserStar, Workspace
+from ..models import (
+    Attachment,
+    Node,
+    NodeLink,
+    NodeWatch,
+    OrgRole,
+    Revision,
+    Space,
+    UserStar,
+    Workspace,
+)
 from ..notifications import deliver_mention_notifications
 from ..rbac import _check_membership, require_node_role, require_space_role
 from ..schemas import (

--- a/api/marrow/routers/spaces.py
+++ b/api/marrow/routers/spaces.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..dependencies import AuthContext, get_db
-from ..models import OrgMembership, OrgRole, Organization, Space, Workspace
+from ..models import Organization, OrgMembership, OrgRole, Space, Workspace
 from ..rbac import require_workspace_role
 from ..schemas import SpaceCreate, SpaceRead
 

--- a/api/tests/test_node_tree.py
+++ b/api/tests/test_node_tree.py
@@ -15,7 +15,6 @@ from marrow.models import (
     Node,
     Organization,
     OrgMembership,
-    OrgRole,
     Space,
     User,
     Workspace,
@@ -336,7 +335,7 @@ def test_soft_deleted_node_hidden_from_list(session, client):
     user = _make_user(session, "viewer-listhidden@test.com")
     session.add(OrgMembership(org_id=org.id, user_id=user.id, email=user.email, role="viewer"))
 
-    alive = _make_folder(session, space, "alive")
+    _make_folder(session, space, "alive")
     dead = _make_folder(session, space, "dead")
     dead.deleted_at = datetime.now(timezone.utc)
     session.commit()

--- a/api/tests/test_notifications.py
+++ b/api/tests/test_notifications.py
@@ -9,7 +9,6 @@ from fastapi.testclient import TestClient
 
 from marrow.auth import COOKIE_NAME, create_session_jwt, reset_oidc_config
 from marrow.models import (
-    Node,
     Notification,
     Organization,
     OrgMembership,

--- a/web/components/app-sidebar.tsx
+++ b/web/components/app-sidebar.tsx
@@ -48,6 +48,7 @@ interface Props {
   user?: User | null;
   panel: RailPanel;
   memberCount: number | null;
+  showOrgSettings?: boolean;
   searchInputRef: React.RefObject<HTMLInputElement | null>;
   onInboxUnreadChange?: (count: number) => void;
 }
@@ -461,7 +462,7 @@ function SpaceSection({
   );
 }
 
-function WorkspaceHeader({ tree, memberCount }: { tree: WorkspaceTree; memberCount: number | null }) {
+function WorkspaceHeader({ tree, memberCount, showOrgSettings }: { tree: WorkspaceTree; memberCount: number | null; showOrgSettings?: boolean }) {
   return (
     <div className="flex items-center gap-2 border-b border-sidebar-border px-3.5 py-3 group">
       <div className="min-w-0 flex-1">
@@ -472,13 +473,15 @@ function WorkspaceHeader({ tree, memberCount }: { tree: WorkspaceTree; memberCou
       </div>
       <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
         <ExportDialog workspaceId={tree.id} workspaceName={tree.name} />
-        <a
-          href={`/orgs/${tree.org_id}/settings`}
-          className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
-          title="Organization settings"
-        >
-          <Settings className="h-3.5 w-3.5" />
-        </a>
+        {showOrgSettings && (
+          <a
+            href={`/orgs/${tree.org_id}/settings`}
+            className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground"
+            title="Organization settings"
+          >
+            <Settings className="h-3.5 w-3.5" />
+          </a>
+        )}
       </div>
       <button
         type="button"
@@ -745,7 +748,7 @@ export function AppSidebar({ tree, user, panel, memberCount, showOrgSettings, se
 
   return (
     <aside className="flex h-full w-[272px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground">
-      <WorkspaceHeader tree={tree} memberCount={memberCount} />
+      <WorkspaceHeader tree={tree} memberCount={memberCount} showOrgSettings={showOrgSettings} />
 
       {panel === "pages" && (
         <PagesPanel tree={tree} activePath={pathname} refresh={refresh} user={user} />

--- a/web/components/workspace-shell.tsx
+++ b/web/components/workspace-shell.tsx
@@ -76,6 +76,7 @@ export function WorkspaceShell({ tree, user, memberCount, showOrgSettings, works
             user={user}
             panel={panel}
             memberCount={memberCount}
+            showOrgSettings={showOrgSettings}
             searchInputRef={searchInputRef}
             onInboxUnreadChange={setInboxUnread}
           />

--- a/web/components/workspace-tree-context.tsx
+++ b/web/components/workspace-tree-context.tsx
@@ -45,10 +45,7 @@ export function findNodeBreadcrumb(
  * callers should migrate to findNodeBreadcrumb. Kept as a no-op for incremental
  * migration of consumer components.
  */
-export function findBreadcrumb(
-  _tree: WorkspaceTree,
-  _id: string,
-): { spaceName: string; collectionName: string } | null {
+export function findBreadcrumb(): { spaceName: string; collectionName: string } | null {
   return null;
 }
 

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -467,9 +467,8 @@ export function markNotificationRead(id: string): Promise<Notification> {
 
 export async function markAllNotificationsRead(): Promise<void> {
   await apiFetch("/api/users/me/notifications/read-all", { method: "POST" });
+}
 
-// ---------------------------------------------------------------------------
-// Node properties
 // ---------------------------------------------------------------------------
 // Node properties
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **`web/lib/api.ts`** — missing `}` closing `markAllNotificationsRead()` was a parse error that prevented the entire module from compiling
- **`api/marrow/export.py`** — `all_nodes` → `nodes` fixes a `NameError` that would crash any export including node properties
- **`api/marrow/rbac.py`** — restored missing `_check_membership` + `return auth` in `require_comment_role`; role enforcement was silently skipped on all comment routes (security fix)
- **`web/components/app-sidebar.tsx`** — wired `showOrgSettings` through the component tree (`WorkspaceShell` → `AppSidebar` → `WorkspaceHeader`) and gated the org settings link behind it
- Ruff auto-fixes: import sort/wrap in `app.py`, `nodes.py`, `spaces.py`, `notifications.py`; imports above `getLogger` in `links.py`; long lines in `restore.py`; unused var in `test_node_tree.py`
- Dropped unused params from deprecated `findBreadcrumb` in `workspace-tree-context.tsx`

## Test plan

- [x] `cd api && ruff check .` → clean
- [x] `cd web && npm run lint` → 0 errors (pre-existing setState-in-effect warnings are deferred)
- [x] `cd web && ./node_modules/.bin/tsc --noEmit` → 0 errors (excluding generated validator.ts)