### PR TITLE
docs(changelog): cut 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Each release also has fuller narrative notes (highlights, breaking changes, upgrade
 steps) on its [GitHub release](https://github.com/marrow-software/marrow/releases).
 
-## [Unreleased]
+## [0.3.0] — 2026-06-09
 
 ### Added
 - Unified post-login flow: **login → subscription gate → global Home/For You**.


### PR DESCRIPTION
Promotes the CHANGELOG `[Unreleased]` section to **`[0.3.0] — 2026-06-09`** ahead of tagging.

0.3.0 = the login flow / subscription checkout + global Home work (#208, merged in #212).
Minor bump: new backward-compatible feature; the `subscription_status` migration is additive
(server default + backfill).

After this merges, the release is cut by tagging `v0.3.0` on `main` (triggers `release.yml`:
api → Fly.io, web → Cloudflare Workers; migration runs via the Fly release_command).