### PR TITLE
Fix node route links in panels

### DIFF
--- a/web/components/rail-panels/inbox-panel.tsx
+++ b/web/components/rail-panels/inbox-panel.tsx
@@ -82,7 +82,7 @@ export function InboxPanel({ onUnreadChange }: Props) {
     const nodeId = n.payload.node_id as string | undefined;
     const workspaceId = n.payload.workspace_id as string | undefined;
     if (nodeId && workspaceId) {
-      router.push(`/w/${workspaceId}/pages/${nodeId}`);
+      router.push(`/w/${workspaceId}/n/${nodeId}`);
     }
   }
 

--- a/web/components/rail-panels/starred-panel.tsx
+++ b/web/components/rail-panels/starred-panel.tsx
@@ -51,7 +51,7 @@ export function StarredPanel({ workspaceId }: { workspaceId: string }) {
         return (
           <Link
             key={node.id}
-            href={`/w/${workspaceId}/pages/${node.id}`}
+            href={`/w/${workspaceId}/n/${node.id}/${node.slug}`}
             className="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] text-foreground transition-colors hover:bg-accent"
           >
             <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />

--- a/web/components/side-drawer.tsx
+++ b/web/components/side-drawer.tsx
@@ -103,7 +103,7 @@ function BacklinksList({
   return (
     <ul className="flex flex-col gap-1">
       {backlinks.map((node) => {
-        const href = workspaceId ? `/w/${workspaceId}/pages/${node.id}` : null;
+        const href = workspaceId ? `/w/${workspaceId}/n/${node.id}/${node.slug}` : null;
         const inner = (
           <>
             <div className="text-xs font-medium text-foreground">{node.name}</div>


### PR DESCRIPTION
## Summary
- Update starred panel links to use canonical `/w/{workspaceId}/n/{nodeId}/{slug}` routes
- Update backlink side drawer links to use canonical node routes with slugs
- Update inbox notification navigation from `/pages/{nodeId}` to `/n/{nodeId}`

## Testing
- `npm.cmd run lint` (passes with existing app-sidebar unused-variable warnings)
- `npm.cmd run build` (fails because Next/font cannot fetch Inter from Google Fonts in this environment)

Fixes #228