### PR TITLE
Release 0.3.2: login redirect (#216) + Stripe StripeObject fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Each release also has fuller narrative notes (highlights, breaking changes, upgrade
 steps) on its [GitHub release](https://github.com/marrow-software/marrow/releases).
 
+## [0.3.2] — 2026-06-21
+
+### Fixed
+- Stripe webhook/reconcile silently dropping subscription updates: in `stripe>=15`,
+  `StripeObject` no longer subclasses `dict`, so `.get(...)` on a real webhook/reconcile
+  payload raised `AttributeError` — and the webhook swallowed it, so checkout never persisted
+  `subscription_status`/`tier`. All Stripe-object reads in `routers/billing.py` now use typed
+  attribute access; the webhook logs handler exceptions and still returns 200 so reconcile
+  self-heals without Stripe retry storms. Tests use real `StripeObject` fixtures so the bug
+  class fails CI. (#217, #218)
+
+### Changed
+- `/login` now server-redirects straight to the Auth0 login widget instead of rendering an
+  intermediate "Sign in with SSO" page. Signing out lands on a minimal `/login?signedout=1`
+  page with a single Sign-in link (no auto-bounce back into Auth0); the backend
+  `post_logout_redirect_uri` points there. (#216)
+
+### Added
+- Marrowglyph SVG served from `web/public` for Auth0 login-page branding. (#215)
+
 ## [0.3.1] — 2026-06-11
 
 ### Fixed
@@ -121,6 +141,9 @@ restore guarantee.
 - PostgreSQL full-text search.
 - BlockNote rich-text editor.
 
+[0.3.2]: https://github.com/marrow-software/marrow/releases/tag/v0.3.2
+[0.3.1]: https://github.com/marrow-software/marrow/releases/tag/v0.3.1
+[0.3.0]: https://github.com/marrow-software/marrow/releases/tag/v0.3.0
 [0.2.9]: https://github.com/marrow-software/marrow/releases/tag/v0.2.9
 [0.1.1]: https://github.com/marrow-software/marrow/releases/tag/v0.1.1
 [0.1.0]: https://github.com/marrow-software/marrow/releases/tag/v0.1.0

--- a/api/marrow/routers/auth.py
+++ b/api/marrow/routers/auth.py
@@ -257,7 +257,7 @@ async def logout(request: Request):
             if end_session_endpoint:
                 params: dict[str, str] = {
                     "client_id": config.client_id,
-                    "post_logout_redirect_uri": config.frontend_url + "/login",
+                    "post_logout_redirect_uri": config.frontend_url + "/login?signedout=1",
                 }
                 if id_token_hint:
                     params["id_token_hint"] = id_token_hint

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,29 +1,26 @@
 import { redirect } from "next/navigation";
 import { getApiUrl, getOidcEnabled } from "@/lib/runtime-config";
+import { Button } from "@/components/ui/button";
 
-export default function LoginPage() {
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ signedout?: string }>;
+}) {
   if (!getOidcEnabled()) {
     redirect("/workspaces");
   }
 
   const apiUrl = getApiUrl();
+  const { signedout } = await searchParams;
 
-  return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="w-full max-w-sm space-y-6 text-center">
-        <div className="space-y-2">
-          <h1 className="text-2xl font-bold tracking-tight">Marrow</h1>
-          <p className="text-muted-foreground text-sm">
-            Sign in to access your workspace
-          </p>
-        </div>
-        <a
-          href={`${apiUrl}/api/auth/login`}
-          className="inline-flex h-9 w-full items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-        >
-          Sign in with SSO
-        </a>
-      </div>
-    </div>
-  );
+  if (signedout) {
+    return (
+      <Button render={<a href={`${apiUrl}/api/auth/login`} />}>
+        You have been signed out. Click here to sign in again.
+      </Button>
+    );
+  }
+
+  redirect(`${apiUrl}/api/auth/login`);
 }


### PR DESCRIPTION
## Summary

Brings the **login-redirect** work (#216) onto `main` and cuts the **v0.3.2** changelog entry. The Stripe StripeObject fix (#217/#218) already landed on `main` via #218 — this PR documents it in the changelog alongside #216 and #215 so the `v0.3.2` tag covers the full set.

**Merge with "Rebase and merge"** so #216 + the changelog commit replay on top of #218 (disjoint files — `login/page.tsx`/`auth.py` vs `billing.py` vs `CHANGELOG.md` — no conflicts).

## What's in v0.3.2 (everything since v0.3.1)

- **#215** — marrowglyph SVG for Auth0 branding *(already on main)*
- **#216** — `/login` redirects straight to Auth0 + `/login?signedout=1` logged-out landing *(this branch)*
- **#217/#218** — StripeObject attribute-access fix; webhook logs + returns 200 *(already on main)*

## Verification

- `cd api && pytest` → **239 passed**; `ruff check` + `ruff format --check` clean
- `cd web && npm run build` passes; `npm run lint` 0 errors (pre-existing warnings only)

## ⚠️ Before the v0.3.2 tag is pushed (production deploy)

Add `https://app.marrow.so/login?signedout=1` to Auth0 **Allowed Logout URLs** — #216 sets `post_logout_redirect_uri` to that path, and logout breaks in prod if it isn't allowed. This PR's merge does **not** deploy; only the tag push does.

https://claude.ai/code/session_01ByBF2MRjtWbNH53zmTWwcr