### PR TITLE
Apply Marrow brand tokens to the docs site (#210)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -8,6 +8,28 @@ export default defineConfig({
       title: "Marrow",
       description:
         "Self-hosted, open-source knowledge base built around a non-negotiable restore guarantee.",
+      logo: {
+        src: "./src/assets/marrow-glyph.svg",
+        alt: "Marrow",
+      },
+      customCss: ["./src/styles/marrow.css"],
+      head: [
+        {
+          tag: "link",
+          attrs: { rel: "preconnect", href: "https://fonts.googleapis.com" },
+        },
+        {
+          tag: "link",
+          attrs: { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: true },
+        },
+        {
+          tag: "link",
+          attrs: {
+            rel: "stylesheet",
+            href: "https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1&family=Inter:wght@300..700&family=JetBrains+Mono:wght@400;500&display=swap",
+          },
+        },
+      ],
       editLink: {
         baseUrl: "https://github.com/spmcgraw/marrow/edit/main/docs/",
       },

--- a/docs/src/assets/marrow-glyph.svg
+++ b/docs/src/assets/marrow-glyph.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect x="1.5" y="1.5" width="29" height="29" rx="6" fill="none" stroke="#e8805c" stroke-width="1.5" />
+  <path d="M7 23 V10 L11 10 L16 17 L21 10 L25 10 V23" fill="none" stroke="#e8805c" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="16" cy="20.5" r="1.6" fill="#e8805c" />
+</svg>

--- a/docs/src/styles/marrow.css
+++ b/docs/src/styles/marrow.css
@@ -60,6 +60,14 @@ h1#_top,
   font-variation-settings: "SOFT" 40, "WONK" 0;
 }
 
+/* Site title reads as the lowercase "marrow" wordmark (matches web-marketing),
+   while the document <title> stays "Marrow" for SEO. */
+.site-title {
+  text-transform: lowercase;
+  letter-spacing: -0.02em;
+  font-variation-settings: "SOFT" 30, "WONK" 0;
+}
+
 /* Selection matches the brand accent. */
 ::selection {
   background: var(--sl-color-accent);

--- a/docs/src/styles/marrow.css
+++ b/docs/src/styles/marrow.css
@@ -1,0 +1,67 @@
+/* Marrow brand layer for Starlight.
+ *
+ * Maps the brand tokens shared with web/ and web-marketing/ onto Starlight's
+ * theme variables: orange accent, the Fraunces / Inter / JetBrains Mono type
+ * system, and the Marrow base surfaces. Starlight's default dark gray scale is
+ * already slate-compatible, so we only retune the accent, fonts, and surfaces.
+ *
+ * Reference: https://starlight.astro.build/guides/css-and-tailwind/
+ */
+
+:root {
+  /* Type system */
+  --sl-font: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+  --sl-font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --marrow-font-display: "Fraunces", ui-serif, Georgia, serif;
+
+  /* Accent — Marrow orange (dark theme is the default) */
+  --sl-color-accent-low: #3a1d10;
+  --sl-color-accent: #e8805c;
+  --sl-color-accent-high: #f3b39c;
+
+  /* Surfaces — Marrow dark base */
+  --sl-color-bg: #111318;
+  --sl-color-bg-nav: #1a1d27;
+  --sl-color-bg-sidebar: #14171f;
+  --sl-color-bg-inline-code: #222636;
+  --sl-color-hairline-light: #2d3348;
+  --sl-color-hairline: #2d3348;
+}
+
+:root[data-theme="light"] {
+  /* Accent — darker orange for contrast on light surfaces */
+  --sl-color-accent-low: #f1d6c8;
+  --sl-color-accent: #9a3412;
+  --sl-color-accent-high: #7c2d12;
+
+  /* Surfaces — Marrow light base */
+  --sl-color-bg: #dde3ee;
+  --sl-color-bg-nav: #eaeff7;
+  --sl-color-bg-sidebar: #eaeff7;
+  --sl-color-bg-inline-code: #f4f6fb;
+  --sl-color-hairline-light: #c8d0e0;
+  --sl-color-hairline: #c8d0e0;
+}
+
+/* Fraunces for the site title and all content headings, with the editorial
+   SOFT axis used across the brand. */
+.site-title,
+.sl-markdown-content h1,
+.sl-markdown-content h2,
+.sl-markdown-content h3,
+.sl-markdown-content h4,
+.sl-markdown-content h5,
+.sl-markdown-content h6,
+h1#_top,
+.content-panel h1 {
+  font-family: var(--marrow-font-display);
+  font-weight: 400;
+  letter-spacing: -0.015em;
+  font-variation-settings: "SOFT" 40, "WONK" 0;
+}
+
+/* Selection matches the brand accent. */
+::selection {
+  background: var(--sl-color-accent);
+  color: #1a0f0a;
+}


### PR DESCRIPTION
Closes #210.

The Astro Starlight docs site (`docs/`) rendered with stock theming — default blue/purple accent and system fonts. This adds a brand layer so `docs.marrow.so` matches `web/` and `web-marketing/`. **`docs/` only; no content changes.**

## Changes
- **`src/styles/marrow.css`** (new) — maps brand tokens onto Starlight's theme vars:
  - Accent → Marrow orange: `#e8805c` (dark) / `#9a3412` (light), with tuned `-low`/`-high` shades for contrast.
  - Fonts → `--sl-font` = Inter, `--sl-font-mono` = JetBrains Mono; Fraunces (SOFT axis) for the site title + all content headings.
  - Surfaces → `--sl-color-bg`/`-bg-nav`/`-bg-sidebar`/`-bg-inline-code`/`-hairline` aligned to the Marrow base palette in both themes. (Starlight's default gray text scale is already slate-compatible, so it's left intact.)
  - `::selection` uses the accent.
- **`src/assets/marrow-glyph.svg`** (new) — MarrowGlyph wired as the Starlight `logo` (fixed brand orange, since Starlight renders the logo as an `<img>` where `currentColor` wouldn't adapt).
- **`astro.config.mjs`** — `logo`, `customCss`, and `head` Google Fonts links (with preconnect).

## Verification
- `npm run build` clean (9 pages).
- Confirmed in built `dist/`: the Fraunces/Inter/JetBrains font link, the logo `<img>`, accent `#e8805c`, and `JetBrains Mono` all compiled into the output.
- Browser visual check pending (couldn't run headed locally); the token mapping follows Starlight's documented theming API.