### PR TITLE
Login flow fixes: Stripe reconcile + org onboarding + repeatable billing tests (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Each release also has fuller narrative notes (highlights, breaking changes, upgrade
 steps) on its [GitHub release](https://github.com/marrow-software/marrow/releases).
 
+## [0.3.1] — 2026-06-11
+
+### Fixed
+- The `/subscribe → /home → /subscribe` redirect loop after a completed Stripe Checkout:
+  `/subscribe/success` now actively **reconciles** the subscription from Stripe
+  (`POST /api/billing/{org}/reconcile`, owner) instead of waiting on the webhook, and renders
+  a terminal Retry/billing-portal/support state on failure — it never forwards to `/home`
+  while the org is unsubscribed.
+- Silent Stripe webhook failures: every early-return in the webhook handlers now logs a
+  warning (missing fields, unknown customer/org, unrecognized price), and the persistence
+  logic is shared between the webhook and reconcile paths (`_apply_subscription`).
+
+### Added
+- First-run **organization onboarding** (`/onboarding`) — new users name their auto-created
+  org before anything else; the post-login gate order is now **onboarding → subscription →
+  home**. Orgs can also be renamed in org settings (`PATCH /api/orgs/{id}` accepts `name`).
+- `organizations.onboarded_at` (backfilled to `created_at` for existing orgs, so nobody is
+  re-onboarded) and `AuthStatus.needs_onboarding`.
+- `marrow reset-org-billing <slug>` CLI — resets billing + onboarding state to fresh-signup
+  values for repeatable auth/payment testing (never touches Stripe).
+
 ## [0.3.0] — 2026-06-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ cd api && alembic downgrade -1
 cd api && marrow export --workspace <slug> --output <path>
 cd api && marrow restore <bundle.zip>
 cd api && marrow purge-trash --older-than-days 30   # hard-delete old trashed nodes (cron'able)
+cd api && marrow reset-org-billing <slug>           # reset billing+onboarding state for repeatable testing (#214)
 
 # Product frontend (web/)
 cd web && npm run dev
@@ -184,7 +185,8 @@ marrow/
 │   │       ├── ac1e5d8ab0f8_add_node_links_backlink_index.py
 │   │       ├── cd990242773c_add_user_stars_table.py
 │   │       ├── 70645242437d_merge_swarm_v0_2_migrations.py
-│   │       └── a1b2c3d4e5f6_add_subscription_status_to_organizations.py  # #208
+│   │       ├── a1b2c3d4e5f6_add_subscription_status_to_organizations.py  # #208
+│   │       └── b8d2e4f6a1c3_add_onboarded_at_to_organizations.py  # #214
 │   ├── marrow/                       # Main package
 │   │   ├── app.py                    # FastAPI app factory, CORS + session middleware
 │   │   ├── auth.py                   # OIDC config, session JWT helpers, cookie params
@@ -200,7 +202,7 @@ marrow/
 │   │   ├── storage.py                # StorageAdapter ABC + LocalFilesystemAdapter
 │   │   ├── export.py                 # Export workspace → zip bundle
 │   │   ├── restore.py                # Restore workspace ← zip bundle
-│   │   ├── cli.py                    # Typer CLI (export, restore commands)
+│   │   ├── cli.py                    # Typer CLI (export, restore, reset-org-billing)
 │   │   └── routers/
 │   │       ├── auth.py               # OIDC login/callback/me/logout + personal org creation
 │   │       ├── organizations.py      # Org CRUD, member management (invite, role, remove)
@@ -328,7 +330,7 @@ organizations → org_memberships (user roles: owner/editor/viewer)
 
 | Table | Key columns |
 | --- | --- |
-| organizations | id, slug (unique), name, members_can_create_spaces (bool, default true) |
+| organizations | id, slug (unique), name, onboarded_at (nullable — NULL means show first-run /onboarding), members_can_create_spaces (bool, default true) |
 | org_memberships | id, org_id (FK), user_id (FK, nullable for pending), email, role (owner/editor/viewer) |
 | workspaces | id, org_id (FK), slug (unique), name |
 | spaces | id, workspace_id (FK cascade), slug (unique per workspace), name |
@@ -368,7 +370,8 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | POST | /api/auth/logout | Clear session cookie | — |
 | GET/POST | /api/orgs | List user's orgs / create org | session |
 | GET | /api/orgs/{oid} | Get org details | viewer |
-| PATCH | /api/orgs/{oid} | Update org settings (members_can_create_spaces) | owner |
+| PATCH | /api/orgs/{oid} | Update org settings (name, members_can_create_spaces) | owner |
+| POST | /api/orgs/{oid}/onboard | First-run onboarding: set org name + stamp onboarded_at | owner |
 | GET | /api/orgs/{oid}/members | List members (incl. pending) | viewer |
 | POST | /api/orgs/{oid}/members | Invite member by email | owner |
 | PATCH | /api/orgs/{oid}/members/{mid} | Change member role | owner |
@@ -397,6 +400,7 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | GET | /api/users/me/recent | Recently edited pages across all the caller's workspaces (#208) | session |
 | POST | /api/billing/{oid}/checkout | Create a Stripe Checkout session (JSON body `{tier, interval}`, 14-day trial) | owner |
 | POST | /api/billing/{oid}/portal | Create a Stripe Customer Portal session | owner |
+| POST | /api/billing/{oid}/reconcile | Pull subscription truth from Stripe and persist it (webhook-independent self-heal) | owner |
 | POST | /api/billing/webhook | Stripe webhook — writes `subscription_status`, sends confirmation email | — |
 | POST | /api/nodes/{nid}/star | Star a node (idempotent) | viewer |
 | DELETE | /api/nodes/{nid}/star | Unstar a node | viewer |
@@ -494,15 +498,19 @@ Marrow supports three authentication methods, checked in priority order:
 
 **Key files**: `auth.py` (config, JWT helpers), `dependencies.py` (`verify_auth` + `AuthContext`), `rbac.py` (role enforcement dependencies), `routers/auth.py` (login/callback/me/logout), `routers/organizations.py` (org CRUD + member management).
 
-### Subscriptions & Billing (#208)
+### Subscriptions & Billing (#208, #214)
 
-Post-login flow: **login → subscription gate → global `/home`**.
+Post-login flow: **login → onboarding gate → subscription gate → global `/home`**.
 
 - **Gate model** — "active subscription" is a property of the **org** (`marrow/subscriptions.py`, the single source of truth). `is_org_active(tier, subscription_status)` is True when `SAAS_MODE` is off (self-hosted is never gated), the tier is `enterprise`, or `subscription_status ∈ {trialing, active}`. `is_saas_mode()` reads `SAAS_MODE` dynamically.
-- **`organizations.subscription_status`** (`none | trialing | active | past_due | canceled`, default `none`) is written **only** by the Stripe webhook. `OrganizationRead` exposes `tier`, `subscription_status`, and the computed `has_active_subscription`. `AuthStatus.has_payable_unsubscribed_org` (computed in `/api/auth/me` over the user's *owned* orgs) lets the post-login gate be one round trip. **Billing fields are never exported** (the restore round-trip is unaffected).
+- **`organizations.subscription_status`** (`none | trialing | active | past_due | canceled`, default `none`) is written by the Stripe webhook **and** the reconcile endpoint — both go through the shared `_apply_subscription(org, subscription)` write path in `routers/billing.py`. `OrganizationRead` exposes `tier`, `subscription_status`, and the computed `has_active_subscription`. `AuthStatus.has_payable_unsubscribed_org` and `AuthStatus.needs_onboarding` (computed in `/api/auth/me` over the user's *owned* orgs) let the post-login gates be one round trip. **Billing and onboarding fields are never exported** (the restore round-trip is unaffected).
+- **Reconcile** (#214): `POST /api/billing/{oid}/reconcile` (owner) pulls the org's latest subscription from Stripe (`Subscription.list(customer=…, status="all", limit=1)`) and persists it — the webhook-independent self-heal that `/subscribe/success` relies on. Every webhook early-return logs a `logger.warning` (missing fields, unknown customer/org, unrecognized price); failures are never silent.
+- **Onboarding** (#214): `organizations.onboarded_at` is NULL only for the auto-created personal org (explicitly created and restored orgs are stamped immediately; existing rows were backfilled to `created_at`). `POST /api/orgs/{oid}/onboard {name}` sets name + `onboarded_at` atomically. `marrow reset-org-billing <slug>` resets billing + onboarding state for repeatable testing (never touches Stripe) — see `references/deploy-runbook.md` for the incognito test process.
 - **Webhook** (`routers/billing.py`): `checkout.session.completed` → status from the Stripe subscription (trial → `trialing`) + confirmation email; `customer.subscription.updated` → mapped status; `…deleted` → `canceled`; `invoice.payment_failed` → `past_due`. `/checkout` takes a **JSON body** (`{tier, interval}`), adds a 14-day trial, and redirects to `/subscribe/success?org=` / `/subscribe?org=&canceled=1`.
 - **Email** (`marrow/email.py`): `send_email(to, subject, html)` via the Resend REST API, sender `hello@marrow.so`. Best-effort — never raises, never blocks the webhook 200; skipped when `RESEND_API_KEY` is unset.
-- **Gate enforcement (frontend)**: `app/auth/callback` routes only to `/subscribe` (owner of an unsubscribed org) or `/home`; `app/home/layout.tsx` re-asserts it (defense in depth); `app/w/[workspaceId]/layout.tsx` gates on *that* workspace's org (owner → `/subscribe?org=`, member → notice).
+- **Gate enforcement (frontend)**: `app/auth/callback` routes in order — `/onboarding` (owner of an un-onboarded org) → `/subscribe` (owner of an unsubscribed org) → `/home`; `app/home/layout.tsx` re-asserts the same order (defense in depth); `app/w/[workspaceId]/layout.tsx` gates on *that* workspace's org (owner → `/subscribe?org=`, member → notice).
+- **Success page (#214)**: `app/subscribe/success` calls `reconcileSubscription(orgId)` with bounded retries; active → `/home`, exhausted retries → a terminal "couldn't confirm payment" state with Retry + billing-portal + support links. It **never** auto-forwards to `/home` while the org is inactive (that's what caused the `/subscribe → /home → /subscribe` loop).
+- **Onboarding page (#214)**: `app/onboarding/page.tsx` pre-fills the org name, submits via `completeOnboarding`, then continues to `/subscribe` or `/home` per the subscription gate. Org settings has a Name field (`updateOrg({name})`).
 
 ### Frontend Patterns
 

--- a/api/alembic/versions/b8d2e4f6a1c3_add_onboarded_at_to_organizations.py
+++ b/api/alembic/versions/b8d2e4f6a1c3_add_onboarded_at_to_organizations.py
@@ -1,0 +1,31 @@
+"""add onboarded_at to organizations
+
+Revision ID: b8d2e4f6a1c3
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b8d2e4f6a1c3'
+down_revision: Union[str, Sequence[str], None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'organizations',
+        sa.Column('onboarded_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    # Backfill: existing orgs are treated as already onboarded so current
+    # users are never sent through the first-run /onboarding step.
+    op.execute("UPDATE organizations SET onboarded_at = created_at")
+
+
+def downgrade() -> None:
+    op.drop_column('organizations', 'onboarded_at')

--- a/api/marrow/cli.py
+++ b/api/marrow/cli.py
@@ -93,5 +93,42 @@ def restore(
         raise typer.Exit(1)
 
 
+@app.command("reset-org-billing")
+def reset_org_billing(
+    slug: str = typer.Argument(..., help="Organization slug to reset"),
+    database_url: str | None = typer.Option(
+        None, "--database-url", envvar="DATABASE_URL", help="PostgreSQL connection URL"
+    ),
+) -> None:
+    """Reset an org's billing + onboarding state for repeatable auth/payment testing.
+
+    Clears subscription_status / tier / billing_interval / Stripe IDs /
+    onboarded_at back to fresh-signup values. Never touches Stripe — delete
+    the Stripe test customer separately before re-testing.
+    """
+    load_dotenv()
+
+    from sqlalchemy import select
+
+    from .db import get_session
+    from .models import Organization
+
+    with get_session(database_url) as session:
+        org = session.execute(
+            select(Organization).where(Organization.slug == slug)
+        ).scalar_one_or_none()
+        if org is None:
+            typer.echo(f"Error: organization '{slug}' not found", err=True)
+            raise typer.Exit(1)
+        org.subscription_status = "none"
+        org.tier = "starter"
+        org.billing_interval = None
+        org.stripe_subscription_id = None
+        org.stripe_customer_id = None
+        org.onboarded_at = None
+        session.commit()
+    typer.echo(f"Reset billing + onboarding state for org '{slug}'")
+
+
 if __name__ == "__main__":
     app()

--- a/api/marrow/models.py
+++ b/api/marrow/models.py
@@ -45,6 +45,9 @@ class Organization(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+    # When the owner completed first-run onboarding (naming the org).
+    # NULL means the /onboarding step should be shown (SaaS only).
+    onboarded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Billing
     tier: Mapped[str] = mapped_column(Text, nullable=False, server_default="starter")

--- a/api/marrow/restore.py
+++ b/api/marrow/restore.py
@@ -14,6 +14,7 @@ import zipfile
 from datetime import datetime
 from pathlib import Path
 
+from sqlalchemy import func as sa_func
 from sqlalchemy.orm import Session
 
 from .links import rebuild_node_links
@@ -98,6 +99,8 @@ def restore_workspace(
                         slug=org_meta["slug"],
                         name=org_meta["name"],
                         created_at=_dt(org_meta["created_at"]),
+                        # Restored orgs are already named — never re-onboard.
+                        onboarded_at=_dt(org_meta["created_at"]),
                     )
                 )
                 session.flush()
@@ -115,6 +118,7 @@ def restore_workspace(
                     id=org_id,
                     slug=slug,
                     name=f"{ws_meta['name']} (imported)",
+                    onboarded_at=sa_func.now(),
                 )
             )
             session.flush()

--- a/api/marrow/routers/auth.py
+++ b/api/marrow/routers/auth.py
@@ -164,12 +164,14 @@ async def me(request: Request) -> AuthStatus:
                 email=claims["email"],
                 name=claims["name"],
             )
+            has_payable, needs_onboarding = _owner_gate_flags(user.id)
             return AuthStatus(
                 authenticated=True,
                 user=user,
                 method="session",
                 oidc_enabled=config.is_enabled,
-                has_payable_unsubscribed_org=_user_has_payable_unsubscribed_org(user.id),
+                has_payable_unsubscribed_org=has_payable,
+                needs_onboarding=needs_onboarding,
             )
         except Exception:
             pass
@@ -182,14 +184,15 @@ async def me(request: Request) -> AuthStatus:
     )
 
 
-def _user_has_payable_unsubscribed_org(user_id: uuid.UUID) -> bool:
-    """Whether the user owns >=1 org that lacks an active subscription.
+def _owner_gate_flags(user_id: uuid.UUID) -> tuple[bool, bool]:
+    """Post-login gate flags over the orgs the user owns.
 
-    Drives the post-login subscription gate. Returns False in self-hosted mode
-    (``is_org_active`` short-circuits to active when SaaS mode is off).
+    Returns ``(has_payable_unsubscribed_org, needs_onboarding)``. Both drive
+    the post-login flow (onboarding → subscription → home) and are always
+    False in self-hosted mode (``SAAS_MODE`` off skips both gates).
     """
     if not is_saas_mode():
-        return False
+        return False, False
     db = next(get_db())
     try:
         owned_orgs = (
@@ -201,7 +204,11 @@ def _user_has_payable_unsubscribed_org(user_id: uuid.UUID) -> bool:
             )
             .all()
         )
-        return any(not is_org_active(org.tier, org.subscription_status) for org in owned_orgs)
+        has_payable = any(
+            not is_org_active(org.tier, org.subscription_status) for org in owned_orgs
+        )
+        needs_onboarding = any(org.onboarded_at is None for org in owned_orgs)
+        return has_payable, needs_onboarding
     finally:
         db.close()
 

--- a/api/marrow/routers/billing.py
+++ b/api/marrow/routers/billing.py
@@ -1,5 +1,6 @@
-"""Stripe billing — checkout, portal, and webhook endpoints."""
+"""Stripe billing — checkout, portal, webhook, and reconcile endpoints."""
 
+import logging
 import os
 from uuid import UUID
 
@@ -14,6 +15,9 @@ from ..dependencies import AuthContext, get_db
 from ..email import send_email, subscription_confirmation_html
 from ..models import Organization, OrgRole
 from ..rbac import require_org_role
+from ..subscriptions import is_org_active
+
+logger = logging.getLogger(__name__)
 
 stripe.api_key = os.getenv("STRIPE_SECRET_KEY", "")
 _webhook_secret = os.getenv("STRIPE_WEBHOOK_SECRET", "")
@@ -167,6 +171,49 @@ def create_portal_session(
     return {"url": session.url}
 
 
+@router.post("/{org_id}/reconcile")
+def reconcile_subscription(
+    org_id: UUID,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_org_role(OrgRole.OWNER)),
+):
+    """Pull the org's subscription truth from Stripe and persist it.
+
+    Webhook-independent self-heal: makes a completed Checkout land even when
+    the `checkout.session.completed` webhook never arrives.
+    """
+    org = db.get(Organization, org_id)
+    if org is None:
+        raise HTTPException(404, "Organization not found")
+
+    def _result(reconciled: bool, reason: str | None = None):
+        return {
+            "reconciled": reconciled,
+            "reason": reason,
+            "tier": org.tier,
+            "subscription_status": org.subscription_status,
+            "has_active_subscription": is_org_active(org.tier, org.subscription_status),
+        }
+
+    if not org.stripe_customer_id:
+        logger.warning("billing: reconcile for org %s skipped — no Stripe customer", org.id)
+        return _result(False, "no_customer")
+
+    subscriptions = stripe.Subscription.list(customer=org.stripe_customer_id, status="all", limit=1)
+    data = subscriptions.get("data") or []
+    if not data:
+        logger.warning(
+            "billing: reconcile for org %s found no subscriptions (customer=%s)",
+            org.id,
+            org.stripe_customer_id,
+        )
+        return _result(False, "no_subscription")
+
+    if not _apply_subscription(org, data[0], db):
+        return _result(False, "unknown_price")
+    return _result(True)
+
+
 @router.post("/webhook", include_in_schema=False)
 async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
     """Handle Stripe webhook events. Signature verified before processing."""
@@ -211,31 +258,70 @@ def _tier_from_subscription(subscription: dict) -> tuple[str, str] | None:
     return tier, billing_interval
 
 
+def _apply_subscription(
+    org: Organization,
+    subscription: dict,
+    db: Session,
+    *,
+    subscription_id: str | None = None,
+    default_status: str | None = None,
+) -> bool:
+    """Persist a Stripe subscription's tier/interval/status onto an org.
+
+    Single write path shared by the webhook handlers and the reconcile
+    endpoint. Returns False (after logging) when the subscription's price
+    isn't one of ours.
+    """
+    result = _tier_from_subscription(subscription)
+    if result is None:
+        logger.warning(
+            "billing: subscription %s for org %s has an unrecognized price; "
+            "check STRIPE_*_PRICE_* configuration",
+            subscription_id or subscription.get("id"),
+            org.id,
+        )
+        return False
+    tier, billing_interval = result
+
+    org.stripe_subscription_id = subscription_id or subscription.get("id")
+    org.tier = tier
+    org.billing_interval = billing_interval
+    # StripeObject supports .get(); default_status covers checkout, where the
+    # subscription was just created with a trial period.
+    org.subscription_status = _map_stripe_status(subscription.get("status") or default_status)
+    db.commit()
+    return True
+
+
 def _handle_checkout_completed(session: dict, db: Session) -> None:
     customer_id = session.get("customer")
     subscription_id = session.get("subscription")
     org_id = session.get("metadata", {}).get("org_id")
     if not (customer_id and subscription_id and org_id):
+        logger.warning(
+            "billing: checkout.session.completed missing fields "
+            "(customer=%s subscription=%s org_id=%s); org not updated",
+            customer_id,
+            subscription_id,
+            org_id,
+        )
         return
 
     org = db.get(Organization, org_id) or _org_by_customer(customer_id, db)
     if org is None:
+        logger.warning(
+            "billing: checkout.session.completed matched no org (org_id=%s customer=%s)",
+            org_id,
+            customer_id,
+        )
         return
 
     subscription = stripe.Subscription.retrieve(subscription_id)
-    result = _tier_from_subscription(subscription)
-    if result is None:
-        return
-    tier, billing_interval = result
-
     org.stripe_customer_id = customer_id
-    org.stripe_subscription_id = subscription_id
-    org.tier = tier
-    org.billing_interval = billing_interval
-    # StripeObject supports .get(); falls back to 'trialing' since checkout
-    # created the subscription with a trial period.
-    org.subscription_status = _map_stripe_status(subscription.get("status") or "trialing")
-    db.commit()
+    if not _apply_subscription(
+        org, subscription, db, subscription_id=subscription_id, default_status="trialing"
+    ):
+        return
 
     # Best-effort confirmation email — never blocks the webhook 200.
     recipient = session.get("customer_details", {}).get("email") or session.get("customer_email")
@@ -243,33 +329,31 @@ def _handle_checkout_completed(session: dict, db: Session) -> None:
         send_email(
             to=recipient,
             subject="Your Marrow subscription is active",
-            html=subscription_confirmation_html(org.name, tier),
+            html=subscription_confirmation_html(org.name, org.tier),
         )
 
 
 def _handle_subscription_updated(subscription: dict, db: Session) -> None:
     customer_id = subscription.get("customer")
-    subscription_id = subscription.get("id")
     org = _org_by_customer(customer_id, db)
     if org is None:
+        logger.warning(
+            "billing: customer.subscription.updated matched no org (customer=%s)",
+            customer_id,
+        )
         return
 
-    result = _tier_from_subscription(subscription)
-    if result is None:
-        return
-    tier, billing_interval = result
-
-    org.stripe_subscription_id = subscription_id
-    org.tier = tier
-    org.billing_interval = billing_interval
-    org.subscription_status = _map_stripe_status(subscription.get("status"))
-    db.commit()
+    _apply_subscription(org, subscription, db)
 
 
 def _handle_subscription_deleted(subscription: dict, db: Session) -> None:
     customer_id = subscription.get("customer")
     org = _org_by_customer(customer_id, db)
     if org is None:
+        logger.warning(
+            "billing: customer.subscription.deleted matched no org (customer=%s)",
+            customer_id,
+        )
         return
 
     org.tier = "starter"
@@ -284,6 +368,10 @@ def _handle_payment_failed(invoice: dict, db: Session) -> None:
     customer_id = invoice.get("customer")
     org = _org_by_customer(customer_id, db)
     if org is None:
+        logger.warning(
+            "billing: invoice.payment_failed matched no org (customer=%s)",
+            customer_id,
+        )
         return
     org.subscription_status = "past_due"
     db.commit()

--- a/api/marrow/routers/organizations.py
+++ b/api/marrow/routers/organizations.py
@@ -12,6 +12,7 @@ from ..models import Organization, OrgMembership, OrgRole, User
 from ..rbac import require_org_role
 from ..schemas import (
     OrganizationCreate,
+    OrganizationOnboard,
     OrganizationRead,
     OrganizationUpdate,
     OrgMembershipCreate,
@@ -50,8 +51,12 @@ def create_org(
     db: Session = Depends(get_db),
     auth: AuthContext = Depends(verify_auth),
 ):
-    """Create an org. The creating user becomes the owner."""
-    org = Organization(slug=body.slug, name=body.name)
+    """Create an org. The creating user becomes the owner.
+
+    Explicitly created orgs are named by the user already, so they skip the
+    first-run /onboarding step (unlike the auto-created personal org).
+    """
+    org = Organization(slug=body.slug, name=body.name, onboarded_at=func.now())
     db.add(org)
     try:
         db.flush()
@@ -97,8 +102,35 @@ def update_org(
     org = db.get(Organization, org_id)
     if org is None:
         raise HTTPException(404, "Organization not found")
+    if body.name is not None:
+        name = body.name.strip()
+        if not name:
+            raise HTTPException(422, "Organization name cannot be empty")
+        org.name = name
     if body.members_can_create_spaces is not None:
         org.members_can_create_spaces = body.members_can_create_spaces
+    db.commit()
+    db.refresh(org)
+    return org
+
+
+@router.post("/{org_id}/onboard", response_model=OrganizationRead)
+def onboard_org(
+    org_id: UUID,
+    body: OrganizationOnboard,
+    db: Session = Depends(get_db),
+    auth: AuthContext = Depends(require_org_role(OrgRole.OWNER)),
+):
+    """Complete first-run onboarding: name the org and stamp ``onboarded_at``."""
+    org = db.get(Organization, org_id)
+    if org is None:
+        raise HTTPException(404, "Organization not found")
+    name = body.name.strip()
+    if not name:
+        raise HTTPException(422, "Organization name cannot be empty")
+    org.name = name
+    if org.onboarded_at is None:
+        org.onboarded_at = func.now()
     db.commit()
     db.refresh(org)
     return org

--- a/api/marrow/schemas.py
+++ b/api/marrow/schemas.py
@@ -402,6 +402,7 @@ class OrganizationRead(_ReadBase):
     slug: str
     name: str
     created_at: datetime
+    onboarded_at: datetime | None = None
     members_can_create_spaces: bool = True
     tier: str = "starter"
     subscription_status: str = "none"
@@ -415,7 +416,14 @@ class OrganizationRead(_ReadBase):
 
 
 class OrganizationUpdate(BaseModel):
+    name: str | None = None
     members_can_create_spaces: bool | None = None
+
+
+class OrganizationOnboard(BaseModel):
+    """First-run onboarding: name the org (sets ``onboarded_at``)."""
+
+    name: str
 
 
 # ---------------------------------------------------------------------------
@@ -460,6 +468,9 @@ class AuthStatus(BaseModel):
     # True when the user owns >=1 org with no active subscription (SaaS only).
     # Lets the post-login callback decide the subscription gate in one round trip.
     has_payable_unsubscribed_org: bool = False
+    # True when the user owns >=1 org that hasn't completed first-run
+    # onboarding (onboarded_at IS NULL). SaaS only; gates the /onboarding step.
+    needs_onboarding: bool = False
 
 
 class WatchStatus(BaseModel):

--- a/api/tests/test_billing.py
+++ b/api/tests/test_billing.py
@@ -1,5 +1,6 @@
 """Webhook handler tests — subscription_status transitions + confirmation email."""
 
+import logging
 import os
 import uuid
 
@@ -64,6 +65,13 @@ def db(engine):
     session.close()
     tx.rollback()
     conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _enable_billing_logger():
+    # Alembic's fileConfig (run by the db_url fixture) disables pre-existing
+    # loggers, which would silently swallow the records caplog asserts on.
+    logging.getLogger("marrow.routers.billing").disabled = False
 
 
 def _seed_org(db: Session, *, customer="cus_test", **overrides) -> Organization:
@@ -153,3 +161,121 @@ def test_handlers_noop_for_unknown_customer(db):
     # No org with this customer — must not raise.
     billing._handle_payment_failed({"customer": "cus_missing"}, db)
     billing._handle_subscription_deleted({"customer": "cus_missing"}, db)
+
+
+# ---------------------------------------------------------------------------
+# Webhook observability — every early-return must log (#214)
+# ---------------------------------------------------------------------------
+
+
+def test_checkout_completed_missing_fields_logs(db, caplog):
+    with caplog.at_level("WARNING", logger="marrow.routers.billing"):
+        billing._handle_checkout_completed({}, db)
+    assert any("missing fields" in r.message for r in caplog.records)
+
+
+def test_checkout_completed_unknown_org_logs(db, caplog):
+    session = {
+        "customer": "cus_ghost",
+        "subscription": "sub_ghost",
+        "metadata": {"org_id": str(uuid.uuid4())},
+    }
+    with caplog.at_level("WARNING", logger="marrow.routers.billing"):
+        billing._handle_checkout_completed(session, db)
+    assert any("matched no org" in r.message for r in caplog.records)
+
+
+def test_subscription_updated_unknown_customer_logs(db, caplog):
+    with caplog.at_level("WARNING", logger="marrow.routers.billing"):
+        billing._handle_subscription_updated({"id": "sub_x", "customer": "cus_missing"}, db)
+    assert any("matched no org" in r.message for r in caplog.records)
+
+
+def test_unknown_price_logs(db, caplog, monkeypatch):
+    org = _seed_org(db, customer="cus_badprice")
+    monkeypatch.setattr(billing, "_PRICE_TO_TIER", {})
+    with caplog.at_level("WARNING", logger="marrow.routers.billing"):
+        applied = billing._apply_subscription(org, {"id": "sub_bp", **_sub_obj("active")}, db)
+    assert applied is False
+    assert any("unrecognized price" in r.message for r in caplog.records)
+
+
+def test_payment_failed_unknown_customer_logs(db, caplog):
+    with caplog.at_level("WARNING", logger="marrow.routers.billing"):
+        billing._handle_payment_failed({"customer": "cus_missing"}, db)
+    assert any("matched no org" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Reconcile — pull subscription truth from Stripe (#214)
+# ---------------------------------------------------------------------------
+
+
+def _stub_subscription_list(monkeypatch, data):
+    calls = []
+
+    def _fake_list(**kwargs):
+        calls.append(kwargs)
+        return {"data": data}
+
+    monkeypatch.setattr(billing.stripe.Subscription, "list", _fake_list)
+    return calls
+
+
+def test_reconcile_writes_subscription_from_stripe(db, monkeypatch, known_price):
+    monkeypatch.setenv("SAAS_MODE", "true")
+    org = _seed_org(db, customer="cus_rec")
+    calls = _stub_subscription_list(monkeypatch, [{"id": "sub_rec", **_sub_obj("trialing")}])
+
+    result = billing.reconcile_subscription(org.id, db=db, auth=None)
+    db.refresh(org)
+
+    assert calls == [{"customer": "cus_rec", "status": "all", "limit": 1}]
+    assert result["reconciled"] is True
+    assert result["has_active_subscription"] is True
+    assert org.subscription_status == "trialing"
+    assert org.tier == "business"
+    assert org.billing_interval == "monthly"
+    assert org.stripe_subscription_id == "sub_rec"
+
+
+def test_reconcile_without_customer_is_clean_noop(db, monkeypatch, caplog):
+    monkeypatch.setenv("SAAS_MODE", "true")
+    org = _seed_org(db, customer=None)
+
+    with caplog.at_level("WARNING", logger="marrow.routers.billing"):
+        result = billing.reconcile_subscription(org.id, db=db, auth=None)
+    db.refresh(org)
+
+    assert result["reconciled"] is False
+    assert result["reason"] == "no_customer"
+    assert result["has_active_subscription"] is False
+    assert org.subscription_status == "none"
+    assert any("no Stripe customer" in r.message for r in caplog.records)
+
+
+def test_reconcile_with_no_subscriptions(db, monkeypatch, caplog):
+    monkeypatch.setenv("SAAS_MODE", "true")
+    org = _seed_org(db, customer="cus_empty")
+    _stub_subscription_list(monkeypatch, [])
+
+    with caplog.at_level("WARNING", logger="marrow.routers.billing"):
+        result = billing.reconcile_subscription(org.id, db=db, auth=None)
+
+    assert result["reconciled"] is False
+    assert result["reason"] == "no_subscription"
+    assert any("found no subscriptions" in r.message for r in caplog.records)
+
+
+def test_reconcile_with_unknown_price(db, monkeypatch):
+    monkeypatch.setenv("SAAS_MODE", "true")
+    org = _seed_org(db, customer="cus_unk")
+    monkeypatch.setattr(billing, "_PRICE_TO_TIER", {})
+    _stub_subscription_list(monkeypatch, [{"id": "sub_unk", **_sub_obj("active")}])
+
+    result = billing.reconcile_subscription(org.id, db=db, auth=None)
+    db.refresh(org)
+
+    assert result["reconciled"] is False
+    assert result["reason"] == "unknown_price"
+    assert org.subscription_status == "none"

--- a/api/tests/test_onboarding.py
+++ b/api/tests/test_onboarding.py
@@ -1,0 +1,180 @@
+"""Org onboarding tests — onboarded_at, /onboard endpoint, needs_onboarding (#214)."""
+
+import os
+import uuid
+from types import SimpleNamespace
+
+import psycopg2
+import pytest
+from alembic.config import Config
+from fastapi import HTTPException
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from alembic import command
+from marrow.models import Organization, OrgMembership, OrgRole, User
+from marrow.routers import auth as auth_router
+from marrow.routers import organizations as orgs_router
+from marrow.schemas import OrganizationCreate, OrganizationOnboard, OrganizationUpdate
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
+
+
+def _base_dsn() -> str:
+    return DATABASE_URL.rsplit("/", 1)[0]
+
+
+def _alembic_cfg(url: str) -> Config:
+    os.environ["DATABASE_URL"] = url
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", url)
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def db_url():
+    db_name = f"marrow_onboarding_{uuid.uuid4().hex[:8]}"
+    admin = psycopg2.connect(f"{_base_dsn()}/postgres")
+    admin.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with admin.cursor() as cur:
+        cur.execute(f'CREATE DATABASE "{db_name}"')
+    admin.close()
+
+    url = f"{_base_dsn()}/{db_name}"
+    command.upgrade(_alembic_cfg(url), "head")
+    yield url
+
+    admin = psycopg2.connect(f"{_base_dsn()}/postgres")
+    admin.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with admin.cursor() as cur:
+        cur.execute(f'DROP DATABASE "{db_name}" WITH (FORCE)')
+    admin.close()
+
+
+@pytest.fixture(scope="module")
+def engine(db_url):
+    eng = create_engine(db_url)
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture()
+def db(engine):
+    conn = engine.connect()
+    tx = conn.begin()
+    session = Session(bind=conn)
+    yield session
+    session.close()
+    tx.rollback()
+    conn.close()
+
+
+def _seed_org(db: Session, **overrides) -> Organization:
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Acme's Space", **overrides)
+    db.add(org)
+    db.flush()
+    return org
+
+
+def _seed_owner(db: Session, org: Organization) -> User:
+    user = User(
+        oidc_issuer="https://test.example.com",
+        oidc_subject=uuid.uuid4().hex,
+        email=f"owner-{uuid.uuid4().hex[:6]}@example.com",
+        name="Owner",
+    )
+    db.add(user)
+    db.flush()
+    db.add(
+        OrgMembership(org_id=org.id, user_id=user.id, email=user.email, role=OrgRole.OWNER.value)
+    )
+    db.flush()
+    return user
+
+
+def test_onboard_sets_name_and_onboarded_at(db):
+    org = _seed_org(db)
+    assert org.onboarded_at is None
+
+    result = orgs_router.onboard_org(
+        org.id, OrganizationOnboard(name="  Real Name  "), db=db, auth=None
+    )
+
+    assert result.name == "Real Name"
+    assert result.onboarded_at is not None
+
+
+def test_onboard_rejects_empty_name(db):
+    org = _seed_org(db)
+    with pytest.raises(HTTPException) as exc:
+        orgs_router.onboard_org(org.id, OrganizationOnboard(name="   "), db=db, auth=None)
+    assert exc.value.status_code == 422
+
+
+def test_onboard_is_idempotent_on_timestamp(db):
+    org = _seed_org(db)
+    orgs_router.onboard_org(org.id, OrganizationOnboard(name="First"), db=db, auth=None)
+    first_ts = db.get(Organization, org.id).onboarded_at
+
+    orgs_router.onboard_org(org.id, OrganizationOnboard(name="Second"), db=db, auth=None)
+    refreshed = db.get(Organization, org.id)
+    assert refreshed.name == "Second"
+    assert refreshed.onboarded_at == first_ts
+
+
+def test_update_org_applies_name(db):
+    org = _seed_org(db, onboarded_at=None)
+    result = orgs_router.update_org(
+        org.id, OrganizationUpdate(name="Renamed Org"), db=db, auth=None
+    )
+    assert result.name == "Renamed Org"
+
+
+def test_update_org_rejects_empty_name(db):
+    org = _seed_org(db)
+    with pytest.raises(HTTPException) as exc:
+        orgs_router.update_org(org.id, OrganizationUpdate(name="  "), db=db, auth=None)
+    assert exc.value.status_code == 422
+
+
+def test_create_org_skips_onboarding(db):
+    auth = SimpleNamespace(user_id=None, email=None)
+    result = orgs_router.create_org(
+        OrganizationCreate(slug=f"explicit-{uuid.uuid4().hex[:6]}", name="Named Already"),
+        db=db,
+        auth=auth,
+    )
+    assert result.onboarded_at is not None
+
+
+def test_needs_onboarding_toggles(db, monkeypatch):
+    monkeypatch.setenv("SAAS_MODE", "true")
+    monkeypatch.setattr(auth_router, "get_db", lambda: iter([db]))
+
+    org = _seed_org(db)
+    user = _seed_owner(db, org)
+
+    has_payable, needs_onboarding = auth_router._owner_gate_flags(user.id)
+    assert needs_onboarding is True
+    assert has_payable is True
+
+    org = db.get(Organization, org.id)
+    orgs_router.onboard_org(org.id, OrganizationOnboard(name="Acme"), db=db, auth=None)
+    org = db.get(Organization, org.id)
+    org.subscription_status = "trialing"
+    db.flush()
+
+    has_payable, needs_onboarding = auth_router._owner_gate_flags(user.id)
+    assert needs_onboarding is False
+    assert has_payable is False
+
+
+def test_gate_flags_off_in_self_hosted_mode(db, monkeypatch):
+    monkeypatch.delenv("SAAS_MODE", raising=False)
+    monkeypatch.setattr(auth_router, "get_db", lambda: iter([db]))
+
+    org = _seed_org(db)
+    user = _seed_owner(db, org)
+
+    assert auth_router._owner_gate_flags(user.id) == (False, False)

--- a/web/app/auth/callback/page.tsx
+++ b/web/app/auth/callback/page.tsx
@@ -14,9 +14,12 @@ export default function AuthCallbackPage() {
           router.replace("/login");
           return;
         }
-        // Subscription gate: an owner of an unsubscribed org (SaaS only) is sent
-        // to checkout. Otherwise land on the global Home. Never the picker.
-        if (status.has_payable_unsubscribed_org) {
+        // Gate order: onboarding → subscription → home. A first-run owner names
+        // their org before anything else; an owner of an unsubscribed org (SaaS
+        // only) is sent to checkout. Otherwise the global Home. Never the picker.
+        if (status.needs_onboarding) {
+          router.replace("/onboarding");
+        } else if (status.has_payable_unsubscribed_org) {
           router.replace("/subscribe");
         } else {
           router.replace("/home");

--- a/web/app/home/layout.tsx
+++ b/web/app/home/layout.tsx
@@ -9,15 +9,19 @@ import {
 
 /**
  * Global Home shell. Uses its own lightweight chrome (NOT WorkspaceShell, which
- * is workspace-bound). Re-asserts the subscription gate as defense in depth:
- * the post-login callback already routes unsubscribed owners to /subscribe, but
- * a direct hit on /home must enforce the same rule.
+ * is workspace-bound). Re-asserts the post-login gates (onboarding →
+ * subscription) as defense in depth: the callback already routes first-run
+ * owners to /onboarding and unsubscribed owners to /subscribe, but a direct
+ * hit on /home must enforce the same rules.
  */
 export default async function HomeLayout({ children }: { children: React.ReactNode }) {
   const auth = await getAuthStatus().catch(() => null);
 
   if (!auth?.authenticated) {
     redirect("/login");
+  }
+  if (auth.needs_onboarding) {
+    redirect("/onboarding");
   }
   if (auth.has_payable_unsubscribed_org) {
     redirect("/subscribe");

--- a/web/app/onboarding/page.tsx
+++ b/web/app/onboarding/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { completeOnboarding, getAuthStatus, listOrgs } from "@/lib/api";
+import type { Organization } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+/**
+ * First-run onboarding: name the auto-created organization. Shown when
+ * AuthStatus.needs_onboarding is true (the user owns an org with
+ * onboarded_at unset). Gate order is onboarding → subscription → home.
+ */
+export default function OnboardingPage() {
+  const router = useRouter();
+  const [org, setOrg] = useState<Organization | null>(null);
+  const [name, setName] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const status = await getAuthStatus();
+        if (cancelled) return;
+        if (!status.authenticated) {
+          router.replace("/login");
+          return;
+        }
+        if (!status.needs_onboarding) {
+          router.replace(status.has_payable_unsubscribed_org ? "/subscribe" : "/home");
+          return;
+        }
+        const orgs = await listOrgs();
+        if (cancelled) return;
+        const pending = orgs.find((o) => o.onboarded_at === null) ?? orgs[0] ?? null;
+        if (!pending) {
+          router.replace("/home");
+          return;
+        }
+        setOrg(pending);
+        setName(pending.name);
+        setLoading(false);
+      } catch {
+        if (!cancelled) router.replace("/login");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!org || !name.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await completeOnboarding(org.id, name.trim());
+      const status = await getAuthStatus();
+      router.replace(status.has_payable_unsubscribed_org ? "/subscribe" : "/home");
+    } catch (err) {
+      setBusy(false);
+      setError(err instanceof Error ? err.message : "Failed to save organization name");
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-muted-foreground text-sm">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-6">
+      <form onSubmit={handleSubmit} className="w-full max-w-md space-y-6">
+        <div className="space-y-2 text-center">
+          <h1 className="text-2xl font-bold tracking-tight">Name your organization</h1>
+          <p className="text-muted-foreground text-sm">
+            This is how your team&apos;s workspace will appear in Marrow. You can change it
+            anytime in organization settings.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <Input
+            autoFocus
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Acme Inc."
+            disabled={busy}
+            aria-label="Organization name"
+          />
+          {error && <p className="text-destructive text-sm">{error}</p>}
+        </div>
+        <Button type="submit" size="lg" className="w-full" disabled={busy || !name.trim()}>
+          {busy ? "Saving…" : "Continue"}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/web/app/orgs/[orgId]/settings/page.tsx
+++ b/web/app/orgs/[orgId]/settings/page.tsx
@@ -27,6 +27,8 @@ export default function OrgSettingsPage() {
   const [inviteRole, setInviteRole] = useState<string>("editor");
   const [busy, setBusy] = useState(false);
   const [savingPermission, setSavingPermission] = useState(false);
+  const [nameDraft, setNameDraft] = useState("");
+  const [savingName, setSavingName] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -45,6 +47,7 @@ export default function OrgSettingsPage() {
         const [o, m] = await Promise.all([getOrg(orgId), listOrgMembers(orgId)]);
         if (cancelled) return;
         setOrg(o);
+        setNameDraft(o.name);
         setMembers(m);
       } catch (err) {
         if (!cancelled) toast.error(String(err));
@@ -117,6 +120,48 @@ export default function OrgSettingsPage() {
           </Link>
         </div>
       </div>
+
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">General</h2>
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            const name = nameDraft.trim();
+            if (!name || name === org.name) return;
+            setSavingName(true);
+            try {
+              const updated = await updateOrg(orgId, { name });
+              setOrg(updated);
+              setNameDraft(updated.name);
+              toast.success("Organization renamed");
+            } catch (err) {
+              toast.error(String(err));
+            } finally {
+              setSavingName(false);
+            }
+          }}
+          className="space-y-2"
+        >
+          <label htmlFor="org-name" className="text-sm font-medium">
+            Organization name
+          </label>
+          <div className="flex gap-2">
+            <Input
+              id="org-name"
+              value={nameDraft}
+              onChange={(e) => setNameDraft(e.target.value)}
+              disabled={savingName}
+              className="flex-1"
+            />
+            <Button
+              type="submit"
+              disabled={savingName || !nameDraft.trim() || nameDraft.trim() === org.name}
+            >
+              {savingName ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </form>
+      </section>
 
       <section className="space-y-4">
         <h2 className="text-lg font-semibold">Members</h2>

--- a/web/app/subscribe/success/page.tsx
+++ b/web/app/subscribe/success/page.tsx
@@ -1,61 +1,112 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { getOrg, listOrgs } from "@/lib/api";
+import { createPortalSession, listOrgs, reconcileSubscription } from "@/lib/api";
+import { Button } from "@/components/ui/button";
 
 // Stripe redirects back here before the webhook is guaranteed to have landed.
-// Poll the org's subscription state, then forward into the app once active.
-const MAX_ATTEMPTS = 15;
-const POLL_MS = 1500;
+// Instead of waiting on the webhook, actively reconcile: pull subscription
+// truth from Stripe via the API and persist it. A few retries absorb the race
+// where the trial subscription isn't queryable the instant Checkout finishes.
+// On final failure we show a terminal Retry/support state — never a silent
+// forward to /home, which the subscription gate would just bounce back here.
+const MAX_ATTEMPTS = 5;
+const RETRY_MS = 2000;
 
 function SuccessInner() {
   const router = useRouter();
   const params = useSearchParams();
-  const orgId = params.get("org");
+  const orgParam = params.get("org");
+
+  const [phase, setPhase] = useState<"confirming" | "failed">("confirming");
   const [slow, setSlow] = useState(false);
+  const [portalBusy, setPortalBusy] = useState(false);
+  const [runId, setRunId] = useState(0);
 
   useEffect(() => {
-    let attempts = 0;
-    let timer: ReturnType<typeof setTimeout>;
     let cancelled = false;
 
-    async function isActive(): Promise<boolean> {
+    async function resolveOrgId(): Promise<string | null> {
+      if (orgParam) return orgParam;
+      const orgs = await listOrgs();
+      return (orgs.find((o) => !o.has_active_subscription) ?? orgs[0])?.id ?? null;
+    }
+
+    async function confirm() {
+      let orgId: string | null = null;
       try {
-        if (orgId) {
-          const org = await getOrg(orgId);
-          return org.has_active_subscription;
-        }
-        const orgs = await listOrgs();
-        return orgs.some((o) => o.has_active_subscription);
+        orgId = await resolveOrgId();
       } catch {
-        return false;
+        // fall through to the failure state below
       }
+      for (let attempt = 0; orgId && attempt < MAX_ATTEMPTS; attempt++) {
+        if (cancelled) return;
+        if (attempt >= 2) setSlow(true);
+        try {
+          const result = await reconcileSubscription(orgId);
+          if (result.has_active_subscription) {
+            router.replace("/home");
+            return;
+          }
+        } catch {
+          // transient API error — retry
+        }
+        await new Promise((r) => setTimeout(r, RETRY_MS));
+      }
+      if (!cancelled) setPhase("failed");
     }
 
-    async function poll() {
-      if (cancelled) return;
-      if (await isActive()) {
-        router.replace("/home");
-        return;
-      }
-      attempts += 1;
-      if (attempts >= MAX_ATTEMPTS) {
-        // Webhook is taking longer than expected — let the user proceed; the
-        // workspace/home gate re-checks server-side.
-        router.replace("/home");
-        return;
-      }
-      if (attempts >= 3) setSlow(true);
-      timer = setTimeout(poll, POLL_MS);
-    }
-
-    poll();
+    setPhase("confirming");
+    setSlow(false);
+    confirm();
     return () => {
       cancelled = true;
-      clearTimeout(timer);
     };
-  }, [orgId, router]);
+  }, [orgParam, router, runId]);
+
+  const openPortal = useCallback(async () => {
+    if (!orgParam) return;
+    setPortalBusy(true);
+    try {
+      const { url } = await createPortalSession(orgParam);
+      window.location.assign(url);
+    } catch {
+      setPortalBusy(false);
+    }
+  }, [orgParam]);
+
+  if (phase === "failed") {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="max-w-md space-y-4 text-center">
+          <h1 className="text-xl font-semibold">We couldn&apos;t confirm your payment</h1>
+          <p className="text-muted-foreground text-sm">
+            Your checkout may still be processing on Stripe&apos;s side. You haven&apos;t been
+            charged twice — retry the confirmation, or check your subscription in the billing
+            portal.
+          </p>
+          <div className="flex items-center justify-center gap-3">
+            <Button onClick={() => setRunId((n) => n + 1)}>Retry</Button>
+            {orgParam && (
+              <Button variant="outline" disabled={portalBusy} onClick={openPortal}>
+                {portalBusy ? "Opening…" : "Billing portal"}
+              </Button>
+            )}
+          </div>
+          <p className="text-muted-foreground text-xs">
+            Still stuck?{" "}
+            <a
+              href="mailto:hello@marrow.so?subject=Subscription%20confirmation%20issue"
+              className="font-medium text-foreground underline underline-offset-4"
+            >
+              Contact support
+            </a>
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center">

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -24,6 +24,7 @@ import type {
   OrgMembership,
   PropertySchema,
   PropertyValueType,
+  ReconcileResult,
   Revision,
   SearchResponse,
   ShareLink,
@@ -378,6 +379,10 @@ export function createPortalSession(orgId: string): Promise<{ url: string }> {
   return apiFetch(`/api/billing/${orgId}/portal`, { method: "POST" });
 }
 
+export function reconcileSubscription(orgId: string): Promise<ReconcileResult> {
+  return apiFetch(`/api/billing/${orgId}/reconcile`, { method: "POST" });
+}
+
 // ---------------------------------------------------------------------------
 // Organizations
 // ---------------------------------------------------------------------------
@@ -399,11 +404,18 @@ export function getOrg(orgId: string): Promise<Organization> {
 
 export function updateOrg(
   orgId: string,
-  patch: { members_can_create_spaces?: boolean }
+  patch: { name?: string; members_can_create_spaces?: boolean }
 ): Promise<Organization> {
   return apiFetch(`/api/orgs/${orgId}`, {
     method: "PATCH",
     body: JSON.stringify(patch),
+  });
+}
+
+export function completeOnboarding(orgId: string, name: string): Promise<Organization> {
+  return apiFetch(`/api/orgs/${orgId}/onboard`, {
+    method: "POST",
+    body: JSON.stringify({ name }),
   });
 }
 

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -12,7 +12,18 @@ export interface Organization {
   slug: string;
   name: string;
   created_at: string;
+  onboarded_at: string | null;
   members_can_create_spaces: boolean;
+  tier: string;
+  subscription_status: SubscriptionStatus;
+  has_active_subscription: boolean;
+}
+
+// Result of POST /api/billing/{orgId}/reconcile — pulls subscription truth
+// from Stripe so a completed Checkout lands even without the webhook.
+export interface ReconcileResult {
+  reconciled: boolean;
+  reason: string | null;
   tier: string;
   subscription_status: SubscriptionStatus;
   has_active_subscription: boolean;
@@ -248,6 +259,7 @@ export interface AuthStatus {
   method: string;
   oidc_enabled: boolean;
   has_payable_unsubscribed_org: boolean;
+  needs_onboarding: boolean;
 }
 
 // View-only sharing links (#40)


### PR DESCRIPTION
Closes #214. Implements `references/prd-login-flow-fixes.md` (follow-up to #208 / v0.3.0).

## What changed

**Billing reconcile + webhook observability**
- New `POST /api/billing/{org_id}/reconcile` (owner): pulls the org's subscription from Stripe (`Subscription.list(customer=…, status="all", limit=1)`) and persists tier/interval/status/IDs. Self-heals a completed Checkout even if the webhook never arrives.
- Extracted shared `_apply_subscription(org, subscription)` — single write path for `checkout.session.completed`, `customer.subscription.updated`, and reconcile.
- Module logger + `logger.warning` on **every** webhook early-return (missing fields, unknown customer/org, unrecognized price). No more silent 200s.

**Success-page loop fix**
- `/subscribe/success` reconciles on mount (5 bounded retries absorbing the trial-subscription race). Active → `/home`. Exhausted retries → terminal "couldn't confirm payment" state with Retry + billing-portal + support links. **Never** auto-forwards to `/home` while inactive — this was the `/subscribe → /home → /subscribe` loop.

**Org onboarding**
- `organizations.onboarded_at` migration (`b8d2e4f6a1c3`), backfilled to `created_at` so existing users are never re-onboarded. Explicitly created and restored orgs are stamped immediately; only the auto-created personal org triggers onboarding.
- `POST /api/orgs/{id}/onboard {name}` sets name + `onboarded_at` atomically; `PATCH /api/orgs/{id}` now accepts `name`; `AuthStatus.needs_onboarding` computed in `/me`.
- New `/onboarding` page (pre-filled name → continue). Gate order is now **onboarding → subscription → home** in `auth/callback`, re-asserted in `home/layout.tsx`. Org settings gains a Name field.

**Test harness**
- `marrow reset-org-billing <slug>` CLI — resets `subscription_status`/`tier`/`billing_interval`/Stripe IDs/`onboarded_at` to fresh-signup values; never touches Stripe. Manual incognito test runbook added to `references/deploy-runbook.md` (local, gitignored).

**Decision D (PRD):** silent SSO stays — no `prompt=` change.

## Verification

- `cd api && ruff check . && ruff format --check .` — clean
- `cd api && pytest` — **239 passed** (fresh Docker Postgres), incl. `test_round_trip` (billing/onboarding fields are never exported) and `alembic downgrade -1 && upgrade head`
- New tests: reconcile from stubbed `stripe.Subscription.list` (success / no customer / no subscription / unknown price), webhook early-return logging via `caplog`, `/onboard` semantics, `needs_onboarding` toggling, self-hosted gate-off
- `cd web && npm run build` — passes; touched files lint clean
- CLI smoke-tested: `marrow reset-org-billing` help + unknown-slug error path

**Remaining for v0.3.1 release (post-merge):** E2E pass in Stripe test mode per the runbook (login → `/onboarding` → Checkout `4242…` → reconcile → `/home`, twice), then tag `v0.3.1`.