### PR TITLE
Update environment configuration and README for v0.3.3 release

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -3,19 +3,17 @@
 
 # --- Required ---
 SECRET_KEY=replace-with-a-long-random-string
-MARROW_API_URL=https://api.marrow.so
+MARROW_API_URL=https://api.example.com
 
 # --- Database ---
-# Self-hosted (docker-compose.prod.yml): set POSTGRES_PASSWORD — DSN is built automatically.
+# docker-compose.prod.yml builds the DSN from these — set POSTGRES_PASSWORD.
 POSTGRES_PASSWORD=replace-with-a-strong-password
 # POSTGRES_USER=marrow
 # POSTGRES_DB=marrow
-# Cloudflare / Neon: set DATABASE_URL directly as a wrangler secret instead.
-# DATABASE_URL=postgresql://marrow:<password>@<host>.neon.tech/<db>?sslmode=require
 
 # --- Storage ---
-# Self-hosted: local filesystem is the default (STORAGE_PATH is set inside the container).
-# Cloudflare: use R2 — set these as wrangler secrets.
+# Local filesystem is the default (STORAGE_PATH is set inside the container).
+# Optional: S3-compatible object storage (e.g. Cloudflare R2).
 # STORAGE_BACKEND=r2
 # R2_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
 # R2_ACCESS_KEY_ID=
@@ -27,16 +25,16 @@ POSTGRES_PASSWORD=replace-with-a-strong-password
 # OIDC_ISSUER=
 # OIDC_CLIENT_ID=
 # OIDC_CLIENT_SECRET=
-# OIDC_REDIRECT_URI=https://api.marrow.so/api/auth/callback
-# FRONTEND_URL=https://app.marrow.so
-# COOKIE_DOMAIN=.marrow.so
+# OIDC_REDIRECT_URI=https://api.example.com/api/auth/callback
+# FRONTEND_URL=https://app.example.com
+# COOKIE_DOMAIN=.example.com
 # MARROW_OIDC_ENABLED=true
 # API key (for CLI/scripts, or as sole auth for solo use):
 # API_KEY=
 # MARROW_API_KEY=  # same value, browser-visible
 
 # --- Optional ---
-# MARROW_VERSION=latest
+# MARROW_VERSION=v0.3.3
 # API_PORT=8000
 # WEB_PORT=3000
-# CORS_ORIGINS=https://app.marrow.so
+# CORS_ORIGINS=https://app.example.com

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -34,6 +34,7 @@ POSTGRES_PASSWORD=replace-with-a-strong-password
 # MARROW_API_KEY=  # same value, browser-visible
 
 # --- Optional ---
+# Pin the GHCR API image tag. Must match the git tag you checked out; update on upgrade.
 # MARROW_VERSION=v0.3.3
 # API_PORT=8000
 # WEB_PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Marrow
 
