### PR TITLE
Enhance backlinks functionality and export/restore processes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -444,7 +444,7 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 >
 > **Search response shape (v0.2):** `SearchResultItem` fields are `node_id`, `name`, `snippet`, `space_id`, `space_name`, `node_path` (list of ancestor folder names, root→leaf), `rank`. The old `page_id`, `title`, `collection_id`, `collection_name` fields are gone.
 >
-> **Backlinks (#100, 2.6):** `GET /api/nodes/{nid}/backlinks` returns the nodes that link to `{nid}` (min role `viewer`, trashed sources excluded). `marrow/links.py` parses wiki-links and reconciles the `node_links` table on every page create/update via `reconcile_node_links()`. Export/restore calls `serialize_node_links()` / `rebuild_node_links()` to persist the index in `links.json`.
+> **Backlinks (#100, 2.6):** `GET /api/nodes/{nid}/backlinks` returns the nodes that link to `{nid}` (min role `viewer`, trashed sources excluded). `marrow/links.py` parses wiki-links (`/pages/{id}` and `/nodes/{id}` hrefs) and reconciles the `node_links` table on every page create/update via `reconcile_node_links()`. Export serializes the live DB index via `serialize_node_links()` into `links.json`; restore rebuilds it with `rebuild_node_links()`, honouring `manifest.include_trash` so links involving trashed nodes round-trip when the bundle was exported with `include_trash=True`.
 > **Node properties (#42, 2.4):** Folder nodes declare a property schema (key + `value_type` + `options`); every descendant page inherits it (nearest-ancestor wins) and may set its own value. Effective properties resolve at read time via the ancestor folder chain. Property keys+values fold into the page `search_vector` at weight C — a single `marrow_node_search_vector(uuid)` SQL helper computes the full vector and all node search triggers (revision-insert, name-change, and the new `node_properties` change trigger) keep it consistent. Frontend: `web/components/property-editor.tsx` renders chips/date pickers/dropdowns/checkboxes below the page title. Export/restore bundle bumped to **v4** (`node_properties` array in `manifest.json`); the v4 export/restore *handlers* still depend on the #132/#133 node-aware rewrite to run end-to-end, but the property serialization (`export.serialize_node_properties`) and restore loop are in place and symmetric.
 
 ### Storage Adapter Interface
@@ -472,7 +472,7 @@ marrow-export-{workspace-slug}-slim-{timestamp}.zip     # slim
 │       └── {revision-id}.json   # BlockNote JSON revisions (canonical)
 ├── assets/
 │   └── {attachment-id}{ext}
-└── links.json           # internal links, broken links, orphaned pages
+└── links.json           # node_links index (internal_links + orphaned_nodes; broken_links always [])
 ```
 
 **Schema versions**: v1/v2 were Markdown-only. v3 added `.json` as canonical. v4 (Marrow 0.2) carries the `nodes` tree (folders + pages, with `parent_id`, `position`, `deleted_at`) instead of the old `collections`+`pages` shape. Restore supports v1–v4 — older bundles are auto-upgraded onto the node tree on read.

--- a/api/marrow/export.py
+++ b/api/marrow/export.py
@@ -21,7 +21,6 @@ from the manifest in favour of a flat nodes list.
 
 import hashlib
 import json
-import re
 import zipfile
 from datetime import datetime, timezone
 from io import BytesIO
@@ -29,6 +28,7 @@ from pathlib import Path
 
 from sqlalchemy.orm import Session
 
+from .links import serialize_node_links
 from .models import Node, NodeProperty, Workspace
 from .storage import StorageAdapter
 
@@ -37,11 +37,6 @@ SCHEMA_VERSION = "4"
 
 def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
-
-
-def _extract_hrefs(content: str) -> list[str]:
-    """Return all link targets found in Markdown content."""
-    return re.findall(r"\[(?:[^\]]*)\]\(([^)]+)\)", content)
 
 
 def _collect_nodes(workspace: Workspace, include_trash: bool = False) -> list[Node]:
@@ -199,41 +194,28 @@ def blocks_to_markdown(content_json: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Link analysis (Markdown only — best-effort for JSON revisions)
+# Link index serialization (from node_links table)
 # ---------------------------------------------------------------------------
 
 
-def _build_links(nodes: list[Node], node_id_set: set[str]) -> dict:
-    internal_links: list[dict] = []
-    broken_links: list[dict] = []
+def _build_links(session: Session, nodes: list[Node]) -> dict:
+    """Build links.json payload from the live ``node_links`` index."""
+    page_nodes = [n for n in nodes if n.type == "page"]
+    page_ids = {n.id for n in page_nodes}
+    exported_ids = {str(nid) for nid in page_ids}
 
-    for node in nodes:
-        if node.type != "page" or node.current_revision is None:
-            continue
-        content = node.current_revision.content or ""
-        content_format = node.current_revision.content_format
-
-        if content_format == "json":
-            content = blocks_to_markdown(content)
-
-        for href in _extract_hrefs(content):
-            source = str(node.id)
-            # Strip both /nodes/ (v4) and /pages/ (v3/pre-migration) prefixes.
-            candidate = href.removeprefix("/nodes/").removeprefix("/pages/").rstrip("/")
-            if candidate in node_id_set:
-                internal_links.append(
-                    {"source_node_id": source, "target_node_id": candidate, "href": href}
-                )
-            elif href.startswith("/") or not href.startswith(("http://", "https://")):
-                broken_links.append({"source_node_id": source, "href": href})
+    internal_links = [
+        lnk
+        for lnk in serialize_node_links(session, page_ids)
+        if lnk["target_node_id"] in exported_ids
+    ]
 
     linked_ids = {lnk["target_node_id"] for lnk in internal_links}
-    page_nodes = [n for n in nodes if n.type == "page"]
     orphaned = [str(n.id) for n in page_nodes if str(n.id) not in linked_ids]
 
     return {
         "internal_links": internal_links,
-        "broken_links": broken_links,
+        "broken_links": [],
         "orphaned_nodes": orphaned,
     }
 
@@ -300,7 +282,7 @@ def _build_manifest(
         node_records.append(rec)
 
     org = workspace.organization
-    return {
+    manifest: dict = {
         "schema_version": SCHEMA_VERSION,
         "export_timestamp": export_timestamp,
         "organization": {
@@ -331,6 +313,9 @@ def _build_manifest(
         "attachments": attachment_records,
         "node_properties": node_properties or [],
     }
+    if include_trash:
+        manifest["include_trash"] = True
+    return manifest
 
 
 def estimate_export_sizes(
@@ -392,7 +377,6 @@ def export_workspace(
         raise ValueError(f"Workspace '{slug}' not found")
 
     nodes = _collect_nodes(workspace, include_trash=include_trash)
-    node_id_set = {str(n.id) for n in nodes if n.type == "page"}
 
     # Eagerly touch lazy-loaded relationships while the session is open.
     for node in nodes:
@@ -472,7 +456,7 @@ def export_workspace(
                 }
             )
 
-        zf.writestr("links.json", json.dumps(_build_links(nodes, node_id_set), indent=2))
+        zf.writestr("links.json", json.dumps(_build_links(session, nodes), indent=2))
 
         node_id_list = [n.id for n in nodes]
         prop_rows = (

--- a/api/marrow/export.py
+++ b/api/marrow/export.py
@@ -211,9 +211,7 @@ def _reconcile_export_links(
         else:
             content = ""
             fmt = "markdown"
-        reconcile_node_links(
-            session, node.id, content, fmt, include_trash=include_trash
-        )
+        reconcile_node_links(session, node.id, content, fmt, include_trash=include_trash)
 
 
 def _build_links(session: Session, nodes: list[Node]) -> dict:

--- a/api/marrow/export.py
+++ b/api/marrow/export.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 from sqlalchemy.orm import Session
 
-from .links import serialize_node_links
+from .links import reconcile_node_links, serialize_node_links
 from .models import Node, NodeProperty, Workspace
 from .storage import StorageAdapter
 
@@ -196,6 +196,24 @@ def blocks_to_markdown(content_json: str) -> str:
 # ---------------------------------------------------------------------------
 # Link index serialization (from node_links table)
 # ---------------------------------------------------------------------------
+
+
+def _reconcile_export_links(
+    session: Session, nodes: list[Node], *, include_trash: bool = False
+) -> None:
+    """Sync ``node_links`` from each exported page's current revision content."""
+    for node in nodes:
+        if node.type != "page":
+            continue
+        if node.current_revision:
+            content = node.current_revision.content
+            fmt = node.current_revision.content_format
+        else:
+            content = ""
+            fmt = "markdown"
+        reconcile_node_links(
+            session, node.id, content, fmt, include_trash=include_trash
+        )
 
 
 def _build_links(session: Session, nodes: list[Node]) -> dict:
@@ -456,6 +474,7 @@ def export_workspace(
                 }
             )
 
+        _reconcile_export_links(session, nodes, include_trash=include_trash)
         zf.writestr("links.json", json.dumps(_build_links(session, nodes), indent=2))
 
         node_id_list = [n.id for n in nodes]

--- a/api/marrow/links.py
+++ b/api/marrow/links.py
@@ -10,8 +10,9 @@ A page links to another node in two ways:
   ``nodeId`` prop is treated as a link for forward-compatibility.
 
 The set of targets parsed from a node's current content is reconciled into the
-``node_links`` table on every save (add new, remove stale). Export serializes
-the index into ``links.json``; restore rebuilds it.
+``node_links`` table on every save (add new, remove stale). Export reconciles
+from current revision content before serializing the index into ``links.json``;
+restore rebuilds it.
 """
 
 import json
@@ -107,22 +108,24 @@ def reconcile_node_links(
     source_node_id: uuid.UUID,
     content: str | None,
     content_format: str,
+    *,
+    include_trash: bool = False,
 ) -> None:
     """Make ``node_links`` for *source_node_id* match the links in *content*.
 
     Adds rows for new targets and deletes rows for targets no longer present.
-    Self-links and links to missing or trashed nodes are dropped. The caller
-    is responsible for committing the session.
+    Self-links and links to missing nodes are dropped; links to soft-deleted
+    nodes are kept only when *include_trash* is True (export with trash).
+    The caller is responsible for committing the session.
     """
     targets = extract_link_targets(content, content_format)
     targets.discard(source_node_id)
 
     if targets:
-        live = set(
-            db.execute(
-                select(Node.id).where(Node.id.in_(targets), Node.deleted_at.is_(None))
-            ).scalars()
-        )
+        live_query = select(Node.id).where(Node.id.in_(targets))
+        if not include_trash:
+            live_query = live_query.where(Node.deleted_at.is_(None))
+        live = set(db.execute(live_query).scalars())
         targets &= live
 
     existing = set(

--- a/api/marrow/links.py
+++ b/api/marrow/links.py
@@ -3,7 +3,8 @@
 A page links to another node in two ways:
 
 * **Wiki-links** — a Markdown/BlockNote link whose href points at a node, e.g.
-  ``/w/{workspace}/pages/{node-id}`` or the export-relative ``/pages/{node-id}``.
+  ``/w/{workspace}/pages/{node-id}``, ``/nodes/{node-id}``, or the export-relative
+  ``/pages/{node-id}``.
 * **`@` mentions** — a BlockNote ``mention`` inline element. User mentions carry
   a ``userId`` (not a node) and are ignored here; a mention that carries a
   ``nodeId`` prop is treated as a link for forward-compatibility.
@@ -33,12 +34,12 @@ _UUID = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F
 # adversarial input (ReDoS). Requires Python 3.11+.
 _MD_HREF_RE = re.compile(r"\[(?>[^\]]*)\]\(([^)]+)\)")
 
-# Pull the node id out of a /pages/{id} href (with or without a /w/{ws} prefix).
-_PAGE_HREF_RE = re.compile(rf"/pages/({_UUID})(?:[/?#]|$)")
+# Pull the node id out of a /pages/{id} or /nodes/{id} href (with or without a /w/{ws} prefix).
+_NODE_HREF_RE = re.compile(rf"/(?:pages|nodes)/({_UUID})(?:[/?#]|$)")
 
 
 def _href_to_node_id(href: str) -> uuid.UUID | None:
-    match = _PAGE_HREF_RE.search(href)
+    match = _NODE_HREF_RE.search(href)
     if match is None:
         return None
     try:
@@ -155,14 +156,15 @@ def serialize_node_links(db: Session, node_ids: set[uuid.UUID]) -> list[dict]:
     return [{"source_node_id": str(src), "target_node_id": str(tgt)} for src, tgt in rows]
 
 
-def rebuild_node_links(db: Session, links: list[dict]) -> None:
+def rebuild_node_links(db: Session, links: list[dict], *, include_trash: bool = False) -> None:
     """Recreate ``node_links`` rows from an export *links* list, on restore.
 
     Idempotent: deletes any existing links for all source nodes in the list
     before re-inserting, so retried restores don't hit unique-constraint errors.
     Skips entries whose endpoints are missing so a partial bundle still
-    restores cleanly without FK violations. The caller is responsible for
-    committing the session.
+    restores cleanly without FK violations. When *include_trash* is True,
+    links involving soft-deleted nodes are kept (matching ``include_trash``
+    exports). The caller is responsible for committing the session.
     """
     candidates: list[tuple[uuid.UUID, uuid.UUID]] = []
     for link in links:
@@ -178,9 +180,10 @@ def rebuild_node_links(db: Session, links: list[dict]) -> None:
         return
 
     all_ids = {nid for pair in candidates for nid in pair}
-    live_ids: set[uuid.UUID] = set(
-        db.execute(select(Node.id).where(Node.id.in_(all_ids), Node.deleted_at.is_(None))).scalars()
-    )
+    live_query = select(Node.id).where(Node.id.in_(all_ids))
+    if not include_trash:
+        live_query = live_query.where(Node.deleted_at.is_(None))
+    live_ids: set[uuid.UUID] = set(db.execute(live_query).scalars())
 
     valid = [(src, tgt) for src, tgt in candidates if src in live_ids and tgt in live_ids]
     if not valid:

--- a/api/marrow/restore.py
+++ b/api/marrow/restore.py
@@ -72,6 +72,7 @@ def restore_workspace(
         )
 
         is_slim = manifest.get("slim", False)
+        include_trash = manifest.get("include_trash", False)
 
         ws_meta = manifest["workspace"]
         ws_id = uuid.UUID(ws_meta["id"])
@@ -166,7 +167,7 @@ def restore_workspace(
                 }
                 for lnk in raw_links
             ]
-            rebuild_node_links(session, normalized)
+            rebuild_node_links(session, normalized, include_trash=include_trash)
 
     return ws_meta["slug"]
 

--- a/api/tests/test_backlinks.py
+++ b/api/tests/test_backlinks.py
@@ -45,6 +45,11 @@ class TestExtractLinkTargets:
         content = f"[link](/pages/{tid})"
         assert extract_link_targets(content, "markdown") == {tid}
 
+    def test_markdown_nodes_href(self):
+        tid = uuid.uuid4()
+        content = f"[link](/nodes/{tid})"
+        assert extract_link_targets(content, "markdown") == {tid}
+
     def test_markdown_external_links_ignored(self):
         content = "[ext](https://example.com) and [anchor](#section)"
         assert extract_link_targets(content, "markdown") == set()
@@ -351,3 +356,142 @@ class TestSerializeRebuild:
         finally:
             db.rollback()
             db.close()
+
+    def test_rebuild_keeps_trashed_endpoints_when_include_trash(self):
+        from datetime import datetime, timezone
+
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            _, _, space = _make_workspace(db)
+            live = _make_page(db, space, "Live")
+            trashed = _make_page(db, space, "Trashed")
+            trashed.deleted_at = datetime.now(timezone.utc)
+            db.flush()
+            link = {"source_node_id": str(live.id), "target_node_id": str(trashed.id)}
+            db.commit()
+
+            rebuild_node_links(db, [link], include_trash=True)
+            db.commit()
+
+            rows = (
+                db.query(NodeLink)
+                .filter_by(source_node_id=live.id, target_node_id=trashed.id)
+                .all()
+            )
+            assert len(rows) == 1
+        finally:
+            db.rollback()
+            db.close()
+
+    def test_rebuild_skips_trashed_endpoints_by_default(self):
+        from datetime import datetime, timezone
+
+        from marrow.dependencies import get_db
+
+        db = next(get_db())
+        try:
+            _, _, space = _make_workspace(db)
+            live = _make_page(db, space, "Live")
+            trashed = _make_page(db, space, "Trashed")
+            trashed.deleted_at = datetime.now(timezone.utc)
+            db.flush()
+            link = {"source_node_id": str(live.id), "target_node_id": str(trashed.id)}
+            db.commit()
+
+            rebuild_node_links(db, [link])
+            db.commit()
+
+            assert (
+                db.query(NodeLink)
+                .filter_by(source_node_id=live.id, target_node_id=trashed.id)
+                .count()
+                == 0
+            )
+        finally:
+            db.rollback()
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# Export / restore round-trip of links involving trashed nodes
+# ---------------------------------------------------------------------------
+
+
+class TestExportRestoreLinks:
+    def test_include_trash_restores_links_to_trashed_nodes(self, tmp_path):
+        import zipfile
+        from datetime import datetime, timezone
+
+        from sqlalchemy import create_engine, text
+        from sqlalchemy.orm import Session
+
+        from marrow.export import export_workspace
+        from marrow.restore import restore_workspace
+        from marrow.storage import StorageAdapter
+
+        class MemStorage(StorageAdapter):
+            def read(self, attachment_id: str, filename: str) -> bytes:
+                raise FileNotFoundError(attachment_id)
+
+            def write(self, attachment_id: str, filename: str, data: bytes) -> None:
+                pass
+
+        engine = create_engine(DATABASE_URL)
+        org_id = None
+        with Session(engine) as session:
+            org = Organization(slug=f"bl-org-{uuid.uuid4().hex[:6]}", name="BL Org")
+            session.add(org)
+            session.flush()
+            ws = Workspace(org_id=org.id, slug=f"bl-ws-{uuid.uuid4().hex[:6]}", name="BL WS")
+            session.add(ws)
+            session.flush()
+            space = Space(workspace_id=ws.id, slug="main", name="Main")
+            session.add(space)
+            session.flush()
+
+            live = _make_page(session, space, "Live")
+            trashed = _make_page(session, space, "Trashed")
+            session.flush()
+            reconcile_node_links(
+                session, live.id, f"[trashed](/pages/{trashed.id})", "markdown"
+            )
+            trashed.deleted_at = datetime.now(timezone.utc)
+            session.commit()
+            org_id = org.id
+            ws_slug = ws.slug
+            live_id, trashed_id = live.id, trashed.id
+
+            bundle = export_workspace(
+                ws_slug, session, MemStorage(), output_path=tmp_path, include_trash=True
+            )
+
+        with zipfile.ZipFile(bundle) as zf:
+            links = json.loads(zf.read("links.json"))
+            manifest = json.loads(zf.read("manifest.json"))
+        assert manifest.get("include_trash") is True
+        assert links["internal_links"] == [
+            {"source_node_id": str(live_id), "target_node_id": str(trashed_id)}
+        ]
+
+        with Session(engine) as session:
+            session.execute(text("DELETE FROM organizations WHERE id = :id"), {"id": org_id})
+            session.commit()
+
+        with Session(engine) as session:
+            restore_workspace(bundle, session, MemStorage())
+            session.commit()
+
+        with Session(engine) as session:
+            rows = (
+                session.query(NodeLink)
+                .filter_by(source_node_id=live_id, target_node_id=trashed_id)
+                .all()
+            )
+            assert len(rows) == 1
+
+            session.execute(text("DELETE FROM organizations WHERE id = :id"), {"id": org_id})
+            session.commit()
+
+        engine.dispose()

--- a/api/tests/test_backlinks.py
+++ b/api/tests/test_backlinks.py
@@ -454,7 +454,14 @@ class TestExportRestoreLinks:
             live = _make_page(session, space, "Live")
             trashed = _make_page(session, space, "Trashed")
             session.flush()
-            reconcile_node_links(session, live.id, f"[trashed](/pages/{trashed.id})", "markdown")
+            # Link in content only — node_links index never reconciled on save.
+            rev = Revision(
+                node_id=live.id,
+                content=f"[trashed](/pages/{trashed.id})",
+            )
+            session.add(rev)
+            session.flush()
+            live.current_revision_id = rev.id
             trashed.deleted_at = datetime.now(timezone.utc)
             session.commit()
             org_id = org.id

--- a/api/tests/test_backlinks.py
+++ b/api/tests/test_backlinks.py
@@ -454,9 +454,7 @@ class TestExportRestoreLinks:
             live = _make_page(session, space, "Live")
             trashed = _make_page(session, space, "Trashed")
             session.flush()
-            reconcile_node_links(
-                session, live.id, f"[trashed](/pages/{trashed.id})", "markdown"
-            )
+            reconcile_node_links(session, live.id, f"[trashed](/pages/{trashed.id})", "markdown")
             trashed.deleted_at = datetime.now(timezone.utc)
             session.commit()
             org_id = org.id

--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -14,6 +14,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from marrow.export import SCHEMA_VERSION, estimate_export_sizes, export_workspace
+from marrow.links import reconcile_node_links
 from marrow.models import Attachment, Node, Organization, Revision, Space, Workspace
 from marrow.storage import StorageAdapter
 
@@ -123,6 +124,9 @@ def seeded(session):
     session.flush()
 
     node1.current_revision_id = rev1c.id
+    session.flush()
+
+    reconcile_node_links(session, node1.id, link_content, "markdown")
     session.flush()
 
     # Attachment on node1.

--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -337,6 +337,7 @@ def test_export_reconciles_stale_links_from_content(session, tmp_path):
         {"source_node_id": str(src.id), "target_node_id": str(tgt.id)}
     ]
 
+
 def test_attachment_hash_mismatch_raises(seeded, session, tmp_path):
     att = seeded["attachment"]
     bad_storage = FakeStorageAdapter({(str(att.id), "photo.png"): b"corrupted bytes"})

--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -278,6 +278,65 @@ def test_links_json(seeded, session, tmp_path):
     assert node1_id in links["orphaned_nodes"]
 
 
+def test_export_reconciles_stale_links_from_content(session, tmp_path):
+    """Wiki links in page content but missing from node_links are exported."""
+    from marrow.models import NodeLink
+
+    org = Organization(slug="stale-links-org", name="Stale Links Org")
+    session.add(org)
+    session.flush()
+
+    ws = Workspace(org_id=org.id, slug="stale-links-ws", name="Stale Links WS")
+    session.add(ws)
+    session.flush()
+
+    space = Space(workspace_id=ws.id, slug="sp", name="Space")
+    session.add(space)
+    session.flush()
+
+    src = Node(
+        space_id=space.id,
+        parent_id=None,
+        type="page",
+        name="Source",
+        slug="source",
+        position="a0",
+    )
+    tgt = Node(
+        space_id=space.id,
+        parent_id=None,
+        type="page",
+        name="Target",
+        slug="target",
+        position="a1",
+    )
+    session.add_all([src, tgt])
+    session.flush()
+
+    link_content = f"# Source\n[See target](/nodes/{tgt.id})"
+    rev = Revision(node_id=src.id, content=link_content)
+    session.add(rev)
+    session.flush()
+    src.current_revision_id = rev.id
+    session.flush()
+
+    assert session.query(NodeLink).filter_by(source_node_id=src.id).count() == 0
+
+    storage = FakeStorageAdapter()
+    result = export_workspace(
+        slug="stale-links-ws",
+        session=session,
+        storage=storage,
+        output_path=tmp_path,
+    )
+
+    with zipfile.ZipFile(result) as zf:
+        links = json.loads(zf.read("links.json"))
+
+    assert links["internal_links"] == [
+        {"source_node_id": str(src.id), "target_node_id": str(tgt.id)}
+    ]
+
 def test_attachment_hash_mismatch_raises(seeded, session, tmp_path):
     att = seeded["attachment"]
     bad_storage = FakeStorageAdapter({(str(att.id), "photo.png"): b"corrupted bytes"})

--- a/api/tests/test_round_trip.py
+++ b/api/tests/test_round_trip.py
@@ -286,7 +286,9 @@ def test_export_restore_round_trip(db_url, tmp_path):
         }
         original["node_links"] = [
             {"source_node_id": str(row.source_node_id), "target_node_id": str(row.target_node_id)}
-            for row in session.query(NodeLink).order_by(NodeLink.source_node_id, NodeLink.target_node_id)
+            for row in session.query(NodeLink).order_by(
+                NodeLink.source_node_id, NodeLink.target_node_id
+            )
         ]
 
         session.commit()
@@ -415,7 +417,9 @@ def test_export_restore_round_trip(db_url, tmp_path):
         # node_links index — must round-trip via links.json
         restored_links = [
             {"source_node_id": str(row.source_node_id), "target_node_id": str(row.target_node_id)}
-            for row in session.query(NodeLink).order_by(NodeLink.source_node_id, NodeLink.target_node_id)
+            for row in session.query(NodeLink).order_by(
+                NodeLink.source_node_id, NodeLink.target_node_id
+            )
         ]
         assert restored_links == original["node_links"], (
             f"node_links mismatch after restore. Got: {restored_links} Expected: {original['node_links']}"

--- a/api/tests/test_round_trip.py
+++ b/api/tests/test_round_trip.py
@@ -21,7 +21,8 @@ from sqlalchemy.orm import Session
 
 from alembic import command
 from marrow.export import export_workspace
-from marrow.models import Attachment, Node, Organization, Revision, Space, Workspace
+from marrow.links import reconcile_node_links
+from marrow.models import Attachment, Node, NodeLink, Organization, Revision, Space, Workspace
 from marrow.restore import restore_workspace
 from marrow.storage import StorageAdapter
 
@@ -210,6 +211,9 @@ def test_export_restore_round_trip(db_url, tmp_path):
         page2.current_revision_id = rev2a.id
         session.flush()
 
+        reconcile_node_links(session, page1.id, rev1c.content, rev1c.content_format)
+        session.flush()
+
         att_data = b"binary attachment content"
         att_hash = hashlib.sha256(att_data).hexdigest()
         att = Attachment(
@@ -280,6 +284,10 @@ def test_export_restore_round_trip(db_url, tmp_path):
             "size_bytes": att.size_bytes,
             "data": att_data,
         }
+        original["node_links"] = [
+            {"source_node_id": str(row.source_node_id), "target_node_id": str(row.target_node_id)}
+            for row in session.query(NodeLink).order_by(NodeLink.source_node_id, NodeLink.target_node_id)
+        ]
 
         session.commit()
 
@@ -403,6 +411,15 @@ def test_export_restore_round_trip(db_url, tmp_path):
             "Attachment hash mismatch after restore"
         )
         assert restored_data == exp_att["data"], "Attachment bytes differ after restore"
+
+        # node_links index — must round-trip via links.json
+        restored_links = [
+            {"source_node_id": str(row.source_node_id), "target_node_id": str(row.target_node_id)}
+            for row in session.query(NodeLink).order_by(NodeLink.source_node_id, NodeLink.target_node_id)
+        ]
+        assert restored_links == original["node_links"], (
+            f"node_links mismatch after restore. Got: {restored_links} Expected: {original['node_links']}"
+        )
 
     engine.dispose()
 


### PR DESCRIPTION
Closes #227 

- Updated the backlinks API to support both `/pages/{id}` and `/nodes/{id}` hrefs.
- Improved the `rebuild_node_links` function to optionally include trashed nodes during link restoration.
- Added tests to ensure proper handling of links to trashed nodes during export and restore operations.
- Updated documentation to reflect changes in the backlinks response and the links.json structure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes export/restore link indexing on the restore-guarantee path; behavior shifts from inline Markdown heuristics to DB reconciliation, with new trash semantics that must stay aligned with manifest flags.
> 
> **Overview**
> **Backlinks and bundle links** now follow the same **`node_links`** path used on page save instead of re-parsing Markdown at export time. Before writing **`links.json`**, export **reconciles** each exported page’s current revision into **`node_links`** (via **`reconcile_node_links`**) and then **serializes** the table; **`broken_links`** is always **`[]`**. Wiki-link parsing also recognizes **`/nodes/{id}`** in addition to **`/pages/{id}`**.
> 
> **Trash-aware exports:** **`reconcile_node_links`** and **`rebuild_node_links`** take **`include_trash`** so links to soft-deleted nodes are kept when exporting with trash; restore reads **`manifest.include_trash`** and passes it into rebuild. Exports with trash set **`include_trash: true`** on the manifest.
> 
> Tests cover stale-index export, trashed-endpoint rebuild, full export→restore with trash, and round-trip **`node_links`** parity; docs describe the updated **`links.json`** shape and backlink behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb27085efd85d772dc1c159e0829f55bb13f8130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->