### PR TITLE
Fix StripeObject handling in billing webhooks

### DIFF
--- a/api/marrow/routers/billing.py
+++ b/api/marrow/routers/billing.py
@@ -1,5 +1,7 @@
 """Stripe billing — checkout, portal, webhook, and reconcile endpoints."""
 
+from __future__ import annotations
+
 import logging
 import os
 from uuid import UUID
@@ -200,7 +202,7 @@ def reconcile_subscription(
         return _result(False, "no_customer")
 
     subscriptions = stripe.Subscription.list(customer=org.stripe_customer_id, status="all", limit=1)
-    data = subscriptions.get("data") or []
+    data = getattr(subscriptions, "data", None) or []
     if not data:
         logger.warning(
             "billing: reconcile for org %s found no subscriptions (customer=%s)",
@@ -225,14 +227,25 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
     except stripe.error.SignatureVerificationError:
         raise HTTPException(400, "Invalid Stripe signature")
 
-    if event["type"] == "checkout.session.completed":
-        _handle_checkout_completed(event["data"]["object"], db)
-    elif event["type"] == "customer.subscription.updated":
-        _handle_subscription_updated(event["data"]["object"], db)
-    elif event["type"] == "customer.subscription.deleted":
-        _handle_subscription_deleted(event["data"]["object"], db)
-    elif event["type"] == "invoice.payment_failed":
-        _handle_payment_failed(event["data"]["object"], db)
+    event_type = getattr(event, "type", None)
+    event_data = getattr(event, "data", None)
+    event_object = getattr(event_data, "object", None)
+
+    try:
+        if event_type == "checkout.session.completed":
+            _handle_checkout_completed(event_object, db)
+        elif event_type == "customer.subscription.updated":
+            _handle_subscription_updated(event_object, db)
+        elif event_type == "customer.subscription.deleted":
+            _handle_subscription_deleted(event_object, db)
+        elif event_type == "invoice.payment_failed":
+            _handle_payment_failed(event_object, db)
+    except Exception:
+        logger.exception(
+            "billing: Stripe webhook handler failed for event_type=%s; returning 200 "
+            "so reconcile can self-heal without a Stripe retry storm",
+            event_type,
+        )
 
     return JSONResponse({"received": True})
 
@@ -243,13 +256,16 @@ def _org_by_customer(customer_id: str, db: Session) -> Organization | None:
     ).scalar_one_or_none()
 
 
-def _tier_from_subscription(subscription: dict) -> tuple[str, str] | None:
+def _tier_from_subscription(subscription: stripe.Subscription) -> tuple[str, str] | None:
     """Return (tier, interval) from the first line item's price ID, or None."""
-    items = subscription.get("items", {}).get("data", [])
+    items = getattr(getattr(subscription, "items", None), "data", None) or []
     if not items:
         return None
-    price_id = items[0]["price"]["id"]
-    interval = items[0]["price"]["recurring"]["interval"]  # 'month' or 'year'
+    price = getattr(items[0], "price", None)
+    price_id = getattr(price, "id", None)
+    interval = getattr(getattr(price, "recurring", None), "interval", None)
+    if not (price_id and interval):
+        return None
     tier_info = _PRICE_TO_TIER.get(price_id)
     if not tier_info:
         return None
@@ -260,7 +276,7 @@ def _tier_from_subscription(subscription: dict) -> tuple[str, str] | None:
 
 def _apply_subscription(
     org: Organization,
-    subscription: dict,
+    subscription: stripe.Subscription,
     db: Session,
     *,
     subscription_id: str | None = None,
@@ -277,26 +293,26 @@ def _apply_subscription(
         logger.warning(
             "billing: subscription %s for org %s has an unrecognized price; "
             "check STRIPE_*_PRICE_* configuration",
-            subscription_id or subscription.get("id"),
+            subscription_id or getattr(subscription, "id", None),
             org.id,
         )
         return False
     tier, billing_interval = result
 
-    org.stripe_subscription_id = subscription_id or subscription.get("id")
+    org.stripe_subscription_id = subscription_id or getattr(subscription, "id", None)
     org.tier = tier
     org.billing_interval = billing_interval
-    # StripeObject supports .get(); default_status covers checkout, where the
-    # subscription was just created with a trial period.
-    org.subscription_status = _map_stripe_status(subscription.get("status") or default_status)
+    org.subscription_status = _map_stripe_status(
+        getattr(subscription, "status", None) or default_status
+    )
     db.commit()
     return True
 
 
-def _handle_checkout_completed(session: dict, db: Session) -> None:
-    customer_id = session.get("customer")
-    subscription_id = session.get("subscription")
-    org_id = session.get("metadata", {}).get("org_id")
+def _handle_checkout_completed(session: stripe.checkout.Session, db: Session) -> None:
+    customer_id = getattr(session, "customer", None)
+    subscription_id = getattr(session, "subscription", None)
+    org_id = getattr(getattr(session, "metadata", None), "org_id", None)
     if not (customer_id and subscription_id and org_id):
         logger.warning(
             "billing: checkout.session.completed missing fields "
@@ -324,7 +340,9 @@ def _handle_checkout_completed(session: dict, db: Session) -> None:
         return
 
     # Best-effort confirmation email — never blocks the webhook 200.
-    recipient = session.get("customer_details", {}).get("email") or session.get("customer_email")
+    recipient = getattr(getattr(session, "customer_details", None), "email", None) or getattr(
+        session, "customer_email", None
+    )
     if recipient:
         send_email(
             to=recipient,
@@ -333,8 +351,8 @@ def _handle_checkout_completed(session: dict, db: Session) -> None:
         )
 
 
-def _handle_subscription_updated(subscription: dict, db: Session) -> None:
-    customer_id = subscription.get("customer")
+def _handle_subscription_updated(subscription: stripe.Subscription, db: Session) -> None:
+    customer_id = getattr(subscription, "customer", None)
     org = _org_by_customer(customer_id, db)
     if org is None:
         logger.warning(
@@ -346,8 +364,8 @@ def _handle_subscription_updated(subscription: dict, db: Session) -> None:
     _apply_subscription(org, subscription, db)
 
 
-def _handle_subscription_deleted(subscription: dict, db: Session) -> None:
-    customer_id = subscription.get("customer")
+def _handle_subscription_deleted(subscription: stripe.Subscription, db: Session) -> None:
+    customer_id = getattr(subscription, "customer", None)
     org = _org_by_customer(customer_id, db)
     if org is None:
         logger.warning(
@@ -363,9 +381,9 @@ def _handle_subscription_deleted(subscription: dict, db: Session) -> None:
     db.commit()
 
 
-def _handle_payment_failed(invoice: dict, db: Session) -> None:
+def _handle_payment_failed(invoice: stripe.Invoice, db: Session) -> None:
     """Mark the org past_due on a failed invoice payment. Stripe keeps retrying."""
-    customer_id = invoice.get("customer")
+    customer_id = getattr(invoice, "customer", None)
     org = _org_by_customer(customer_id, db)
     if org is None:
         logger.warning(

--- a/api/tests/test_billing.py
+++ b/api/tests/test_billing.py
@@ -10,6 +10,7 @@ from alembic.config import Config
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
+from starlette.requests import Request
 
 from alembic import command
 from marrow.models import Organization
@@ -86,6 +87,10 @@ def _seed_org(db: Session, *, customer="cus_test", **overrides) -> Organization:
     return org
 
 
+def _stripe_obj(payload: dict):
+    return billing.stripe.StripeObject.construct_from(payload, None)
+
+
 @pytest.fixture
 def stub_email(monkeypatch):
     sent: list[dict] = []
@@ -99,10 +104,26 @@ def stub_email(monkeypatch):
 
 
 def _sub_obj(status: str, price_id: str = "price_business_monthly"):
-    return {
-        "status": status,
-        "items": {"data": [{"price": {"id": price_id, "recurring": {"interval": "month"}}}]},
-    }
+    return _stripe_obj(
+        {
+            "id": "sub_test",
+            "object": "subscription",
+            "status": status,
+            "items": {
+                "object": "list",
+                "data": [
+                    {
+                        "object": "subscription_item",
+                        "price": {
+                            "object": "price",
+                            "id": price_id,
+                            "recurring": {"interval": "month"},
+                        },
+                    }
+                ],
+            },
+        }
+    )
 
 
 @pytest.fixture
@@ -116,12 +137,15 @@ def test_checkout_completed_sets_trialing_and_emails(db, monkeypatch, stub_email
     org = _seed_org(db, customer="cus_co")
     monkeypatch.setattr(billing.stripe.Subscription, "retrieve", lambda sid: _sub_obj("trialing"))
 
-    session = {
-        "customer": "cus_co",
-        "subscription": "sub_co",
-        "metadata": {"org_id": str(org.id)},
-        "customer_details": {"email": "buyer@example.com"},
-    }
+    session = _stripe_obj(
+        {
+            "object": "checkout.session",
+            "customer": "cus_co",
+            "subscription": "sub_co",
+            "metadata": {"org_id": str(org.id)},
+            "customer_details": {"email": "buyer@example.com"},
+        }
+    )
     billing._handle_checkout_completed(session, db)
     db.refresh(org)
 
@@ -134,9 +158,10 @@ def test_checkout_completed_sets_trialing_and_emails(db, monkeypatch, stub_email
 
 def test_subscription_updated_maps_status(db, known_price):
     org = _seed_org(db, customer="cus_up", subscription_status="trialing")
-    billing._handle_subscription_updated(
-        {"id": "sub_up", "customer": "cus_up", **_sub_obj("active")}, db
-    )
+    sub = _sub_obj("active")
+    sub.id = "sub_up"
+    sub.customer = "cus_up"
+    billing._handle_subscription_updated(sub, db)
     db.refresh(org)
     assert org.subscription_status == "active"
     assert org.tier == "business"
@@ -144,7 +169,9 @@ def test_subscription_updated_maps_status(db, known_price):
 
 def test_subscription_deleted_marks_canceled(db):
     org = _seed_org(db, customer="cus_del", subscription_status="active", tier="business")
-    billing._handle_subscription_deleted({"id": "sub_del", "customer": "cus_del"}, db)
+    billing._handle_subscription_deleted(
+        _stripe_obj({"id": "sub_del", "object": "subscription", "customer": "cus_del"}), db
+    )
     db.refresh(org)
     assert org.subscription_status == "canceled"
     assert org.stripe_subscription_id is None
@@ -152,15 +179,22 @@ def test_subscription_deleted_marks_canceled(db):
 
 def test_payment_failed_marks_past_due(db):
     org = _seed_org(db, customer="cus_pf", subscription_status="active")
-    billing._handle_payment_failed({"customer": "cus_pf"}, db)
+    billing._handle_payment_failed(
+        _stripe_obj({"id": "in_pf", "object": "invoice", "customer": "cus_pf"}), db
+    )
     db.refresh(org)
     assert org.subscription_status == "past_due"
 
 
 def test_handlers_noop_for_unknown_customer(db):
     # No org with this customer — must not raise.
-    billing._handle_payment_failed({"customer": "cus_missing"}, db)
-    billing._handle_subscription_deleted({"customer": "cus_missing"}, db)
+    billing._handle_payment_failed(
+        _stripe_obj({"id": "in_missing", "object": "invoice", "customer": "cus_missing"}), db
+    )
+    billing._handle_subscription_deleted(
+        _stripe_obj({"id": "sub_missing", "object": "subscription", "customer": "cus_missing"}),
+        db,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -170,16 +204,19 @@ def test_handlers_noop_for_unknown_customer(db):
 
 def test_checkout_completed_missing_fields_logs(db, caplog):
     with caplog.at_level("WARNING", logger="marrow.routers.billing"):
-        billing._handle_checkout_completed({}, db)
+        billing._handle_checkout_completed(_stripe_obj({"object": "checkout.session"}), db)
     assert any("missing fields" in r.message for r in caplog.records)
 
 
 def test_checkout_completed_unknown_org_logs(db, caplog):
-    session = {
-        "customer": "cus_ghost",
-        "subscription": "sub_ghost",
-        "metadata": {"org_id": str(uuid.uuid4())},
-    }
+    session = _stripe_obj(
+        {
+            "object": "checkout.session",
+            "customer": "cus_ghost",
+            "subscription": "sub_ghost",
+            "metadata": {"org_id": str(uuid.uuid4())},
+        }
+    )
     with caplog.at_level("WARNING", logger="marrow.routers.billing"):
         billing._handle_checkout_completed(session, db)
     assert any("matched no org" in r.message for r in caplog.records)
@@ -187,7 +224,9 @@ def test_checkout_completed_unknown_org_logs(db, caplog):
 
 def test_subscription_updated_unknown_customer_logs(db, caplog):
     with caplog.at_level("WARNING", logger="marrow.routers.billing"):
-        billing._handle_subscription_updated({"id": "sub_x", "customer": "cus_missing"}, db)
+        billing._handle_subscription_updated(
+            _stripe_obj({"id": "sub_x", "object": "subscription", "customer": "cus_missing"}), db
+        )
     assert any("matched no org" in r.message for r in caplog.records)
 
 
@@ -195,14 +234,18 @@ def test_unknown_price_logs(db, caplog, monkeypatch):
     org = _seed_org(db, customer="cus_badprice")
     monkeypatch.setattr(billing, "_PRICE_TO_TIER", {})
     with caplog.at_level("WARNING", logger="marrow.routers.billing"):
-        applied = billing._apply_subscription(org, {"id": "sub_bp", **_sub_obj("active")}, db)
+        sub = _sub_obj("active")
+        sub.id = "sub_bp"
+        applied = billing._apply_subscription(org, sub, db)
     assert applied is False
     assert any("unrecognized price" in r.message for r in caplog.records)
 
 
 def test_payment_failed_unknown_customer_logs(db, caplog):
     with caplog.at_level("WARNING", logger="marrow.routers.billing"):
-        billing._handle_payment_failed({"customer": "cus_missing"}, db)
+        billing._handle_payment_failed(
+            _stripe_obj({"id": "in_missing", "object": "invoice", "customer": "cus_missing"}), db
+        )
     assert any("matched no org" in r.message for r in caplog.records)
 
 
@@ -216,7 +259,7 @@ def _stub_subscription_list(monkeypatch, data):
 
     def _fake_list(**kwargs):
         calls.append(kwargs)
-        return {"data": data}
+        return _stripe_obj({"object": "list", "data": data})
 
     monkeypatch.setattr(billing.stripe.Subscription, "list", _fake_list)
     return calls
@@ -225,7 +268,9 @@ def _stub_subscription_list(monkeypatch, data):
 def test_reconcile_writes_subscription_from_stripe(db, monkeypatch, known_price):
     monkeypatch.setenv("SAAS_MODE", "true")
     org = _seed_org(db, customer="cus_rec")
-    calls = _stub_subscription_list(monkeypatch, [{"id": "sub_rec", **_sub_obj("trialing")}])
+    sub = _sub_obj("trialing")
+    sub.id = "sub_rec"
+    calls = _stub_subscription_list(monkeypatch, [sub])
 
     result = billing.reconcile_subscription(org.id, db=db, auth=None)
     db.refresh(org)
@@ -271,7 +316,9 @@ def test_reconcile_with_unknown_price(db, monkeypatch):
     monkeypatch.setenv("SAAS_MODE", "true")
     org = _seed_org(db, customer="cus_unk")
     monkeypatch.setattr(billing, "_PRICE_TO_TIER", {})
-    _stub_subscription_list(monkeypatch, [{"id": "sub_unk", **_sub_obj("active")}])
+    sub = _sub_obj("active")
+    sub.id = "sub_unk"
+    _stub_subscription_list(monkeypatch, [sub])
 
     result = billing.reconcile_subscription(org.id, db=db, auth=None)
     db.refresh(org)
@@ -279,3 +326,44 @@ def test_reconcile_with_unknown_price(db, monkeypatch):
     assert result["reconciled"] is False
     assert result["reason"] == "unknown_price"
     assert org.subscription_status == "none"
+
+
+@pytest.mark.asyncio
+async def test_stripe_webhook_logs_handler_errors_and_returns_200(db, monkeypatch, caplog):
+    event = _stripe_obj(
+        {
+            "id": "evt_checkout",
+            "object": "event",
+            "type": "checkout.session.completed",
+            "data": {"object": {"object": "checkout.session"}},
+        }
+    )
+    monkeypatch.setattr(
+        billing.stripe.Webhook,
+        "construct_event",
+        lambda payload, sig_header, webhook_secret: event,
+    )
+
+    def _boom(session, db):
+        raise RuntimeError("subscription persistence failed")
+
+    monkeypatch.setattr(billing, "_handle_checkout_completed", _boom)
+
+    async def receive():
+        return {"type": "http.request", "body": b"{}", "more_body": False}
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/billing/webhook",
+            "headers": [(b"stripe-signature", b"sig_test")],
+        },
+        receive,
+    )
+
+    with caplog.at_level("ERROR", logger="marrow.routers.billing"):
+        response = await billing.stripe_webhook(request, db=db)
+
+    assert response.status_code == 200
+    assert any("Stripe webhook handler failed" in r.message for r in caplog.records)


### PR DESCRIPTION
Fixes #217.

## Summary
- Replace dict-style access on Stripe webhook/session/subscription/invoice objects with typed attribute access and `getattr` for optional fields.
- Keep Stripe signature verification as the only webhook 400 path, while logging handler exceptions and returning 200 so reconcile can self-heal without retry storms.
- Move billing webhook tests to `stripe.StripeObject.construct_from(...)` fixtures and add coverage for handler exceptions returning 200.

## Validation
- `api/.venv/bin/ruff check marrow/routers/billing.py tests/test_billing.py`
- `api/.venv/bin/ruff format --check marrow/routers/billing.py tests/test_billing.py`
- `api/.venv/bin/python -m py_compile marrow/routers/billing.py tests/test_billing.py`
- StripeObject smoke check for `_tier_from_subscription` on `StripeObject.construct_from(...)`

I also attempted `DATABASE_URL=postgresql://marrow:marrow@localhost:5433/marrow api/.venv/bin/pytest tests/test_billing.py -v`; it collected the billing suite, but this local environment has no Postgres listening on `localhost:5433`, so the fixture failed before executing test bodies with `connection refused`.
