### PR TITLE
Login flow: subscription checkout gate + global Home/For You landing (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Each release also has fuller narrative notes (highlights, breaking changes, upgrade
 steps) on its [GitHub release](https://github.com/marrow-software/marrow/releases).
 
+## [Unreleased]
+
+### Added
+- Unified post-login flow: **login → subscription gate → global Home/For You**.
+- Subscription checkout — in-app `/subscribe` page (Starter/Business/Growth, monthly↔yearly,
+  Enterprise "Contact sales") starts a Stripe Checkout session with a 14-day trial; a
+  `/subscribe/success` page polls until the subscription is active, then lands you in the app.
+- Global **Home/For You** (`/home`) — the new post-login default, aggregating recently edited
+  pages, starred items, and Inbox unread across *all* workspaces, plus a workspace switcher in
+  a lightweight global chrome. The `/workspaces` picker is demoted to a switcher.
+- `organizations.subscription_status` (`none | trialing | active | past_due | canceled`) — set
+  by the Stripe webhook; an org is "active" when status ∈ {trialing, active}, tier is
+  enterprise, or self-hosted (`SAAS_MODE` off).
+- Subscription confirmation email via Resend (`hello@marrow.so`), best-effort on
+  `checkout.session.completed`.
+- `GET /api/users/me/recent` — recently edited pages across every workspace the caller can access.
+
+### Changed
+- `POST /api/billing/{org}/checkout` now takes a JSON body (`tier`/`interval`) instead of query
+  params, adds a 14-day trial, and uses real `/subscribe/success` + `/subscribe` redirect URLs.
+- `OrganizationRead` exposes `tier`, `subscription_status`, and `has_active_subscription`;
+  `AuthStatus` adds `has_payable_unsubscribed_org` so the post-login gate is a single round trip.
+
 ## [0.2.9] — 2026-06-06
 
 The v0.2 milestone: the collections/pages model collapses into a unified node tree, a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,13 @@ CORS_ORIGINS=http://localhost:3000
 # OIDC_REDIRECT_URI=http://localhost:8000/api/auth/callback
 # FRONTEND_URL=http://localhost:3000
 # COOKIE_DOMAIN=localhost    # shared domain for session cookie (dev: localhost)
+
+# Billing / subscriptions (SaaS only — set SAAS_MODE=true to enforce the gate)
+# SAAS_MODE=true
+# STRIPE_SECRET_KEY=, STRIPE_WEBHOOK_SECRET=, STRIPE_*_PRICE_* (see api/.env.example)
+# Transactional email (Resend) — confirmation emails on checkout; best-effort.
+# RESEND_API_KEY=re_...
+# EMAIL_FROM="Marrow <hello@marrow.so>"
 ```
 
 **Frontend (`web/.env.local`)**:
@@ -176,13 +183,16 @@ marrow/
 │   │       ├── 5441fe9ca011_add_share_links_table.py
 │   │       ├── ac1e5d8ab0f8_add_node_links_backlink_index.py
 │   │       ├── cd990242773c_add_user_stars_table.py
-│   │       └── 70645242437d_merge_swarm_v0_2_migrations.py
+│   │       ├── 70645242437d_merge_swarm_v0_2_migrations.py
+│   │       └── a1b2c3d4e5f6_add_subscription_status_to_organizations.py  # #208
 │   ├── marrow/                       # Main package
 │   │   ├── app.py                    # FastAPI app factory, CORS + session middleware
 │   │   ├── auth.py                   # OIDC config, session JWT helpers, cookie params
 │   │   ├── db.py                     # SQLAlchemy session management
 │   │   ├── dependencies.py           # FastAPI dependency providers (auth, db session, search)
 │   │   ├── rbac.py                   # Role-based access control dependency factories
+│   │   ├── subscriptions.py          # Subscription gate helpers (is_org_active / is_saas_mode) — #208
+│   │   ├── email.py                  # Resend transactional email (send_email) — #208
 │   │   ├── models.py                 # SQLAlchemy ORM models (incl. User)
 │   │   ├── schemas.py                # Pydantic request/response schemas (incl. AuthStatus)
 │   │   ├── fractional_index.py       # Fractional index helpers: between(a,b), after(a)
@@ -384,6 +394,10 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | PATCH | /api/comments/{cid} | Edit body and/or resolve/unresolve (`{"resolved": true\|false}`) | editor |
 | DELETE | /api/comments/{cid} | Delete a comment | editor + (author or org owner) |
 | GET | /api/users/me/starred | List current user's starred nodes (trashed excluded) | session |
+| GET | /api/users/me/recent | Recently edited pages across all the caller's workspaces (#208) | session |
+| POST | /api/billing/{oid}/checkout | Create a Stripe Checkout session (JSON body `{tier, interval}`, 14-day trial) | owner |
+| POST | /api/billing/{oid}/portal | Create a Stripe Customer Portal session | owner |
+| POST | /api/billing/webhook | Stripe webhook — writes `subscription_status`, sends confirmation email | — |
 | POST | /api/nodes/{nid}/star | Star a node (idempotent) | viewer |
 | DELETE | /api/nodes/{nid}/star | Unstar a node | viewer |
 | GET | /api/nodes/{nid}/watching | Whether the current user watches this node | viewer |
@@ -480,6 +494,16 @@ Marrow supports three authentication methods, checked in priority order:
 
 **Key files**: `auth.py` (config, JWT helpers), `dependencies.py` (`verify_auth` + `AuthContext`), `rbac.py` (role enforcement dependencies), `routers/auth.py` (login/callback/me/logout), `routers/organizations.py` (org CRUD + member management).
 
+### Subscriptions & Billing (#208)
+
+Post-login flow: **login → subscription gate → global `/home`**.
+
+- **Gate model** — "active subscription" is a property of the **org** (`marrow/subscriptions.py`, the single source of truth). `is_org_active(tier, subscription_status)` is True when `SAAS_MODE` is off (self-hosted is never gated), the tier is `enterprise`, or `subscription_status ∈ {trialing, active}`. `is_saas_mode()` reads `SAAS_MODE` dynamically.
+- **`organizations.subscription_status`** (`none | trialing | active | past_due | canceled`, default `none`) is written **only** by the Stripe webhook. `OrganizationRead` exposes `tier`, `subscription_status`, and the computed `has_active_subscription`. `AuthStatus.has_payable_unsubscribed_org` (computed in `/api/auth/me` over the user's *owned* orgs) lets the post-login gate be one round trip. **Billing fields are never exported** (the restore round-trip is unaffected).
+- **Webhook** (`routers/billing.py`): `checkout.session.completed` → status from the Stripe subscription (trial → `trialing`) + confirmation email; `customer.subscription.updated` → mapped status; `…deleted` → `canceled`; `invoice.payment_failed` → `past_due`. `/checkout` takes a **JSON body** (`{tier, interval}`), adds a 14-day trial, and redirects to `/subscribe/success?org=` / `/subscribe?org=&canceled=1`.
+- **Email** (`marrow/email.py`): `send_email(to, subject, html)` via the Resend REST API, sender `hello@marrow.so`. Best-effort — never raises, never blocks the webhook 200; skipped when `RESEND_API_KEY` is unset.
+- **Gate enforcement (frontend)**: `app/auth/callback` routes only to `/subscribe` (owner of an unsubscribed org) or `/home`; `app/home/layout.tsx` re-asserts it (defense in depth); `app/w/[workspaceId]/layout.tsx` gates on *that* workspace's org (owner → `/subscribe?org=`, member → notice).
+
 ### Frontend Patterns
 
 - **API client** (`lib/api.ts`): all server calls go through `apiFetch<T>()` which injects auth headers and handles errors
@@ -490,6 +514,7 @@ Marrow supports three authentication methods, checked in priority order:
 - **Sidebar drag-and-drop**: `@dnd-kit/core` drives reparenting and reordering of folders/pages. New positions are computed via `fractional-indexing.generateKeyBetween()` and PATCHed to `/api/nodes/{id}` with `parent_id` + `position`. Cross-workspace drops and descendant-cycle drops are rejected with a `sonner` toast. Server is the source of truth — failures rollback via `router.refresh()`.
 - **Comments**: `useComments(nodeId)` hook (`hooks/use-comments.ts`) owns thread state; `CommentsDrawer` renders threads/composer/resolve and `CommentBubbleFab` shows the unread badge. Unread = comments created after the viewer's last drawer visit, tracked client-side in `localStorage` (`marrow:comment-visit:<nodeId>`) — deliberately simple v1 heuristic, no backend visit table
 - **Inbox**: `rail-panels/inbox-panel.tsx` lists notifications with kind-specific icons/copy and an empty state; `WorkspaceShell` fetches the unread count on mount and `AppRail` renders an unread badge on the Inbox tab. Backend delivery lives in `api/marrow/notifications.py` — `@`-mention saves on page nodes notify newly-mentioned users (only mentions new vs. the prior revision; the actor is never self-notified). Notifications are user-scoped and deliberately excluded from export/restore.
+- **Global Home (#208)**: `app/home/` is the post-login default — `layout.tsx` enforces the auth + subscription gate and renders `components/global-chrome.tsx` (a slim top bar with workspace switcher + user menu, **not** `WorkspaceShell`); `page.tsx` composes self-contained widgets in `components/home/widgets.tsx` (Recently edited via `getMyRecent`, Starred, Inbox summary, Workspace switcher) — each kept standalone for the future widgets-dashboard backlog. The `/workspaces` picker is a switcher, not the landing. `/subscribe` + `/subscribe/success` drive checkout (`createCheckoutSession`).
 - **UI library**: Base UI (`@base-ui/react`) with Tailwind CSS 4 — uses `render` prop pattern, not `asChild`
 - **Theme**: `next-themes` wraps the root layout
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -44,6 +44,11 @@ MARROW_ALLOW_ANONYMOUS=true
 # Key for signing self-hosted license JWTs (any long random secret)
 # LICENSE_SIGNING_KEY=
 
+# Transactional email (Resend) — used for subscription confirmation emails.
+# Best-effort: if unset, email sends are skipped (never blocks the webhook).
+# RESEND_API_KEY=re_...
+# EMAIL_FROM="Marrow <hello@marrow.so>"
+
 # OIDC Authentication (optional — omit OIDC_ISSUER to disable)
 # When configured, users must sign in via the OIDC provider.
 # API key auth is preserved as a fallback for CLI and scripts.

--- a/api/alembic/versions/a1b2c3d4e5f6_add_subscription_status_to_organizations.py
+++ b/api/alembic/versions/a1b2c3d4e5f6_add_subscription_status_to_organizations.py
@@ -1,0 +1,38 @@
+"""add subscription_status to organizations
+
+Revision ID: a1b2c3d4e5f6
+Revises: 70645242437d
+Create Date: 2026-06-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, Sequence[str], None] = '70645242437d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'organizations',
+        sa.Column('subscription_status', sa.Text(), server_default='none', nullable=False),
+    )
+    # Backfill existing rows: enterprise tier and orgs with an active Stripe
+    # subscription are already paying -> 'active'; everyone else stays 'none'.
+    op.execute(
+        """
+        UPDATE organizations
+        SET subscription_status = 'active'
+        WHERE tier = 'enterprise'
+           OR stripe_subscription_id IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('organizations', 'subscription_status')

--- a/api/marrow/email.py
+++ b/api/marrow/email.py
@@ -1,0 +1,59 @@
+"""Transactional email via the Resend REST API.
+
+Best-effort delivery: ``send_email`` never raises. Callers (e.g. the Stripe
+webhook) must not block their success response on email delivery, so failures
+are logged and swallowed. When ``RESEND_API_KEY`` is unset (dev / self-hosted),
+sends are skipped silently.
+
+Cloudflare Email Routing is inbound-only and the webhook runs in FastAPI on
+Fly.io (not a Worker), so the Workers email binding isn't reachable — hence the
+plain REST call here.
+"""
+
+import logging
+import os
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_RESEND_ENDPOINT = "https://api.resend.com/emails"
+_DEFAULT_FROM = "Marrow <hello@marrow.so>"
+
+
+def send_email(to: str, subject: str, html: str) -> bool:
+    """Send a transactional email. Returns True on success, False otherwise.
+
+    Never raises — intended for best-effort sends from request handlers.
+    """
+    api_key = os.getenv("RESEND_API_KEY", "").strip()
+    if not api_key:
+        logger.info("RESEND_API_KEY unset; skipping email to %s (%r)", to, subject)
+        return False
+
+    sender = os.getenv("EMAIL_FROM", _DEFAULT_FROM)
+    try:
+        resp = httpx.post(
+            _RESEND_ENDPOINT,
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"from": sender, "to": [to], "subject": subject, "html": html},
+            timeout=10.0,
+        )
+        resp.raise_for_status()
+        return True
+    except Exception:  # noqa: BLE001 — best-effort; log and continue
+        logger.exception("Failed to send email to %s (%r)", to, subject)
+        return False
+
+
+def subscription_confirmation_html(org_name: str, tier: str) -> str:
+    """Render the subscription confirmation email body."""
+    tier_label = tier.title()
+    return f"""\
+<div style="font-family: -apple-system, system-ui, sans-serif; max-width: 480px; margin: 0 auto;">
+  <h1 style="font-size: 20px;">You're all set 🎉</h1>
+  <p>Your subscription for <strong>{org_name}</strong> is active on the
+  <strong>{tier_label}</strong> plan, including a 14-day free trial.</p>
+  <p>You can manage your plan any time from your organization settings.</p>
+  <p style="color: #888; font-size: 13px;">— The Marrow team</p>
+</div>"""

--- a/api/marrow/models.py
+++ b/api/marrow/models.py
@@ -49,6 +49,8 @@ class Organization(Base):
     # Billing
     tier: Mapped[str] = mapped_column(Text, nullable=False, server_default="starter")
     billing_interval: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Explicit subscription state: none | trialing | active | past_due | canceled
+    subscription_status: Mapped[str] = mapped_column(Text, nullable=False, server_default="none")
     stripe_customer_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True)
     stripe_subscription_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True)
     self_hosted_license: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/api/marrow/routers/auth.py
+++ b/api/marrow/routers/auth.py
@@ -23,6 +23,7 @@ from ..auth import (
 from ..dependencies import get_db
 from ..models import Organization, OrgMembership, OrgRole, User
 from ..schemas import AuthStatus, UserRead
+from ..subscriptions import is_org_active, is_saas_mode
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
@@ -168,6 +169,7 @@ async def me(request: Request) -> AuthStatus:
                 user=user,
                 method="session",
                 oidc_enabled=config.is_enabled,
+                has_payable_unsubscribed_org=_user_has_payable_unsubscribed_org(user.id),
             )
         except Exception:
             pass
@@ -178,6 +180,30 @@ async def me(request: Request) -> AuthStatus:
         method="anonymous",
         oidc_enabled=config.is_enabled,
     )
+
+
+def _user_has_payable_unsubscribed_org(user_id: uuid.UUID) -> bool:
+    """Whether the user owns >=1 org that lacks an active subscription.
+
+    Drives the post-login subscription gate. Returns False in self-hosted mode
+    (``is_org_active`` short-circuits to active when SaaS mode is off).
+    """
+    if not is_saas_mode():
+        return False
+    db = next(get_db())
+    try:
+        owned_orgs = (
+            db.query(Organization)
+            .join(OrgMembership, OrgMembership.org_id == Organization.id)
+            .filter(
+                OrgMembership.user_id == user_id,
+                OrgMembership.role == OrgRole.OWNER.value,
+            )
+            .all()
+        )
+        return any(not is_org_active(org.tier, org.subscription_status) for org in owned_orgs)
+    finally:
+        db.close()
 
 
 @router.post("/logout")

--- a/api/marrow/routers/billing.py
+++ b/api/marrow/routers/billing.py
@@ -6,10 +6,12 @@ from uuid import UUID
 import stripe
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ..dependencies import AuthContext, get_db
+from ..email import send_email, subscription_confirmation_html
 from ..models import Organization, OrgRole
 from ..rbac import require_org_role
 
@@ -60,6 +62,32 @@ TIER_SEAT_LIMITS: dict[str, int | None] = {
 router = APIRouter(prefix="/api/billing", tags=["billing"])
 
 
+class CheckoutRequest(BaseModel):
+    tier: str
+    interval: str = "monthly"
+    quantity: int = 1
+
+
+# Map Stripe subscription.status -> our subscription_status enum.
+_STRIPE_STATUS_MAP: dict[str, str] = {
+    "trialing": "trialing",
+    "active": "active",
+    "past_due": "past_due",
+    "unpaid": "past_due",
+    "incomplete": "past_due",
+    "paused": "past_due",
+    "canceled": "canceled",
+    "incomplete_expired": "canceled",
+}
+
+
+def _map_stripe_status(status: str | None) -> str:
+    """Translate a Stripe subscription status to our enum (default ``none``)."""
+    if not status:
+        return "none"
+    return _STRIPE_STATUS_MAP.get(status, "none")
+
+
 def _get_or_create_customer(org: Organization) -> str:
     """Return the Stripe customer ID for an org, creating one if needed."""
     if org.stripe_customer_id:
@@ -74,17 +102,17 @@ def _get_or_create_customer(org: Organization) -> str:
 @router.post("/{org_id}/checkout")
 def create_checkout_session(
     org_id: UUID,
-    tier: str,
-    interval: str = "monthly",
-    quantity: int = 1,
+    body: CheckoutRequest,
     db: Session = Depends(get_db),
     auth: AuthContext = Depends(require_org_role(OrgRole.OWNER)),
 ):
-    """Create a Stripe Checkout session for a Cloud or self-hosted plan."""
+    """Create a Stripe Checkout session (with a 14-day trial) for a plan."""
     org = db.get(Organization, org_id)
     if org is None:
         raise HTTPException(404, "Organization not found")
 
+    tier = body.tier
+    interval = body.interval
     frontend_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
 
     # Determine price ID
@@ -95,7 +123,7 @@ def create_checkout_session(
         line_quantity = 1  # flat rate
     elif tier in _SH_PRICES:
         price_id = _SH_PRICES[tier]
-        line_quantity = max(1, quantity)  # per-seat
+        line_quantity = max(1, body.quantity)  # per-seat
     else:
         raise HTTPException(422, f"Unknown tier: {tier}")
 
@@ -110,8 +138,9 @@ def create_checkout_session(
         customer=customer_id,
         line_items=[{"price": price_id, "quantity": line_quantity}],
         mode="subscription",
-        success_url=f"{frontend_url}/orgs/{org_id}/billing?success=1",
-        cancel_url=f"{frontend_url}/orgs/{org_id}/billing?canceled=1",
+        subscription_data={"trial_period_days": 14},
+        success_url=f"{frontend_url}/subscribe/success?org={org_id}",
+        cancel_url=f"{frontend_url}/subscribe?org={org_id}&canceled=1",
         metadata={"org_id": str(org_id)},
     )
     return {"url": session.url}
@@ -133,7 +162,7 @@ def create_portal_session(
     frontend_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
     session = stripe.billing_portal.Session.create(
         customer=org.stripe_customer_id,
-        return_url=f"{frontend_url}/orgs/{org_id}/billing",
+        return_url=f"{frontend_url}/home",
     )
     return {"url": session.url}
 
@@ -156,8 +185,7 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
     elif event["type"] == "customer.subscription.deleted":
         _handle_subscription_deleted(event["data"]["object"], db)
     elif event["type"] == "invoice.payment_failed":
-        # Log only — do not downgrade on first failure; Stripe retries
-        pass
+        _handle_payment_failed(event["data"]["object"], db)
 
     return JSONResponse({"received": True})
 
@@ -204,7 +232,19 @@ def _handle_checkout_completed(session: dict, db: Session) -> None:
     org.stripe_subscription_id = subscription_id
     org.tier = tier
     org.billing_interval = billing_interval
+    # StripeObject supports .get(); falls back to 'trialing' since checkout
+    # created the subscription with a trial period.
+    org.subscription_status = _map_stripe_status(subscription.get("status") or "trialing")
     db.commit()
+
+    # Best-effort confirmation email — never blocks the webhook 200.
+    recipient = session.get("customer_details", {}).get("email") or session.get("customer_email")
+    if recipient:
+        send_email(
+            to=recipient,
+            subject="Your Marrow subscription is active",
+            html=subscription_confirmation_html(org.name, tier),
+        )
 
 
 def _handle_subscription_updated(subscription: dict, db: Session) -> None:
@@ -222,6 +262,7 @@ def _handle_subscription_updated(subscription: dict, db: Session) -> None:
     org.stripe_subscription_id = subscription_id
     org.tier = tier
     org.billing_interval = billing_interval
+    org.subscription_status = _map_stripe_status(subscription.get("status"))
     db.commit()
 
 
@@ -234,4 +275,15 @@ def _handle_subscription_deleted(subscription: dict, db: Session) -> None:
     org.tier = "starter"
     org.stripe_subscription_id = None
     org.billing_interval = None
+    org.subscription_status = "canceled"
+    db.commit()
+
+
+def _handle_payment_failed(invoice: dict, db: Session) -> None:
+    """Mark the org past_due on a failed invoice payment. Stripe keeps retrying."""
+    customer_id = invoice.get("customer")
+    org = _org_by_customer(customer_id, db)
+    if org is None:
+        return
+    org.subscription_status = "past_due"
     db.commit()

--- a/api/marrow/routers/users.py
+++ b/api/marrow/routers/users.py
@@ -1,14 +1,48 @@
-"""Per-user endpoints (starred nodes)."""
+"""Per-user endpoints (starred nodes, cross-workspace recent)."""
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
 from ..dependencies import AuthContext, get_db, verify_auth
 from ..models import Node, UserStar
-from ..schemas import StarredNodeRead
+from ..schemas import MyRecentItem, StarredNodeRead
+from ..search import _ANCESTOR_PATH_CTE
 
 router = APIRouter(tags=["users"])
+
+# Recently-edited pages across every workspace the user can access. Ordered by
+# latest revision (append-only, so MAX(created_at) is a reliable recency
+# signal), falling back to the node's creation time. Scoped via the
+# org_memberships join so users only see pages in orgs they belong to.
+_MY_RECENT_SQL = text(
+    """
+    SELECT
+        n.id AS node_id,
+        n.name,
+        s.id AS space_id,
+        s.name AS space_name,
+        w.id AS workspace_id,
+        w.name AS workspace_name,
+        COALESCE(
+            ("""
+    + _ANCESTOR_PATH_CTE
+    + """),
+            ARRAY[]::text[]
+        ) AS node_path,
+        COALESCE(MAX(r.created_at), n.created_at) AS updated_at
+    FROM nodes n
+    JOIN spaces s ON s.id = n.space_id
+    JOIN workspaces w ON w.id = s.workspace_id
+    JOIN org_memberships m ON m.org_id = w.org_id AND m.user_id = :user_id
+    LEFT JOIN revisions r ON r.node_id = n.id
+    WHERE n.type = 'page'
+      AND n.deleted_at IS NULL
+    GROUP BY n.id, n.name, s.id, s.name, w.id, w.name, n.parent_id, n.created_at
+    ORDER BY updated_at DESC
+    LIMIT :limit
+    """
+)
 
 
 @router.get("/api/users/me/starred", response_model=list[StarredNodeRead])
@@ -38,4 +72,32 @@ def list_starred(
             starred_at=starred_at,
         )
         for node, starred_at in rows
+    ]
+
+
+@router.get("/api/users/me/recent", response_model=list[MyRecentItem])
+def list_recent(
+    limit: int = 12,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(verify_auth),
+):
+    """Recently-edited pages across every workspace the current user can access."""
+    if auth.user_id is None:
+        raise HTTPException(400, "Recent pages require an authenticated user")
+
+    limit = max(1, min(limit, 50))
+    rows = db.execute(_MY_RECENT_SQL, {"user_id": auth.user_id, "limit": limit}).fetchall()
+
+    return [
+        MyRecentItem(
+            node_id=row.node_id,
+            name=row.name,
+            space_id=row.space_id,
+            space_name=row.space_name,
+            workspace_id=row.workspace_id,
+            workspace_name=row.workspace_name,
+            node_path=list(row.node_path) if row.node_path else [],
+            updated_at=row.updated_at,
+        )
+        for row in rows
     ]

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, computed_field
 
 
 class _ReadBase(BaseModel):
@@ -185,6 +185,20 @@ class WorkspaceHome(_ReadBase):
     space_count: int
     page_count: int
     recent: list[RecentNodeItem] = []
+
+
+class MyRecentItem(_ReadBase):
+    """A recently-edited page, carrying its workspace for cross-workspace linking."""
+
+    node_id: UUID
+    name: str
+    space_id: UUID
+    space_name: str
+    workspace_id: UUID
+    workspace_name: str
+    # Ancestor folder names, root -> leaf (empty when page sits at space root).
+    node_path: list[str]
+    updated_at: datetime
 
 
 # ---------------------------------------------------------------------------
@@ -389,6 +403,15 @@ class OrganizationRead(_ReadBase):
     name: str
     created_at: datetime
     members_can_create_spaces: bool = True
+    tier: str = "starter"
+    subscription_status: str = "none"
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def has_active_subscription(self) -> bool:
+        from .subscriptions import is_org_active
+
+        return is_org_active(self.tier, self.subscription_status)
 
 
 class OrganizationUpdate(BaseModel):
@@ -434,6 +457,9 @@ class AuthStatus(BaseModel):
     user: UserRead | None = None
     method: str
     oidc_enabled: bool
+    # True when the user owns >=1 org with no active subscription (SaaS only).
+    # Lets the post-login callback decide the subscription gate in one round trip.
+    has_payable_unsubscribed_org: bool = False
 
 
 class WatchStatus(BaseModel):

--- a/api/marrow/subscriptions.py
+++ b/api/marrow/subscriptions.py
@@ -1,0 +1,30 @@
+"""Subscription gating helpers — the single source of truth for whether an
+organization counts as having an active subscription.
+
+An org is **active** when:
+  * SaaS mode is off (self-hosted is never gated), OR
+  * its tier is ``enterprise`` (always-active), OR
+  * its ``subscription_status`` is ``trialing`` or ``active``.
+
+``is_saas_mode`` reads the env var dynamically (not cached at import) so tests
+can toggle ``SAAS_MODE`` per case.
+"""
+
+import os
+
+# Statuses that grant access. ``trialing`` counts as active so a Checkout with
+# a trial lands the user in the app immediately.
+ACTIVE_STATUSES = frozenset({"trialing", "active"})
+
+
+def is_saas_mode() -> bool:
+    return os.getenv("SAAS_MODE", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def is_org_active(tier: str | None, subscription_status: str | None) -> bool:
+    """Whether an org has access (see module docstring)."""
+    if not is_saas_mode():
+        return True
+    if tier == "enterprise":
+        return True
+    return subscription_status in ACTIVE_STATUSES

--- a/api/tests/test_billing.py
+++ b/api/tests/test_billing.py
@@ -1,0 +1,155 @@
+"""Webhook handler tests — subscription_status transitions + confirmation email."""
+
+import os
+import uuid
+
+import psycopg2
+import pytest
+from alembic.config import Config
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from alembic import command
+from marrow.models import Organization
+from marrow.routers import billing
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
+
+
+def _base_dsn() -> str:
+    return DATABASE_URL.rsplit("/", 1)[0]
+
+
+def _alembic_cfg(url: str) -> Config:
+    os.environ["DATABASE_URL"] = url
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", url)
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def db_url():
+    db_name = f"marrow_billing_{uuid.uuid4().hex[:8]}"
+    admin = psycopg2.connect(f"{_base_dsn()}/postgres")
+    admin.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with admin.cursor() as cur:
+        cur.execute(f'CREATE DATABASE "{db_name}"')
+    admin.close()
+
+    url = f"{_base_dsn()}/{db_name}"
+    command.upgrade(_alembic_cfg(url), "head")
+    yield url
+
+    admin = psycopg2.connect(f"{_base_dsn()}/postgres")
+    admin.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with admin.cursor() as cur:
+        cur.execute(f'DROP DATABASE "{db_name}" WITH (FORCE)')
+    admin.close()
+
+
+@pytest.fixture(scope="module")
+def engine(db_url):
+    eng = create_engine(db_url)
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture()
+def db(engine):
+    conn = engine.connect()
+    tx = conn.begin()
+    session = Session(bind=conn)
+    yield session
+    session.close()
+    tx.rollback()
+    conn.close()
+
+
+def _seed_org(db: Session, *, customer="cus_test", **overrides) -> Organization:
+    org = Organization(
+        slug=f"org-{uuid.uuid4().hex[:6]}",
+        name="Acme",
+        stripe_customer_id=customer,
+        **overrides,
+    )
+    db.add(org)
+    db.flush()
+    return org
+
+
+@pytest.fixture
+def stub_email(monkeypatch):
+    sent: list[dict] = []
+
+    def _fake(to, subject, html):
+        sent.append({"to": to, "subject": subject, "html": html})
+        return True
+
+    monkeypatch.setattr(billing, "send_email", _fake)
+    return sent
+
+
+def _sub_obj(status: str, price_id: str = "price_business_monthly"):
+    return {
+        "status": status,
+        "items": {"data": [{"price": {"id": price_id, "recurring": {"interval": "month"}}}]},
+    }
+
+
+@pytest.fixture
+def known_price(monkeypatch):
+    monkeypatch.setattr(
+        billing, "_PRICE_TO_TIER", {"price_business_monthly": ("business", "cloud")}
+    )
+
+
+def test_checkout_completed_sets_trialing_and_emails(db, monkeypatch, stub_email, known_price):
+    org = _seed_org(db, customer="cus_co")
+    monkeypatch.setattr(billing.stripe.Subscription, "retrieve", lambda sid: _sub_obj("trialing"))
+
+    session = {
+        "customer": "cus_co",
+        "subscription": "sub_co",
+        "metadata": {"org_id": str(org.id)},
+        "customer_details": {"email": "buyer@example.com"},
+    }
+    billing._handle_checkout_completed(session, db)
+    db.refresh(org)
+
+    assert org.subscription_status == "trialing"
+    assert org.tier == "business"
+    assert org.stripe_subscription_id == "sub_co"
+    assert len(stub_email) == 1
+    assert stub_email[0]["to"] == "buyer@example.com"
+
+
+def test_subscription_updated_maps_status(db, known_price):
+    org = _seed_org(db, customer="cus_up", subscription_status="trialing")
+    billing._handle_subscription_updated(
+        {"id": "sub_up", "customer": "cus_up", **_sub_obj("active")}, db
+    )
+    db.refresh(org)
+    assert org.subscription_status == "active"
+    assert org.tier == "business"
+
+
+def test_subscription_deleted_marks_canceled(db):
+    org = _seed_org(db, customer="cus_del", subscription_status="active", tier="business")
+    billing._handle_subscription_deleted({"id": "sub_del", "customer": "cus_del"}, db)
+    db.refresh(org)
+    assert org.subscription_status == "canceled"
+    assert org.stripe_subscription_id is None
+
+
+def test_payment_failed_marks_past_due(db):
+    org = _seed_org(db, customer="cus_pf", subscription_status="active")
+    billing._handle_payment_failed({"customer": "cus_pf"}, db)
+    db.refresh(org)
+    assert org.subscription_status == "past_due"
+
+
+def test_handlers_noop_for_unknown_customer(db):
+    # No org with this customer — must not raise.
+    billing._handle_payment_failed({"customer": "cus_missing"}, db)
+    billing._handle_subscription_deleted({"customer": "cus_missing"}, db)

--- a/api/tests/test_recent.py
+++ b/api/tests/test_recent.py
@@ -1,0 +1,175 @@
+"""Tests for GET /api/users/me/recent — cross-workspace recent pages."""
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import psycopg2
+import pytest
+from alembic.config import Config
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from alembic import command
+from marrow.dependencies import AuthContext
+from marrow.models import (
+    Node,
+    Organization,
+    OrgMembership,
+    OrgRole,
+    Revision,
+    Space,
+    User,
+    Workspace,
+)
+from marrow.routers.users import list_recent
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
+
+
+def _base_dsn() -> str:
+    return DATABASE_URL.rsplit("/", 1)[0]
+
+
+def _alembic_cfg(url: str) -> Config:
+    os.environ["DATABASE_URL"] = url
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", url)
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def db_url():
+    db_name = f"marrow_recent_{uuid.uuid4().hex[:8]}"
+    admin = psycopg2.connect(f"{_base_dsn()}/postgres")
+    admin.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with admin.cursor() as cur:
+        cur.execute(f'CREATE DATABASE "{db_name}"')
+    admin.close()
+
+    url = f"{_base_dsn()}/{db_name}"
+    command.upgrade(_alembic_cfg(url), "head")
+    yield url
+
+    admin = psycopg2.connect(f"{_base_dsn()}/postgres")
+    admin.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with admin.cursor() as cur:
+        cur.execute(f'DROP DATABASE "{db_name}" WITH (FORCE)')
+    admin.close()
+
+
+@pytest.fixture(scope="module")
+def engine(db_url):
+    eng = create_engine(db_url)
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture()
+def db(engine):
+    conn = engine.connect()
+    tx = conn.begin()
+    session = Session(bind=conn)
+    yield session
+    session.close()
+    tx.rollback()
+    conn.close()
+
+
+def _make_user(db: Session) -> User:
+    user = User(
+        oidc_issuer="https://idp.test",
+        oidc_subject=uuid.uuid4().hex,
+        email=f"u-{uuid.uuid4().hex[:6]}@example.com",
+        name="Test User",
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _make_workspace(db: Session, *, member: User | None) -> tuple[Workspace, Space]:
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Org")
+    db.add(org)
+    db.flush()
+    if member is not None:
+        db.add(
+            OrgMembership(
+                org_id=org.id, user_id=member.id, email=member.email, role=OrgRole.OWNER.value
+            )
+        )
+    ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name=f"WS {org.slug}")
+    db.add(ws)
+    db.flush()
+    space = Space(workspace_id=ws.id, slug="main", name="Main")
+    db.add(space)
+    db.flush()
+    return ws, space
+
+
+def _create_page(db, space, slug, name, *, updated_at=None) -> Node:
+    node = Node(space_id=space.id, type="page", name=name, slug=slug, position="a0")
+    db.add(node)
+    db.flush()
+    rev = Revision(node_id=node.id, content=f"# {name}")
+    if updated_at is not None:
+        rev.created_at = updated_at
+    db.add(rev)
+    db.flush()
+    node.current_revision_id = rev.id
+    db.flush()
+    return node
+
+
+def test_recent_spans_workspaces_and_orders_by_recency(db):
+    user = _make_user(db)
+    now = datetime.now(timezone.utc)
+
+    ws_a, space_a = _make_workspace(db, member=user)
+    ws_b, space_b = _make_workspace(db, member=user)
+
+    _create_page(db, space_a, "old", "Old A", updated_at=now - timedelta(days=2))
+    _create_page(db, space_b, "new", "New B", updated_at=now)
+    _create_page(db, space_a, "mid", "Mid A", updated_at=now - timedelta(hours=1))
+
+    auth = AuthContext(user_id=user.id, email=user.email, method="session")
+    items = list_recent(limit=12, db=db, auth=auth)
+
+    assert [i.name for i in items] == ["New B", "Mid A", "Old A"]
+    # Cross-workspace: items carry their own workspace identity.
+    ws_names = {i.workspace_name for i in items}
+    assert ws_names == {ws_a.name, ws_b.name}
+    new_b = next(i for i in items if i.name == "New B")
+    assert new_b.workspace_id == ws_b.id
+
+
+def test_recent_excludes_inaccessible_and_trashed(db):
+    user = _make_user(db)
+    now = datetime.now(timezone.utc)
+
+    _ws_a, space_a = _make_workspace(db, member=user)
+    _ws_other, space_other = _make_workspace(db, member=None)  # user is NOT a member
+
+    _create_page(db, space_a, "mine", "Mine", updated_at=now)
+    trashed = _create_page(db, space_a, "trash", "Trashed", updated_at=now)
+    trashed.deleted_at = now
+    db.flush()
+    _create_page(db, space_other, "theirs", "Theirs", updated_at=now)
+
+    auth = AuthContext(user_id=user.id, email=user.email, method="session")
+    names = [i.name for i in list_recent(limit=12, db=db, auth=auth)]
+
+    assert names == ["Mine"]
+    assert "Theirs" not in names  # not a member
+    assert "Trashed" not in names  # soft-deleted
+
+
+def test_recent_limit_clamped(db):
+    user = _make_user(db)
+    _ws, space = _make_workspace(db, member=user)
+    for i in range(5):
+        _create_page(db, space, f"p{i}", f"Page {i}")
+
+    auth = AuthContext(user_id=user.id, email=user.email, method="session")
+    assert len(list_recent(limit=2, db=db, auth=auth)) == 2

--- a/api/tests/test_subscriptions.py
+++ b/api/tests/test_subscriptions.py
@@ -1,0 +1,101 @@
+"""Unit tests for subscription gating logic and status mapping (no DB)."""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from marrow.routers.billing import _map_stripe_status
+from marrow.schemas import OrganizationRead
+from marrow.subscriptions import is_org_active, is_saas_mode
+
+
+@pytest.fixture
+def saas_on(monkeypatch):
+    monkeypatch.setenv("SAAS_MODE", "true")
+
+
+@pytest.fixture
+def saas_off(monkeypatch):
+    monkeypatch.delenv("SAAS_MODE", raising=False)
+
+
+def test_is_saas_mode_reads_env_dynamically(monkeypatch):
+    monkeypatch.setenv("SAAS_MODE", "true")
+    assert is_saas_mode() is True
+    monkeypatch.setenv("SAAS_MODE", "false")
+    assert is_saas_mode() is False
+    monkeypatch.delenv("SAAS_MODE", raising=False)
+    assert is_saas_mode() is False
+
+
+def test_self_hosted_is_always_active(saas_off):
+    assert is_org_active("starter", "none") is True
+    assert is_org_active("starter", "canceled") is True
+
+
+def test_enterprise_is_always_active(saas_on):
+    assert is_org_active("enterprise", "none") is True
+    assert is_org_active("enterprise", "canceled") is True
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        ("none", False),
+        ("trialing", True),
+        ("active", True),
+        ("past_due", False),
+        ("canceled", False),
+    ],
+)
+def test_saas_active_by_status(saas_on, status, expected):
+    assert is_org_active("starter", status) is expected
+
+
+@pytest.mark.parametrize(
+    "stripe_status,expected",
+    [
+        ("trialing", "trialing"),
+        ("active", "active"),
+        ("past_due", "past_due"),
+        ("unpaid", "past_due"),
+        ("incomplete", "past_due"),
+        ("paused", "past_due"),
+        ("canceled", "canceled"),
+        ("incomplete_expired", "canceled"),
+        (None, "none"),
+        ("something_new", "none"),
+    ],
+)
+def test_map_stripe_status(stripe_status, expected):
+    assert _map_stripe_status(stripe_status) == expected
+
+
+def _org_kwargs(**overrides):
+    base = dict(
+        id=uuid.uuid4(),
+        slug="acme",
+        name="Acme",
+        created_at=datetime.now(timezone.utc),
+        tier="starter",
+        subscription_status="none",
+    )
+    base.update(overrides)
+    return base
+
+
+def test_organization_read_has_active_subscription(saas_on):
+    none_org = OrganizationRead(**_org_kwargs(subscription_status="none"))
+    assert none_org.has_active_subscription is False
+
+    trial_org = OrganizationRead(**_org_kwargs(subscription_status="trialing"))
+    assert trial_org.has_active_subscription is True
+
+    ent_org = OrganizationRead(**_org_kwargs(tier="enterprise", subscription_status="none"))
+    assert ent_org.has_active_subscription is True
+
+
+def test_organization_read_active_when_saas_off(saas_off):
+    org = OrganizationRead(**_org_kwargs(subscription_status="none"))
+    assert org.has_active_subscription is True

--- a/web/app/auth/callback/page.tsx
+++ b/web/app/auth/callback/page.tsx
@@ -2,25 +2,24 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { getAuthStatus, listWorkspaces } from "@/lib/api";
+import { getAuthStatus } from "@/lib/api";
 
 export default function AuthCallbackPage() {
   const router = useRouter();
 
   useEffect(() => {
     getAuthStatus()
-      .then(async (status) => {
-        if (status.authenticated) {
-          try {
-            const workspaces = await listWorkspaces();
-            if (workspaces.length === 1) {
-              router.replace(`/w/${workspaces[0].id}`);
-              return;
-            }
-          } catch {}
-          router.replace("/workspaces");
-        } else {
+      .then((status) => {
+        if (!status.authenticated) {
           router.replace("/login");
+          return;
+        }
+        // Subscription gate: an owner of an unsubscribed org (SaaS only) is sent
+        // to checkout. Otherwise land on the global Home. Never the picker.
+        if (status.has_payable_unsubscribed_org) {
+          router.replace("/subscribe");
+        } else {
+          router.replace("/home");
         }
       })
       .catch(() => {

--- a/web/app/home/layout.tsx
+++ b/web/app/home/layout.tsx
@@ -1,0 +1,43 @@
+import { redirect } from "next/navigation";
+import { GlobalChrome } from "@/components/global-chrome";
+import {
+  getAuthStatus,
+  listNotifications,
+  listOrgs,
+  listWorkspaces,
+} from "@/lib/api";
+
+/**
+ * Global Home shell. Uses its own lightweight chrome (NOT WorkspaceShell, which
+ * is workspace-bound). Re-asserts the subscription gate as defense in depth:
+ * the post-login callback already routes unsubscribed owners to /subscribe, but
+ * a direct hit on /home must enforce the same rule.
+ */
+export default async function HomeLayout({ children }: { children: React.ReactNode }) {
+  const auth = await getAuthStatus().catch(() => null);
+
+  if (!auth?.authenticated) {
+    redirect("/login");
+  }
+  if (auth.has_payable_unsubscribed_org) {
+    redirect("/subscribe");
+  }
+
+  const [workspaces, orgs, notifications] = await Promise.all([
+    listWorkspaces().catch(() => []),
+    listOrgs().catch(() => []),
+    listNotifications().catch(() => ({ notifications: [], unread_count: 0 })),
+  ]);
+
+  return (
+    <div className="min-h-screen">
+      <GlobalChrome
+        user={auth.user}
+        workspaces={workspaces}
+        orgs={orgs}
+        unreadCount={notifications.unread_count}
+      />
+      <main>{children}</main>
+    </div>
+  );
+}

--- a/web/app/home/page.tsx
+++ b/web/app/home/page.tsx
@@ -1,0 +1,67 @@
+import { Sparkles } from "lucide-react";
+import {
+  getAuthStatus,
+  getMyRecent,
+  listNotifications,
+  listOrgs,
+  listStarred,
+  listWorkspaces,
+} from "@/lib/api";
+import {
+  InboxWidget,
+  RecentWidget,
+  StarredWidget,
+  SwitcherWidget,
+} from "@/components/home/widgets";
+
+function firstName(name?: string | null): string | null {
+  if (!name) return null;
+  const n = name.trim().split(/\s+/)[0];
+  return n || null;
+}
+
+// Global Home / For You — the post-login default, aggregating across every
+// workspace and org the user can access. The subscription gate is enforced in
+// app/home/layout.tsx.
+export default async function GlobalHomePage() {
+  const [auth, recent, starred, notifications, workspaces, orgs] = await Promise.all([
+    getAuthStatus().catch(() => null),
+    getMyRecent(12).catch(() => []),
+    listStarred().catch(() => []),
+    listNotifications().catch(() => ({ notifications: [], unread_count: 0 })),
+    listWorkspaces().catch(() => []),
+    listOrgs().catch(() => []),
+  ]);
+
+  const name = firstName(auth?.user?.name);
+  const greeting = name ? `Welcome back, ${name}` : "Welcome back";
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-6 py-10">
+      <header className="mb-8">
+        <p className="flex items-center gap-2 text-sm font-medium text-primary">
+          <Sparkles className="h-4 w-4" />
+          For you
+        </p>
+        <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight">{greeting}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Everything across your workspaces, in one place.
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="space-y-6 lg:col-span-2">
+          <RecentWidget items={recent} />
+          <InboxWidget
+            notifications={notifications.notifications}
+            unreadCount={notifications.unread_count}
+          />
+        </div>
+        <div className="space-y-6">
+          <SwitcherWidget workspaces={workspaces} orgs={orgs} />
+          <StarredWidget items={starred} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,17 +1,8 @@
 import { redirect } from "next/navigation";
-import { listWorkspaces } from "@/lib/api";
 
-// Route signed-in users directly to their workspace (skip workspace picker).
-// Falls back to /workspaces when there are zero or multiple workspaces.
-export default async function Home() {
-  try {
-    const workspaces = await listWorkspaces();
-    if (workspaces.length === 1) {
-      redirect(`/w/${workspaces[0].id}`);
-    }
-  } catch {
-    // Unauthenticated or API unavailable — fall through to /workspaces, which
-    // self-gates: a 401 there triggers the OIDC login redirect in lib/api.ts.
-  }
-  redirect("/workspaces");
+// Root redirects to the global Home / For You. The /home layout enforces the
+// auth + subscription gate, so unauthenticated users are sent to /login and
+// unsubscribed owners (SaaS) to /subscribe from there.
+export default function Home() {
+  redirect("/home");
 }

--- a/web/app/subscribe/page.tsx
+++ b/web/app/subscribe/page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { createCheckoutSession, listOrgs } from "@/lib/api";
+import type { Organization } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type Interval = "monthly" | "yearly";
+
+// Display copy for the three self-serve Cloud tiers. Seat caps mirror
+// `api/marrow/routers/billing.py` TIER_SEAT_LIMITS. Prices are display-only —
+// Stripe Checkout is the source of truth and confirms the final amount.
+const TIERS: {
+  id: string;
+  name: string;
+  seats: string;
+  price: Record<Interval, number>;
+  features: string[];
+  highlighted?: boolean;
+}[] = [
+  {
+    id: "starter",
+    name: "Starter",
+    seats: "Up to 10 members",
+    price: { monthly: 12, yearly: 10 },
+    features: ["All core wiki features", "Export / restore guarantee", "Full-text search"],
+  },
+  {
+    id: "business",
+    name: "Business",
+    seats: "Up to 50 members",
+    price: { monthly: 49, yearly: 41 },
+    features: ["Everything in Starter", "Priority email support", "Managed backups"],
+    highlighted: true,
+  },
+  {
+    id: "growth",
+    name: "Growth",
+    seats: "Up to 250 members",
+    price: { monthly: 199, yearly: 166 },
+    features: ["Everything in Business", "Higher rate limits", "Onboarding assistance"],
+  },
+];
+
+function SubscribeInner() {
+  const params = useSearchParams();
+  const canceled = params.get("canceled") === "1";
+  const orgParam = params.get("org");
+
+  const [orgId, setOrgId] = useState<string | null>(orgParam);
+  const [orgName, setOrgName] = useState<string | null>(null);
+  const [interval, setInterval] = useState<Interval>("monthly");
+  const [pendingTier, setPendingTier] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [resolving, setResolving] = useState(!orgParam);
+
+  // Resolve the org to subscribe when none is passed: first org the user can
+  // pay for (no active subscription).
+  useEffect(() => {
+    let cancelled = false;
+    if (orgParam) {
+      listOrgs()
+        .then((orgs) => {
+          const match = orgs.find((o) => o.id === orgParam);
+          if (!cancelled && match) setOrgName(match.name);
+        })
+        .catch(() => {});
+      return () => {
+        cancelled = true;
+      };
+    }
+    listOrgs()
+      .then((orgs: Organization[]) => {
+        if (cancelled) return;
+        const payable = orgs.find((o) => !o.has_active_subscription) ?? orgs[0] ?? null;
+        if (payable) {
+          setOrgId(payable.id);
+          setOrgName(payable.name);
+        }
+        setResolving(false);
+      })
+      .catch(() => {
+        if (!cancelled) setResolving(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [orgParam]);
+
+  async function selectPlan(tier: string) {
+    if (!orgId) {
+      setError("No organization found to subscribe. Please reload and try again.");
+      return;
+    }
+    setError(null);
+    setPendingTier(tier);
+    try {
+      const { url } = await createCheckoutSession(orgId, tier, interval);
+      window.location.assign(url);
+    } catch (e: unknown) {
+      setPendingTier(null);
+      const msg = e instanceof Error ? e.message : "Failed to start checkout";
+      setError(
+        msg.includes("403")
+          ? "Only an organization owner can choose a plan."
+          : msg
+      );
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-16">
+      <div className="space-y-3 text-center">
+        <h1 className="text-3xl font-bold tracking-tight">Choose your plan</h1>
+        <p className="text-muted-foreground">
+          {orgName ? (
+            <>
+              Subscribe <span className="font-medium text-foreground">{orgName}</span> to get
+              started. Every plan includes a 14-day free trial.
+            </>
+          ) : (
+            "Every plan includes a 14-day free trial."
+          )}
+        </p>
+      </div>
+
+      {canceled && (
+        <p className="mt-6 rounded-lg border border-border bg-muted/40 px-4 py-3 text-center text-sm text-muted-foreground">
+          Checkout was canceled. Pick a plan whenever you&apos;re ready.
+        </p>
+      )}
+      {error && (
+        <p className="mt-6 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-center text-sm text-destructive">
+          {error}
+        </p>
+      )}
+
+      <div className="mt-8 flex items-center justify-center gap-2 text-sm">
+        <button
+          type="button"
+          onClick={() => setInterval("monthly")}
+          className={cn(
+            "rounded-full px-4 py-1.5 transition-colors",
+            interval === "monthly"
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          Monthly
+        </button>
+        <button
+          type="button"
+          onClick={() => setInterval("yearly")}
+          className={cn(
+            "rounded-full px-4 py-1.5 transition-colors",
+            interval === "yearly"
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          Yearly <span className="text-xs opacity-80">(save ~17%)</span>
+        </button>
+      </div>
+
+      <div className="mt-10 grid gap-6 md:grid-cols-3">
+        {TIERS.map((tier) => (
+          <div
+            key={tier.id}
+            className={cn(
+              "flex flex-col rounded-2xl border p-6",
+              tier.highlighted
+                ? "border-primary shadow-sm ring-1 ring-primary/20"
+                : "border-border"
+            )}
+          >
+            <h2 className="text-lg font-semibold">{tier.name}</h2>
+            <p className="mt-1 text-sm text-muted-foreground">{tier.seats}</p>
+            <div className="mt-4 flex items-baseline gap-1">
+              <span className="text-3xl font-bold">${tier.price[interval]}</span>
+              <span className="text-sm text-muted-foreground">
+                /mo{interval === "yearly" ? ", billed yearly" : ""}
+              </span>
+            </div>
+            <ul className="mt-5 flex-1 space-y-2 text-sm">
+              {tier.features.map((f) => (
+                <li key={f} className="flex gap-2">
+                  <span aria-hidden className="text-primary">
+                    ✓
+                  </span>
+                  <span>{f}</span>
+                </li>
+              ))}
+            </ul>
+            <Button
+              size="lg"
+              variant={tier.highlighted ? "default" : "outline"}
+              className="mt-6 w-full"
+              disabled={resolving || pendingTier !== null}
+              onClick={() => selectPlan(tier.id)}
+            >
+              {pendingTier === tier.id ? "Redirecting…" : "Start free trial"}
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-8 text-center text-sm text-muted-foreground">
+        Need more than 250 members or custom terms?{" "}
+        <a
+          href="mailto:hello@marrow.so?subject=Marrow%20Enterprise"
+          className="font-medium text-foreground underline underline-offset-4"
+        >
+          Contact sales
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default function SubscribePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <p className="text-muted-foreground text-sm">Loading plans…</p>
+        </div>
+      }
+    >
+      <SubscribeInner />
+    </Suspense>
+  );
+}

--- a/web/app/subscribe/success/page.tsx
+++ b/web/app/subscribe/success/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { getOrg, listOrgs } from "@/lib/api";
+
+// Stripe redirects back here before the webhook is guaranteed to have landed.
+// Poll the org's subscription state, then forward into the app once active.
+const MAX_ATTEMPTS = 15;
+const POLL_MS = 1500;
+
+function SuccessInner() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const orgId = params.get("org");
+  const [slow, setSlow] = useState(false);
+
+  useEffect(() => {
+    let attempts = 0;
+    let timer: ReturnType<typeof setTimeout>;
+    let cancelled = false;
+
+    async function isActive(): Promise<boolean> {
+      try {
+        if (orgId) {
+          const org = await getOrg(orgId);
+          return org.has_active_subscription;
+        }
+        const orgs = await listOrgs();
+        return orgs.some((o) => o.has_active_subscription);
+      } catch {
+        return false;
+      }
+    }
+
+    async function poll() {
+      if (cancelled) return;
+      if (await isActive()) {
+        router.replace("/home");
+        return;
+      }
+      attempts += 1;
+      if (attempts >= MAX_ATTEMPTS) {
+        // Webhook is taking longer than expected — let the user proceed; the
+        // workspace/home gate re-checks server-side.
+        router.replace("/home");
+        return;
+      }
+      if (attempts >= 3) setSlow(true);
+      timer = setTimeout(poll, POLL_MS);
+    }
+
+    poll();
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [orgId, router]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="space-y-3 text-center">
+        <h1 className="text-xl font-semibold">Setting up your subscription…</h1>
+        <p className="text-muted-foreground text-sm">
+          {slow
+            ? "Almost there — confirming your payment with Stripe."
+            : "One moment while we finish things up."}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function SubscribeSuccessPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <p className="text-muted-foreground text-sm">Loading…</p>
+        </div>
+      }
+    >
+      <SuccessInner />
+    </Suspense>
+  );
+}

--- a/web/app/w/[workspaceId]/layout.tsx
+++ b/web/app/w/[workspaceId]/layout.tsx
@@ -31,6 +31,34 @@ export default async function WorkspaceLayout({ children, params }: Props) {
   const userMembership = members?.find((m) => m.user_id === auth?.user?.id) ?? null;
   const userRole = userMembership?.role ?? null;
 
+  // Workspace-entry subscription gate: gate on *this* workspace's org. An owner
+  // of an unsubscribed org is sent to checkout; a non-owner sees a notice.
+  // has_active_subscription already accounts for SAAS_MODE off + enterprise.
+  const thisOrg = orgs?.find((o) => o.id === tree.org_id) ?? null;
+  if (thisOrg && !thisOrg.has_active_subscription) {
+    if (userRole === "owner") {
+      redirect(`/subscribe?org=${tree.org_id}`);
+    }
+    return (
+      <div className="flex min-h-screen items-center justify-center px-6">
+        <div className="max-w-md space-y-3 text-center">
+          <h1 className="text-xl font-semibold">Subscription required</h1>
+          <p className="text-muted-foreground text-sm">
+            This workspace&apos;s organization{thisOrg.name ? ` (${thisOrg.name})` : ""} doesn&apos;t
+            have an active subscription. An organization owner needs to choose a plan before you can
+            open it.
+          </p>
+          <a
+            href="/home"
+            className="inline-flex h-9 items-center justify-center rounded-lg border border-border px-4 text-sm font-medium hover:bg-muted"
+          >
+            Back to Home
+          </a>
+        </div>
+      </div>
+    );
+  }
+
   // Hide org settings for solo users (exactly 1 org, that org has exactly 1 workspace).
   // Show as soon as user has 2+ orgs OR any org has 2+ workspaces.
   const showOrgSettings = (() => {

--- a/web/app/workspaces/page.tsx
+++ b/web/app/workspaces/page.tsx
@@ -49,6 +49,9 @@ export default function WorkspacesPage() {
           </div>
           {auth?.authenticated && (
             <div className="flex items-center gap-3 text-sm text-muted-foreground">
+              <Link href="/home" className="hover:text-foreground transition-colors">
+                Home
+              </Link>
               <span>{auth.user?.name}</span>
               <Button
                 variant="ghost"

--- a/web/components/global-chrome.tsx
+++ b/web/components/global-chrome.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronDown, Home, Inbox, LayoutGrid, LogOut } from "lucide-react";
+import { logout } from "@/lib/api";
+import type { Organization, User, Workspace } from "@/lib/types";
+
+interface Props {
+  user: User | null;
+  workspaces: Workspace[];
+  orgs: Organization[];
+  unreadCount: number;
+}
+
+/**
+ * Lightweight global top bar for the account-level Home — intentionally NOT the
+ * workspace-bound WorkspaceShell. Provides Home, Inbox, a workspace switcher,
+ * and a user menu. Built as a client component for the dropdowns + sign-out.
+ */
+export function GlobalChrome({ user, workspaces, orgs, unreadCount }: Props) {
+  const orgName = (id: string) => orgs.find((o) => o.id === id)?.name ?? "Workspace";
+
+  async function handleSignOut() {
+    const url = await logout().catch(() => null);
+    window.location.assign(url ?? "/login");
+  }
+
+  return (
+    <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-border bg-background/80 px-4 backdrop-blur">
+      <div className="flex items-center gap-1">
+        <Link
+          href="/home"
+          className="mr-2 font-heading text-lg font-semibold tracking-tight lowercase"
+        >
+          marrow
+        </Link>
+        <Link
+          href="/home"
+          className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm font-medium text-foreground hover:bg-muted"
+        >
+          <Home className="h-4 w-4" />
+          Home
+        </Link>
+        <a
+          href="#inbox"
+          className="relative inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <Inbox className="h-4 w-4" />
+          Inbox
+          {unreadCount > 0 && (
+            <span className="ml-0.5 rounded-full bg-primary px-1.5 text-[11px] font-medium text-primary-foreground">
+              {unreadCount}
+            </span>
+          )}
+        </a>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {/* Workspace switcher */}
+        <details className="group relative">
+          <summary className="flex cursor-pointer list-none items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-muted hover:text-foreground">
+            <LayoutGrid className="h-4 w-4" />
+            Switch workspace
+            <ChevronDown className="h-3.5 w-3.5" />
+          </summary>
+          <div className="absolute right-0 z-40 mt-1 w-64 overflow-hidden rounded-lg border border-border bg-popover p-1 shadow-md">
+            {workspaces.length === 0 ? (
+              <p className="px-3 py-2 text-sm text-muted-foreground">No workspaces yet.</p>
+            ) : (
+              <ul className="max-h-72 overflow-y-auto">
+                {workspaces.map((ws) => (
+                  <li key={ws.id}>
+                    <Link
+                      href={`/w/${ws.id}`}
+                      className="flex flex-col rounded-md px-3 py-2 hover:bg-muted"
+                    >
+                      <span className="truncate text-sm font-medium">{ws.name}</span>
+                      <span className="truncate text-xs text-muted-foreground">
+                        {orgName(ws.org_id)}
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="mt-1 border-t border-border pt-1">
+              <Link
+                href="/workspaces"
+                className="block rounded-md px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                See all workspaces
+              </Link>
+            </div>
+          </div>
+        </details>
+
+        {/* User menu */}
+        <details className="group relative">
+          <summary className="flex cursor-pointer list-none items-center gap-1.5 rounded-md px-2 py-1.5 hover:bg-muted">
+            <span className="flex h-7 w-7 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
+              {(user?.name || user?.email || "?").charAt(0).toUpperCase()}
+            </span>
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+          </summary>
+          <div className="absolute right-0 z-40 mt-1 w-56 overflow-hidden rounded-lg border border-border bg-popover p-1 shadow-md">
+            {user && (
+              <div className="border-b border-border px-3 py-2">
+                <p className="truncate text-sm font-medium">{user.name}</p>
+                <p className="truncate text-xs text-muted-foreground">{user.email}</p>
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={handleSignOut}
+              className="mt-1 flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-foreground hover:bg-muted"
+            >
+              <LogOut className="h-4 w-4" />
+              Sign out
+            </button>
+          </div>
+        </details>
+      </div>
+    </header>
+  );
+}

--- a/web/components/home/widgets.tsx
+++ b/web/components/home/widgets.tsx
@@ -1,0 +1,211 @@
+import Link from "next/link";
+import {
+  AtSign,
+  Clock,
+  Eye,
+  FileText,
+  Inbox,
+  LayoutGrid,
+  MessageSquareReply,
+  Share2,
+  Star,
+} from "lucide-react";
+import type {
+  MyRecentItem,
+  Notification,
+  NotificationKind,
+  Organization,
+  StarredNode,
+  Workspace,
+} from "@/lib/types";
+import { relativeTime } from "@/lib/utils";
+
+function WidgetCard({
+  title,
+  icon,
+  children,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-xl border border-border">
+      <h2 className="flex items-center gap-2 border-b border-border px-4 py-3 text-sm font-semibold">
+        {icon}
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function EmptyRow({ children }: { children: React.ReactNode }) {
+  return <p className="px-4 py-6 text-center text-sm text-muted-foreground">{children}</p>;
+}
+
+// --- Recently edited (cross-workspace) ----------------------------------------
+
+export function RecentWidget({ items }: { items: MyRecentItem[] }) {
+  return (
+    <WidgetCard title="Recently edited" icon={<Clock className="h-4 w-4 text-muted-foreground" />}>
+      {items.length === 0 ? (
+        <EmptyRow>Pages you edit across your workspaces show up here.</EmptyRow>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item) => {
+            const crumb = [item.workspace_name, item.space_name, ...item.node_path].join(" / ");
+            return (
+              <li key={item.node_id}>
+                <Link
+                  href={`/w/${item.workspace_id}/n/${item.node_id}`}
+                  className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-accent"
+                >
+                  <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{item.name}</p>
+                    <p className="truncate text-xs text-muted-foreground">{crumb}</p>
+                  </div>
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {relativeTime(item.updated_at)}
+                  </span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </WidgetCard>
+  );
+}
+
+// --- Starred -----------------------------------------------------------------
+
+export function StarredWidget({ items }: { items: StarredNode[] }) {
+  // Starred nodes don't carry workspace context, so v1 lists them without deep
+  // links. Reuses GET /api/users/me/starred as-is.
+  return (
+    <WidgetCard title="Starred" icon={<Star className="h-4 w-4 text-muted-foreground" />}>
+      {items.length === 0 ? (
+        <EmptyRow>Star a page to keep it close.</EmptyRow>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.slice(0, 8).map((item) => (
+            <li key={item.id} className="flex items-center gap-3 px-4 py-3">
+              <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <p className="truncate text-sm font-medium">{item.name}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </WidgetCard>
+  );
+}
+
+// --- Inbox summary -----------------------------------------------------------
+
+const KIND_ICON: Record<NotificationKind, typeof AtSign> = {
+  mention: AtSign,
+  comment_reply: MessageSquareReply,
+  share_request: Share2,
+  watch_event: Eye,
+};
+
+function summarize(n: Notification): string {
+  const name = (n.payload.node_name as string) || "a page";
+  switch (n.kind) {
+    case "mention":
+      return `You were mentioned in ${name}`;
+    case "comment_reply":
+      return `New reply on ${name}`;
+    case "share_request":
+      return `Share request for ${name}`;
+    case "watch_event":
+      return `Activity on ${name}`;
+    default:
+      return name;
+  }
+}
+
+export function InboxWidget({
+  notifications,
+  unreadCount,
+}: {
+  notifications: Notification[];
+  unreadCount: number;
+}) {
+  return (
+    <section id="inbox" className="rounded-xl border border-border scroll-mt-20">
+      <h2 className="flex items-center gap-2 border-b border-border px-4 py-3 text-sm font-semibold">
+        <Inbox className="h-4 w-4 text-muted-foreground" />
+        Inbox
+        {unreadCount > 0 && (
+          <span className="rounded-full bg-primary px-1.5 text-[11px] font-medium text-primary-foreground">
+            {unreadCount}
+          </span>
+        )}
+      </h2>
+      {notifications.length === 0 ? (
+        <EmptyRow>You&apos;re all caught up.</EmptyRow>
+      ) : (
+        <ul className="divide-y divide-border">
+          {notifications.slice(0, 6).map((n) => {
+            const Icon = KIND_ICON[n.kind] ?? Inbox;
+            return (
+              <li key={n.id} className="flex items-center gap-3 px-4 py-3">
+                <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <p className="min-w-0 flex-1 truncate text-sm">{summarize(n)}</p>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {relativeTime(n.created_at)}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+// --- Workspace switcher ------------------------------------------------------
+
+export function SwitcherWidget({
+  workspaces,
+  orgs,
+}: {
+  workspaces: Workspace[];
+  orgs: Organization[];
+}) {
+  const orgName = (id: string) => orgs.find((o) => o.id === id)?.name ?? "Workspace";
+  return (
+    <WidgetCard
+      title="Your workspaces"
+      icon={<LayoutGrid className="h-4 w-4 text-muted-foreground" />}
+    >
+      {workspaces.length === 0 ? (
+        <EmptyRow>
+          No workspaces yet.{" "}
+          <Link href="/workspaces" className="font-medium text-foreground underline">
+            Create one
+          </Link>
+        </EmptyRow>
+      ) : (
+        <ul className="divide-y divide-border">
+          {workspaces.map((ws) => (
+            <li key={ws.id}>
+              <Link
+                href={`/w/${ws.id}`}
+                className="flex flex-col px-4 py-3 transition-colors hover:bg-accent"
+              >
+                <span className="truncate text-sm font-medium">{ws.name}</span>
+                <span className="truncate text-xs text-muted-foreground">
+                  {orgName(ws.org_id)}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </WidgetCard>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -13,6 +13,7 @@ import type {
   Comment,
   EffectiveProperty,
   EffectivePropertiesResponse,
+  MyRecentItem,
   Node,
   NodeType,
   NodeView,
@@ -110,6 +111,11 @@ export function getWorkspaceTree(id: string): Promise<WorkspaceTree> {
 
 export function getWorkspaceHome(id: string): Promise<WorkspaceHome> {
   return apiFetch(`/api/workspaces/${id}/home`);
+}
+
+// Recently-edited pages across every workspace the current user can access.
+export function getMyRecent(limit = 12): Promise<MyRecentItem[]> {
+  return apiFetch(`/api/users/me/recent?limit=${limit}`);
 }
 
 export function getExportSizeEstimate(
@@ -351,6 +357,25 @@ export async function logout(): Promise<string | null> {
     method: "POST",
   });
   return data.logout_url ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Billing
+// ---------------------------------------------------------------------------
+
+export function createCheckoutSession(
+  orgId: string,
+  tier: string,
+  interval: "monthly" | "yearly" = "monthly"
+): Promise<{ url: string }> {
+  return apiFetch(`/api/billing/${orgId}/checkout`, {
+    method: "POST",
+    body: JSON.stringify({ tier, interval }),
+  });
+}
+
+export function createPortalSession(orgId: string): Promise<{ url: string }> {
+  return apiFetch(`/api/billing/${orgId}/portal`, { method: "POST" });
 }
 
 // ---------------------------------------------------------------------------

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -1,11 +1,21 @@
 // TypeScript types mirroring the Marrow API Pydantic schemas.
 
+export type SubscriptionStatus =
+  | "none"
+  | "trialing"
+  | "active"
+  | "past_due"
+  | "canceled";
+
 export interface Organization {
   id: string;
   slug: string;
   name: string;
   created_at: string;
   members_can_create_spaces: boolean;
+  tier: string;
+  subscription_status: SubscriptionStatus;
+  has_active_subscription: boolean;
 }
 
 export interface OrgMembership {
@@ -180,6 +190,18 @@ export interface WorkspaceHome {
   recent: RecentNodeItem[];
 }
 
+// Cross-workspace recent page (global Home / For You)
+export interface MyRecentItem {
+  node_id: string;
+  name: string;
+  space_id: string;
+  space_name: string;
+  workspace_id: string;
+  workspace_name: string;
+  node_path: string[]; // ancestor folder names, root -> leaf
+  updated_at: string;
+}
+
 
 // Node views (table / board / list over a folder of page nodes)
 export type ViewType = "table" | "board" | "list";
@@ -225,6 +247,7 @@ export interface AuthStatus {
   user: User | null;
   method: string;
   oidc_enabled: boolean;
+  has_payable_unsubscribed_org: boolean;
 }
 
 // View-only sharing links (#40)


### PR DESCRIPTION
Closes #208.

Implements the unified post-login flow from `references/prd-subscription-checkout.md`:
**login → subscription gate → global `/home`**.

## Backend (`api/`)
- `organizations.subscription_status` (`none|trialing|active|past_due|canceled`) + migration `a1b2c3d4e5f6` with backfill (enterprise + existing Stripe subs → `active`).
- `subscriptions.py` — single source of truth for the gate (`is_org_active`, `is_saas_mode`).
- `billing.py` — `/checkout` takes a JSON body, adds a 14-day trial, real `/subscribe/success` + `/subscribe` URLs; webhook writes `subscription_status` for completed/updated/deleted/payment_failed and sends a confirmation email.
- `email.py` — best-effort Resend REST helper (never blocks the webhook 200).
- `OrganizationRead` exposes `tier`/`subscription_status`/`has_active_subscription`; `AuthStatus.has_payable_unsubscribed_org` makes the gate one round trip.
- `GET /api/users/me/recent` — cross-workspace recent pages, membership-scoped.

## Frontend (`web/`)
- `/subscribe` + `/subscribe/success` (3 tiers, monthly↔yearly, Enterprise contact-sales, success polls then forwards to `/home`).
- Global `/home` — gated `layout.tsx` + lightweight `global-chrome.tsx` (not WorkspaceShell) + self-contained widgets (recent / starred / inbox / switcher).
- Routing gates: `auth/callback` → only `/subscribe` or `/home`; root → `/home`; workspace-entry gate (owner→checkout, member→notice); picker demoted to switcher.

## Verification
- `cd api && ruff check . && ruff format --check . && pytest` → **222 passed** (incl. `test_round_trip` and 28 new tests).
- `cd web && npm run build` → ✓ compiled; `/home`, `/subscribe`, `/subscribe/success` registered.
- Billing fields are **not exported** (round-trip guarantee intact).

## Manual ops follow-ups (documented in `references/deploy-runbook.md`)
- Resend domain verification + SPF/DKIM/DMARC on the `marrow.so` Cloudflare zone.
- `RESEND_API_KEY` Fly secret; confirm `SAAS_MODE=true` on `marrow-api`.
- Confirm Stripe trial card-up-front config.
- **Blocked by #207** for live E2E — `app.marrow.so` 522 must be resolved first.