### PR TITLE
fix(login): force-dynamic /login (hotfix Workers 500) — v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Each release also has fuller narrative notes (highlights, breaking changes, upgrade
 steps) on its [GitHub release](https://github.com/marrow-software/marrow/releases).
 
+## [0.3.3] — 2026-06-21
+
+### Fixed
+- Production login 500: the v0.3.2 `/login` page (an async server component reading
+  `searchParams`) was statically prerendered with build-time env and crashed on the Workers
+  runtime at request time, breaking the `/ → /home → /login` sign-in path. `/login` is now
+  `export const dynamic = "force-dynamic"`, so it always renders per request with runtime env.
+  (#216 follow-up)
+
 ## [0.3.2] — 2026-06-21
 
 ### Fixed
@@ -141,6 +150,7 @@ restore guarantee.
 - PostgreSQL full-text search.
 - BlockNote rich-text editor.
 
+[0.3.3]: https://github.com/marrow-software/marrow/releases/tag/v0.3.3
 [0.3.2]: https://github.com/marrow-software/marrow/releases/tag/v0.3.2
 [0.3.1]: https://github.com/marrow-software/marrow/releases/tag/v0.3.1
 [0.3.0]: https://github.com/marrow-software/marrow/releases/tag/v0.3.0

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -2,6 +2,12 @@ import { redirect } from "next/navigation";
 import { getApiUrl, getOidcEnabled } from "@/lib/runtime-config";
 import { Button } from "@/components/ui/button";
 
+// Never statically prerender: this page branches on runtime env
+// (getOidcEnabled / getApiUrl, read from process.env per request on Workers)
+// and reads searchParams. A static prerender bakes in build-time env and then
+// 500s on Workers when it reads searchParams at request time.
+export const dynamic = "force-dynamic";
+
 export default async function LoginPage({
   searchParams,
 }: {


### PR DESCRIPTION
## Summary

**Hotfix for a production login outage introduced by v0.3.2.** The web Worker has already been rolled back to v0.3.1 to restore service; this PR is the proper fix-forward for v0.3.3.

### What broke
v0.3.2 shipped #216's `/login` rewrite — an `async` server component that reads `searchParams`. The route was statically prerendered at build time (when OIDC is disabled, so the prerender baked in `redirect("/workspaces")`). On the Workers runtime with OIDC enabled it re-evaluated, read `searchParams` in a static context, and returned **500** on every hit — taking down the live sign-in path `/ → /home → /login`.

### The fix
`export const dynamic = "force-dynamic"` on `web/app/login/page.tsx`, so the route always renders per request with runtime env (like `/home`). One-line change + comment.

## Verification (on the real Workers runtime — the gap that let v0.3.2 through)
- `npm run build`: `/login` now classifies as `ƒ (Dynamic)` (was `○ Static`).
- `npm run pages:build` (OpenNext Cloudflare adapter): succeeds.
- `wrangler dev` against the built worker, OIDC enabled via `wrangler.toml [vars]`:
  - `/login` → `307 → https://api.marrow.so/api/auth/login`
  - `/login?signedout=1` → `200` with the signed-out landing + sign-in link

## Follow-up (not in this PR)
CI builds with `npm run build` but doesn't exercise the Workers runtime, which is why this slipped. Worth adding a `pages:build` (and ideally a smoke curl) step to `ci.yml` so Workers-only runtime breakage is caught pre-merge.

https://claude.ai/code/session_01ByBF2MRjtWbNH53zmTWwcr