+[![CI](https://github.com/marrow-software/marrow/actions/workflows/ci.yml/badge.svg)](https://github.com/marrow-software/marrow/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/marrow-software/marrow)](https://github.com/marrow-software/marrow/releases)
+[![License](https://img.shields.io/github/license/marrow-software/marrow)](https://github.com/marrow-software/marrow/blob/main/LICENSE)
+
 **Your knowledge, owned outright. No landlords. No lock-in. No surprises.**
 
 Marrow is a self-hosted, open-source knowledge base built on one non-negotiable principle: if you have your data, you can always come back. Export, wipe, restore. Every time. No exceptions.
@@ -23,14 +27,14 @@ These are not aspirations. They are constraints that every architectural and pro
 1. **Restore guarantee** — A Marrow export bundle is restorable to an exact replica of the original workspace. A failing restore test is a critical bug.
 2. **Transparent format** — Markdown, JSON, attachments in a zip. No proprietary blobs.
 3. **Append-only history** — Every save creates a revision. Old revisions are never modified or deleted (enforced by a database trigger).
-4. **Pluggable storage** — Local filesystem or Cloudflare R2. Business logic never bypasses the storage adapter.
+4. **Pluggable storage** — Local filesystem or S3-compatible object storage. Business logic never bypasses the storage adapter.
 5. **Self-hosted by default** — Your data stays on infrastructure you control.
 
 See **[Restore guarantee](./docs/src/content/docs/concepts/restore-guarantee.md)** for the full explanation.
 
 ---
 
-## What Marrow is (v0.2)
+## Features
 
 - Content organized in a tree: Organizations → Workspaces → Spaces → Folders / Pages
 - BlockNote-powered editor with code blocks, tables, page links, and `@` mentions
@@ -40,22 +44,61 @@ See **[Restore guarantee](./docs/src/content/docs/concepts/restore-guarantee.md)
 - Backlinks — every page knows what links to it
 - Stars, watches, and per-user Inbox (notifications for edits and `@` mentions)
 - View-only share links for any page or folder (no account required to view)
+- Global Home dashboard — recently edited pages, starred items, and Inbox across all workspaces
+- Organization onboarding for first-run setup
 - File attachments
 - Full-text search across a workspace
 - Append-only revision history on every save
 - One-command export to a transparent zip bundle (full or slim)
 - One-command restore from any export bundle (forwards-compatible across versions)
 - OIDC authentication with org-level RBAC (owner / editor / viewer)
-- Pluggable storage (local filesystem; Cloudflare R2)
+- Pluggable storage (local filesystem; S3-compatible backends such as Cloudflare R2)
 
 ---
 
-## Quickstart (development)
+## Self-hosting
+
+The recommended production path is Docker Compose. The API image is pulled from GHCR; the web image is built locally from source.
+
+**Prerequisites:** Docker and Docker Compose.
+
+```bash
+git clone https://github.com/marrow-software/marrow.git
+cd marrow
+git checkout v0.3.3          # recommended for production
+
+cp .env.prod.example .env
+# edit .env — SECRET_KEY, POSTGRES_PASSWORD, MARROW_API_URL (your public API URL)
+
+docker compose -f docker-compose.prod.yml up -d --build
+curl http://localhost:8000/health
+# open http://localhost:3000
+```
+
+**Auth is required in production.** Set OIDC (preferred for multi-user) or `API_KEY` / `MARROW_API_KEY` for solo use. Without either, all requests are allowed — fine for local dev, never for production. See **[OIDC](./docs/src/content/docs/configuration/oidc.md)** for setup.
+
+**Reverse proxy:** The Compose file does not include TLS termination. In production, put Caddy, Traefik, or nginx in front of the web container. If the API and web run on different hosts, set `CORS_ORIGINS` to the web origin and `COOKIE_DOMAIN` to the parent domain so the session cookie is shared.
+
+**Updating:**
+
+```bash
+git checkout v0.3.x
+docker compose -f docker-compose.prod.yml pull api
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+The API image is pulled from GHCR; the web image is rebuilt from source.
+
+Full reference: **[Docker Compose](./docs/src/content/docs/deployment/docker-compose.md)** · **[Environment variables](./docs/src/content/docs/configuration/env-vars.md)**
+
+---
+
+## Development
 
 **Prerequisites:** Python 3.11+, Node.js 20+, Docker.
 
 ```bash
-git clone https://github.com/spmcgraw/marrow.git
+git clone https://github.com/marrow-software/marrow.git
 cd marrow
 
 # Database
@@ -83,26 +126,16 @@ For more depth see **[Quickstart](./docs/src/content/docs/getting-started/quicks
 
 ---
 
-## Production deployment
-
-- **[Docker Compose](./docs/src/content/docs/deployment/docker-compose.md)** — recommended. Build images, configure `.env`, `docker compose -f docker-compose.prod.yml up`.
-- **[Cloudflare](./docs/src/content/docs/deployment/cloudflare.md)** — Workers + Containers + Neon + R2. The full Cloudflare stack is supported as of v0.2.
-
-See **[Environment variables](./docs/src/content/docs/configuration/env-vars.md)** for the full config reference and **[OIDC](./docs/src/content/docs/configuration/oidc.md)** for sign-in setup.
-
----
-
 ## Tech stack
 
 | Layer | Choice |
 | --- | --- |
 | Backend | FastAPI, SQLAlchemy, Alembic |
 | Database | PostgreSQL 16 |
-| Product app | Next.js 16, React 19, Tailwind 4, Base UI, BlockNote (`web/`) |
-| Marketing site | Next.js 16, static export to Cloudflare Pages (`web-marketing/`) |
-| Auth | OIDC (any provider, Auth0 recommended for multi-provider) + API key fallback |
+| Frontend | Next.js 16, React 19, Tailwind 4, Base UI, BlockNote (`web/`) |
+| Auth | OIDC (any provider) + API key fallback |
 | Search | PostgreSQL FTS (Meilisearch later) |
-| Storage | Local filesystem; Cloudflare R2 |
+| Storage | Local filesystem; S3-compatible object storage |
 | CLI | Typer (`marrow export`, `marrow restore`) |
 
 ---

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ git checkout v0.3.3          # recommended for production
 
 cp .env.prod.example .env
 # edit .env — SECRET_KEY, POSTGRES_PASSWORD, MARROW_API_URL (your public API URL)
+# set MARROW_VERSION to the same tag you checked out (e.g. v0.3.3)
 
 docker compose -f docker-compose.prod.yml up -d --build
 curl http://localhost:8000/health
@@ -81,13 +82,17 @@ curl http://localhost:8000/health
 
 **Updating:**
 
+Check out the release tag, set `MARROW_VERSION` in `.env` to the same tag (so the API image and web build stay in sync), then pull and restart:
+
 ```bash
-git checkout v0.3.x
+git fetch --tags
+git checkout v0.3.4          # pick the release you want
+# edit .env — set MARROW_VERSION=v0.3.4 to match
 docker compose -f docker-compose.prod.yml pull api
 docker compose -f docker-compose.prod.yml up -d --build
 ```
 
-The API image is pulled from GHCR; the web image is rebuilt from source.
+The API image is pulled from GHCR using `MARROW_VERSION`; the web image is rebuilt from the checked-out source. If you skip updating `MARROW_VERSION`, `pull api` keeps resolving the old tag while the web container rebuilds from the new checkout.
 
 Full reference: **[Docker Compose](./docs/src/content/docs/deployment/docker-compose.md)** · **[Environment variables](./docs/src/content/docs/configuration/env-vars.md)**
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,7 +24,7 @@ services:
       retries: 5
 
   api:
-    image: ghcr.io/spmcgraw/marrow-api:${MARROW_VERSION:-latest}
+    image: ghcr.io/marrow-software/marrow-api:${MARROW_VERSION:-v0.3.3}
     restart: unless-stopped
     depends_on:
       db:
@@ -56,7 +56,10 @@ services:
              uvicorn main:app --host 0.0.0.0 --port 8000"
 
   web:
-    image: ghcr.io/spmcgraw/marrow-web:${MARROW_VERSION:-latest}
+    build:
+      context: ./web
+      dockerfile: Dockerfile
+    image: marrow-web:${MARROW_VERSION:-local}
     restart: unless-stopped
     depends_on:
       - api

--- a/docs/src/content/docs/configuration/env-vars.md
+++ b/docs/src/content/docs/configuration/env-vars.md
@@ -61,7 +61,7 @@ When using `docker-compose.prod.yml`, both files are replaced by a single root `
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `MARROW_VERSION` | `latest` | Image tag pulled from GHCR. |
+| `MARROW_VERSION` | `v0.3.3` (compose default) | GHCR API image tag. Set to the same git release tag you checked out; update in `.env` whenever you upgrade. Also labels the locally built web image. |
 | `POSTGRES_USER` | `marrow` | Postgres username. |
 | `POSTGRES_DB` | `marrow` | Postgres database name. |
 | `POSTGRES_PASSWORD` | — | **Required.** Postgres password. |

--- a/docs/src/content/docs/deployment/docker-compose.md
+++ b/docs/src/content/docs/deployment/docker-compose.md
@@ -37,17 +37,26 @@ docker compose -f docker-compose.prod.yml up -d
 `-v` removes the volume — only safe before you have real data.
 :::
 
-## 2. Pull and start
+## 2. Check out a release and start
+
+Pin a release tag so the API image and web source match:
 
 ```bash
-docker compose -f docker-compose.prod.yml up -d
+git fetch --tags
+git checkout v0.3.3          # recommended for production
+```
+
+Set `MARROW_VERSION` in `.env` to the same tag (e.g. `v0.3.3`), then:
+
+```bash
+docker compose -f docker-compose.prod.yml up -d --build
 ```
 
 This:
 
 1. Brings up PostgreSQL with a persistent volume (`postgres_data`).
-2. Pulls the API image from GHCR and runs `alembic upgrade head` then `uvicorn`.
-3. Pulls the web image from GHCR. The browser-visible config (`MARROW_API_URL`, `MARROW_API_KEY`, `MARROW_OIDC_ENABLED`) is read from container env at startup and written into `/config.js` — no rebuild needed when these change.
+2. Pulls the API image from GHCR (`ghcr.io/marrow-software/marrow-api:${MARROW_VERSION}`) and runs `alembic upgrade head` then `uvicorn`.
+3. Builds the web image from `./web` in the checked-out tree. The browser-visible config (`MARROW_API_URL`, `MARROW_API_KEY`, `MARROW_OIDC_ENABLED`) is read from container env at startup and written into `/config.js` — no rebuild needed when only those vars change.
 
 The API exposes port 8000 and the web exposes port 3000 by default. Override with `API_PORT` / `WEB_PORT`.
 
@@ -76,12 +85,19 @@ If the API and web are on different subdomains, set `CORS_ORIGINS` to the web or
 
 ## Updating
 
+Check out the new release, update `MARROW_VERSION` in `.env` to the same tag, then pull the API image and rebuild the web container:
+
 ```bash
-git pull
+git fetch --tags
+git checkout v0.3.4          # pick the release you want
+# edit .env — set MARROW_VERSION=v0.3.4 to match
+docker compose -f docker-compose.prod.yml pull api
 docker compose -f docker-compose.prod.yml up -d --build
 ```
 
-Migrations run automatically on container start.
+Migrations run automatically on API container start.
+
+If you skip updating `MARROW_VERSION`, `pull api` keeps resolving the old pinned tag while the web container rebuilds from the newly checked-out source — API and web versions can diverge.
 
 :::danger[Upgrading from v0.1 → v0.2]
 v0.2.0 ships a one-shot, **breaking** schema migration: the old `collections` and `pages` tables collapse into a single self-referential `nodes` tree (folders + pages). The migration runs automatically on the next container start, but it rewrites primary keys and cascades on existing data.


### PR DESCRIPTION
- Changed MARROW_API_URL and related URLs to use example.com for clarity.
- Updated MARROW_VERSION to v0.3.3 in the environment file.
- Enhanced README with new badges, updated features section, and clarified self-hosting instructions.
- Improved descriptions for pluggable storage options and authentication requirements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default API image registry/tag and switching web from a pulled image to a local build affects how every production deploy is assembled; mistakes in MARROW_VERSION can leave API and web on mismatched versions.
> 
> **Overview**
> **Aligns self-hosting documentation and production Compose with the v0.3.3 release** under the `marrow-software` org, with a clearer split between pulled API images and locally built web.
> 
> Production **`docker-compose.prod.yml`** now pulls **`ghcr.io/marrow-software/marrow-api`** (default tag **`v0.3.3`** instead of `latest`) and **builds the web service from `./web`** instead of pulling a prebuilt GHCR web image. **`.env.prod.example`**, **env-vars**, and **docker-compose** docs describe **`MARROW_VERSION`** as the tag that must match the checked-out git release for both API pull and web labeling, plus upgrade steps (`git checkout`, `pull api`, `up -d --build`) and a warning when API and web can diverge.
> 
> **README** adds CI/release/license badges, expands the feature list, adds a **Self-hosting** section (auth requirement, reverse proxy, updates), renames dev vs production sections, points clones at **`marrow-software/marrow`**, and de-emphasizes the standalone Cloudflare deployment page in favor of generic S3-compatible storage wording. Example URLs move from **`marrow.so`** to **`example.com`**; Neon/Cloudflare-only env comments are trimmed from the prod example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05e06dc7d8318ca6a6a1e3738d98c28bc44c0bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->