### PR TITLE
fix(login): redirect /login straight to Auth0 + logged-out landing (#216)

### DIFF
--- a/api/marrow/routers/auth.py
+++ b/api/marrow/routers/auth.py
@@ -257,7 +257,7 @@ async def logout(request: Request):
             if end_session_endpoint:
                 params: dict[str, str] = {
                     "client_id": config.client_id,
-                    "post_logout_redirect_uri": config.frontend_url + "/login",
+                    "post_logout_redirect_uri": config.frontend_url + "/login?signedout=1",
                 }
                 if id_token_hint:
                     params["id_token_hint"] = id_token_hint

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,29 +1,26 @@
 import { redirect } from "next/navigation";
 import { getApiUrl, getOidcEnabled } from "@/lib/runtime-config";
+import { Button } from "@/components/ui/button";
 
-export default function LoginPage() {
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ signedout?: string }>;
+}) {
   if (!getOidcEnabled()) {
     redirect("/workspaces");
   }
 
   const apiUrl = getApiUrl();
+  const { signedout } = await searchParams;
 
-  return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="w-full max-w-sm space-y-6 text-center">
-        <div className="space-y-2">
-          <h1 className="text-2xl font-bold tracking-tight">Marrow</h1>
-          <p className="text-muted-foreground text-sm">
-            Sign in to access your workspace
-          </p>
-        </div>
-        <a
-          href={`${apiUrl}/api/auth/login`}
-          className="inline-flex h-9 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-        >
-          Sign in with SSO
-        </a>
-      </div>
-    </div>
-  );
+  if (signedout) {
+    return (
+      <Button render={<a href={`${apiUrl}/api/auth/login`} />}>
+        You have been signed out. Click here to sign in again.
+      </Button>
+    );
+  }
+
+  redirect(`${apiUrl}/api/auth/login`);
 }


### PR DESCRIPTION
## Summary

Closes #216. Turns `web/app/login/page.tsx` from an intermediate button/landing page into a direct server-side `redirect()` to Auth0, and adds a param-gated logged-out landing so signing out doesn't immediately re-bounce into the Auth0 widget.

> **Base branch:** this PR targets `fix/login-redirect-stripe-correctness` (the login-redirect/Stripe-correctness work it belongs to), **not** `main`. Merge that base first.

## Changes

- **`web/app/login/page.tsx`** — now an `async` server component:
  - `/login` (no query) server-`redirect()`s straight to `${getApiUrl()}/api/auth/login` (which `authorize_redirect`s to Auth0). No button rendered.
  - OIDC-disabled branch still `redirect("/workspaces")`.
  - `/login?signedout=1` renders a minimal "You have been signed out" landing with a single "Sign in" link → `${getApiUrl()}/api/auth/login` (no auto-redirect), so logout doesn't bounce straight back into the widget.
  - `searchParams` is awaited (Next 16 async `searchParams`).
- **`api/marrow/routers/auth.py`** — `logout` now sets `post_logout_redirect_uri = config.frontend_url + "/login?signedout=1"` so the IdP returns the user to the logged-out landing.

No `proxy.ts`/`middleware.ts` was added (would break `npm run pages:build`). No marketing-site change needed — `app.marrow.so` CTAs already funnel `/` → `/home` → `redirect("/login")`.

## Acceptance criteria

- [x] `/login` (no query) server-redirects to `${getApiUrl()}/api/auth/login`; no button.
- [x] OIDC-disabled branch still `redirect("/workspaces")`.
- [x] `/login?signedout=1` renders the minimal landing with a single Sign in link, no auto-redirect.
- [x] `searchParams` awaited in the server component.
- [x] `routers/auth.py` logout uses `post_logout_redirect_uri = frontend_url + "/login?signedout=1"`.
- [x] `cd web && npm run build && npm run lint` pass.

## Ops note before deploy

Add `…/login?signedout=1` to Auth0 **Allowed Logout URLs** before deploying (per PRD open question), otherwise the post-logout redirect is rejected.

## Test plan

Manual smoke:
- `/login` → Auth0 widget directly.
- `app.marrow.so` root while unauthenticated → `/home` → `/login` → Auth0.
- Sign out → `/login?signedout=1` landing (not the widget) → click Sign in → Auth0.

PRD: `references/prd-login-redirect-stripe-correctness.md` (decisions A1/A2/A3).

https://claude.ai/code/session_01ByBF2MRjtWbNH53zmTWwcr