### PR TITLE
docs: add CHANGELOG.md (v0.1.0 → v0.2.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog
+
+All notable changes to Marrow are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Each release also has fuller narrative notes (highlights, breaking changes, upgrade
+steps) on its [GitHub release](https://github.com/marrow-software/marrow/releases).
+
+## [0.2.9] — 2026-06-06
+
+The v0.2 milestone: the collections/pages model collapses into a unified node tree, a
+suite of collaboration features lands, and Marrow launches as a hosted service.
+
+### Added
+- Comments — page-level threads with replies and resolve.
+- Backlinks — every page tracks what links to it; wiki-links reconciled on save.
+- Stars, watches, and a per-user Inbox (notifications for edits and `@`-mentions).
+- Node properties — text, number, date, select, multi-select, checkbox — declared on a
+  folder and inherited by descendant pages; folded into full-text search.
+- Folder views — render a folder's pages as a table, board, or list with sorts, filters,
+  and grouping.
+- View-only share links — public, account-free access to a page or folder subtree;
+  expiring and revocable.
+- Editor: `@` member mentions, `/page` slash command for wiki-links, code blocks with
+  syntax highlighting, and tables.
+- Cloudflare R2 storage adapter for attachments (alongside local filesystem).
+- Marketing site (`marrow.so`) and a user-facing docs site.
+- Org RBAC (owner / editor / viewer) enforced across all routes, admin dashboard,
+  multi-workspace switcher, and a Home landing screen.
+- Stripe billing with Starter / Business / Growth / Enterprise tiers.
+
+### Changed
+- **Data model:** Organizations → Workspaces → Spaces → **Folders / Pages** (nodes).
+  Folders and pages are both `nodes` (`type = 'folder' | 'page'`); the Collections table
+  was removed. Old collection-scoped and global page routes replaced by
+  `/api/spaces/{id}/nodes` and `/api/nodes/...`.
+- **Export bundle bumped to v4** (carries the node tree and node properties). Restore
+  still accepts v1–v4 bundles; older bundles auto-upgrade onto the node tree on read.
+- **Deployment (SaaS):** API moved off Cloudflare Containers to **Fly.io**; web app moved
+  to **Cloudflare Workers** via `@opennextjs/cloudflare`; marketing and docs on
+  **Cloudflare Pages**; database on **Neon**. Self-hosted Docker Compose is unchanged.
+
+### Fixed
+- Migrations now run automatically on deploy via Fly's `[deploy] release_command`.
+- Web runtime config (API URL, OIDC flag) is supplied to the Workers deploy via wrangler
+  `[vars]` plus a `/config.js` route handler.
+- R2 storage adapter accepts `R2_ENDPOINT_URL` and fails with a clear error instead of a
+  `KeyError` at import.
+- OIDC discovery URL no longer double-slashes when `OIDC_ISSUER` has a trailing slash.
+- Marketing site deploys from the static export (`out/`).
+
+## [0.1.1] — 2026-04-30
+
+### Added
+- Multi-arch container images (`linux/amd64` + `linux/arm64`) for `marrow-api` and
+  `marrow-web`.
+
+### Changed
+- The web container reads browser config at runtime (from `MARROW_*` env vars written into
+  `/public/config.js` at startup) instead of inlining `NEXT_PUBLIC_*` at build time, so the
+  same prebuilt image works on any deployment without rebuilding.
+
+## [0.1.0] — 2026-04-29
+
+Initial release — a self-hosted, open-source knowledge base built around a non-negotiable
+restore guarantee.
+
+### Added
+- Restore guarantee — `marrow restore` reproduces a workspace exactly from any export
+  bundle (round-trip test enforced in CI).
+- Append-only revisions, enforced at the database layer.
+- OIDC SSO (any IdP) with API-key fallback and anonymous dev mode.
+- Org-level RBAC (owner / editor / viewer).
+- Pluggable storage adapter (local filesystem).
+- Markdown + JSON export bundles, human-readable without tooling.
+- PostgreSQL full-text search.
+- BlockNote rich-text editor.
+
+[0.2.9]: https://github.com/marrow-software/marrow/releases/tag/v0.2.9
+[0.1.1]: https://github.com/marrow-software/marrow/releases/tag/v0.1.1
+[0.1.0]: https://github.com/marrow-software/marrow/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Keep this file up to date.** Whenever a meaningful change is made — new routes, schema changes, new components, new environment variables, new constraints, or architectural decisions — update the relevant section here before closing out the task. Treat CLAUDE.md as living documentation.
 
+**When cutting a release:** add a `CHANGELOG.md` entry (Keep a Changelog format) for the new version, and draft the fuller narrative notes on the GitHub release.
+
 **For every feature request:** create a GitHub issue to track it, then create a dedicated git branch off `main` before writing any code. Branch names should follow the pattern `feature/<short-description>` or `fix/<short-description>`. Never implement features directly on `main`.
 
 ---


### PR DESCRIPTION
Adds a `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com) format covering all three published versions (v0.1.0, v0.1.1, v0.2.9). Version headings link to the corresponding GitHub releases, which carry the fuller narrative notes.

Also adds a one-line reminder to CLAUDE.md to update the changelog when cutting a release.

The CHANGELOG is the terse in-tree index; the GitHub releases stay the rich narrative (highlights, breaking changes, upgrade steps). Companion to the v0.2.9 draft release.