### PR TITLE
Add tests for restoring node properties and handling deleted nodes

### DIFF
--- a/.cursor/rules/api-ruff.mdc
+++ b/.cursor/rules/api-ruff.mdc
@@ -1,0 +1,23 @@
+---
+description: Run ruff check and format on API Python changes before finishing (matches CI)
+globs: api/**/*.py
+alwaysApply: false
+---
+
+# API Python — ruff before done
+
+CI runs **both** `ruff check` and `ruff format --check` in `api/` (see `.github/workflows/ci.yml`). Lint-only is not enough — formatting failures fail CI.
+
+Before marking API Python work complete (including tests), run on every changed file under `api/`:
+
+```bash
+cd api && ruff check <paths> && ruff format <paths>
+```
+
+To verify without writing (optional):
+
+```bash
+cd api && ruff format --check <paths>
+```
+
+Use `api/.venv/bin/ruff` when the venv exists. Fix any issues and re-run until both pass.

--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -493,6 +493,79 @@ def test_include_trash_includes_deleted_nodes(session, tmp_path):
     assert str(trashed_node.id) in node_ids2
 
 
+def test_export_excludes_descendants_of_trashed_folder(session, tmp_path):
+    """Children of a trashed folder are excluded from default export."""
+    from datetime import datetime, timezone
+
+    org = Organization(slug="trash-desc-org", name="Trash Desc Org")
+    session.add(org)
+    session.flush()
+
+    ws = Workspace(org_id=org.id, slug="trash-desc-ws", name="Trash Desc WS")
+    session.add(ws)
+    session.flush()
+
+    space = Space(workspace_id=ws.id, slug="sp", name="Space")
+    session.add(space)
+    session.flush()
+
+    trashed_folder = Node(
+        space_id=space.id,
+        parent_id=None,
+        type="folder",
+        name="Archived Folder",
+        slug="archived-folder",
+        position="a0",
+        deleted_at=datetime.now(timezone.utc),
+    )
+    session.add(trashed_folder)
+    session.flush()
+
+    child_page = Node(
+        space_id=space.id,
+        parent_id=trashed_folder.id,
+        type="page",
+        name="Child Page",
+        slug="child-page",
+        position="a0",
+        current_revision_id=None,
+    )
+    session.add(child_page)
+    session.flush()
+
+    rev = Revision(node_id=child_page.id, content="Child content.")
+    session.add(rev)
+    session.flush()
+    child_page.current_revision_id = rev.id
+    session.flush()
+
+    storage = FakeStorageAdapter()
+    result = export_workspace(
+        slug="trash-desc-ws",
+        session=session,
+        storage=storage,
+        output_path=tmp_path,
+    )
+    with zipfile.ZipFile(result) as zf:
+        manifest = json.loads(zf.read("manifest.json"))
+    node_ids = {n["id"] for n in manifest["nodes"]}
+    assert str(trashed_folder.id) not in node_ids
+    assert str(child_page.id) not in node_ids
+
+    result2 = export_workspace(
+        slug="trash-desc-ws",
+        session=session,
+        storage=storage,
+        output_path=tmp_path,
+        include_trash=True,
+    )
+    with zipfile.ZipFile(result2) as zf:
+        manifest2 = json.loads(zf.read("manifest.json"))
+    node_ids2 = {n["id"] for n in manifest2["nodes"]}
+    assert str(trashed_folder.id) in node_ids2
+    assert str(child_page.id) in node_ids2
+
+
 # ---------------------------------------------------------------------------
 # Slim export tests
 # ---------------------------------------------------------------------------

--- a/api/tests/test_restore.py
+++ b/api/tests/test_restore.py
@@ -18,7 +18,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from marrow.export import SCHEMA_VERSION
-from marrow.models import Attachment, Node, Revision, Workspace
+from marrow.models import Attachment, Node, NodeProperty, Revision, Workspace
 from marrow.restore import restore_workspace
 from marrow.storage import StorageAdapter
 
@@ -478,6 +478,212 @@ def test_restore_not_a_zip_raises(session, storage, tmp_path):
 
     with pytest.raises(ValueError, match="Not a valid zip"):
         restore_workspace(path, session, storage)
+
+
+def test_restore_replays_deleted_at_with_include_trash(session, storage, tmp_path):
+    """include_trash bundles restore soft-deleted nodes with deleted_at intact."""
+    now = datetime.now(timezone.utc)
+    deleted_at = datetime(2024, 3, 1, 8, 30, 0, tzinfo=timezone.utc)
+    ws_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    space_id = uuid.uuid4()
+    page_id = uuid.uuid4()
+    rev_id = uuid.uuid4()
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "include_trash": True,
+        "export_timestamp": now.isoformat(),
+        "organization": {
+            "id": str(org_id),
+            "slug": "trash-restore-org",
+            "name": "Trash Restore Org",
+            "created_at": now.isoformat(),
+        },
+        "workspace": {
+            "id": str(ws_id),
+            "org_id": str(org_id),
+            "slug": "trash-restore-ws",
+            "name": "Trash Restore WS",
+            "created_at": now.isoformat(),
+        },
+        "spaces": [
+            {
+                "id": str(space_id),
+                "workspace_id": str(ws_id),
+                "slug": "sp",
+                "name": "Space",
+                "created_at": now.isoformat(),
+            }
+        ],
+        "nodes": [
+            {
+                "id": str(page_id),
+                "space_id": str(space_id),
+                "parent_id": None,
+                "type": "page",
+                "name": "Archived",
+                "slug": "archived",
+                "position": "000000",
+                "current_revision_id": str(rev_id),
+                "deleted_at": deleted_at.isoformat(),
+                "created_at": now.isoformat(),
+            }
+        ],
+        "revisions": [
+            {
+                "id": str(rev_id),
+                "node_id": str(page_id),
+                "content_format": "markdown",
+                "created_at": now.isoformat(),
+            }
+        ],
+        "attachments": [],
+        "node_properties": [],
+    }
+
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+        zf.writestr(f"revisions/{page_id}/{rev_id}.md", "# Archived\nGone.")
+        zf.writestr(f"nodes/{page_id}.md", "# Archived\nGone.")
+        zf.writestr(
+            "links.json",
+            json.dumps(
+                {"internal_links": [], "broken_links": [], "orphaned_nodes": [str(page_id)]}
+            ),
+        )
+
+    path = _write_bundle(tmp_path, buf.getvalue(), name="trash-restore.zip")
+    restore_workspace(path, session, storage)
+    session.flush()
+
+    restored = session.get(Node, page_id)
+    assert restored is not None
+    assert restored.deleted_at is not None
+    assert restored.deleted_at == deleted_at
+
+
+def test_restore_node_properties(session, storage, tmp_path):
+    """v4 bundles restore folder schema and page property values."""
+    now = datetime.now(timezone.utc)
+    ws_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    space_id = uuid.uuid4()
+    folder_id = uuid.uuid4()
+    page_id = uuid.uuid4()
+    rev_id = uuid.uuid4()
+    schema_prop_id = uuid.uuid4()
+    page_prop_id = uuid.uuid4()
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "export_timestamp": now.isoformat(),
+        "organization": {
+            "id": str(org_id),
+            "slug": "props-restore-org",
+            "name": "Props Restore Org",
+            "created_at": now.isoformat(),
+        },
+        "workspace": {
+            "id": str(ws_id),
+            "org_id": str(org_id),
+            "slug": "props-restore-ws",
+            "name": "Props Restore WS",
+            "created_at": now.isoformat(),
+        },
+        "spaces": [
+            {
+                "id": str(space_id),
+                "workspace_id": str(ws_id),
+                "slug": "sp",
+                "name": "Space",
+                "created_at": now.isoformat(),
+            }
+        ],
+        "nodes": [
+            {
+                "id": str(folder_id),
+                "space_id": str(space_id),
+                "parent_id": None,
+                "type": "folder",
+                "name": "Folder",
+                "slug": "folder",
+                "position": "000000",
+                "current_revision_id": None,
+                "created_at": now.isoformat(),
+            },
+            {
+                "id": str(page_id),
+                "space_id": str(space_id),
+                "parent_id": str(folder_id),
+                "type": "page",
+                "name": "Page",
+                "slug": "pg",
+                "position": "000000",
+                "current_revision_id": str(rev_id),
+                "created_at": now.isoformat(),
+            },
+        ],
+        "revisions": [
+            {
+                "id": str(rev_id),
+                "node_id": str(page_id),
+                "content_format": "markdown",
+                "created_at": now.isoformat(),
+            }
+        ],
+        "attachments": [],
+        "node_properties": [
+            {
+                "id": str(schema_prop_id),
+                "node_id": str(folder_id),
+                "key": "priority",
+                "value": None,
+                "value_type": "select",
+                "options": '["low", "high"]',
+                "created_at": now.isoformat(),
+                "updated_at": now.isoformat(),
+            },
+            {
+                "id": str(page_prop_id),
+                "node_id": str(page_id),
+                "key": "priority",
+                "value": "high",
+                "value_type": "select",
+                "options": None,
+                "created_at": now.isoformat(),
+                "updated_at": now.isoformat(),
+            },
+        ],
+    }
+
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+        zf.writestr(f"revisions/{page_id}/{rev_id}.md", "# Page\nBody.")
+        zf.writestr(f"nodes/{page_id}.md", "# Page\nBody.")
+        zf.writestr(
+            "links.json",
+            json.dumps(
+                {"internal_links": [], "broken_links": [], "orphaned_nodes": [str(page_id)]}
+            ),
+        )
+
+    path = _write_bundle(tmp_path, buf.getvalue(), name="props-restore.zip")
+    restore_workspace(path, session, storage)
+    session.flush()
+
+    schema = session.get(NodeProperty, schema_prop_id)
+    value = session.get(NodeProperty, page_prop_id)
+    assert schema is not None
+    assert schema.key == "priority"
+    assert schema.value_type == "select"
+    assert schema.options == '["low", "high"]'
+    assert value is not None
+    assert value.key == "priority"
+    assert value.value == "high"
+    assert value.value_type == "select"
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_round_trip.py
+++ b/api/tests/test_round_trip.py
@@ -324,9 +324,7 @@ def test_export_restore_round_trip(db_url, tmp_path):
                 "value_type": row.value_type,
                 "options": row.options,
             }
-            for row in session.query(NodeProperty).order_by(
-                NodeProperty.node_id, NodeProperty.key
-            )
+            for row in session.query(NodeProperty).order_by(NodeProperty.node_id, NodeProperty.key)
         ]
 
         session.commit()
@@ -473,9 +471,7 @@ def test_export_restore_round_trip(db_url, tmp_path):
                 "value_type": row.value_type,
                 "options": row.options,
             }
-            for row in session.query(NodeProperty).order_by(
-                NodeProperty.node_id, NodeProperty.key
-            )
+            for row in session.query(NodeProperty).order_by(NodeProperty.node_id, NodeProperty.key)
         ]
         assert restored_props == original["node_properties"], (
             f"node_properties mismatch after restore. "

--- a/api/tests/test_round_trip.py
+++ b/api/tests/test_round_trip.py
@@ -22,7 +22,16 @@ from sqlalchemy.orm import Session
 from alembic import command
 from marrow.export import export_workspace
 from marrow.links import reconcile_node_links
-from marrow.models import Attachment, Node, NodeLink, Organization, Revision, Space, Workspace
+from marrow.models import (
+    Attachment,
+    Node,
+    NodeLink,
+    NodeProperty,
+    Organization,
+    Revision,
+    Space,
+    Workspace,
+)
 from marrow.restore import restore_workspace
 from marrow.storage import StorageAdapter
 
@@ -227,6 +236,22 @@ def test_export_restore_round_trip(db_url, tmp_path):
 
         export_storage.write(str(att.id), "diagram.png", att_data)
 
+        # Folder schema + page property value
+        schema_prop = NodeProperty(
+            node_id=folder.id,
+            key="status",
+            value_type="select",
+            options='["todo", "done"]',
+        )
+        page_prop = NodeProperty(
+            node_id=page1.id,
+            key="status",
+            value="todo",
+            value_type="select",
+        )
+        session.add_all([schema_prop, page_prop])
+        session.flush()
+
         # Capture ground truth before committing (IDs are assigned).
         original["organization"] = {
             "id": str(org.id),
@@ -288,6 +313,19 @@ def test_export_restore_round_trip(db_url, tmp_path):
             {"source_node_id": str(row.source_node_id), "target_node_id": str(row.target_node_id)}
             for row in session.query(NodeLink).order_by(
                 NodeLink.source_node_id, NodeLink.target_node_id
+            )
+        ]
+        original["node_properties"] = [
+            {
+                "id": str(row.id),
+                "node_id": str(row.node_id),
+                "key": row.key,
+                "value": row.value,
+                "value_type": row.value_type,
+                "options": row.options,
+            }
+            for row in session.query(NodeProperty).order_by(
+                NodeProperty.node_id, NodeProperty.key
             )
         ]
 
@@ -424,6 +462,104 @@ def test_export_restore_round_trip(db_url, tmp_path):
         assert restored_links == original["node_links"], (
             f"node_links mismatch after restore. Got: {restored_links} Expected: {original['node_links']}"
         )
+
+        # node_properties — folder schema + page values must round-trip via manifest
+        restored_props = [
+            {
+                "id": str(row.id),
+                "node_id": str(row.node_id),
+                "key": row.key,
+                "value": row.value,
+                "value_type": row.value_type,
+                "options": row.options,
+            }
+            for row in session.query(NodeProperty).order_by(
+                NodeProperty.node_id, NodeProperty.key
+            )
+        ]
+        assert restored_props == original["node_properties"], (
+            f"node_properties mismatch after restore. "
+            f"Got: {restored_props} Expected: {original['node_properties']}"
+        )
+
+    engine.dispose()
+
+
+def test_export_restore_round_trip_with_trash(db_url, tmp_path):
+    """include_trash export preserves deleted_at through wipe and restore."""
+    import zipfile
+    from datetime import datetime, timezone
+
+    engine = create_engine(db_url)
+    export_storage = FakeStorageAdapter()
+    trashed_at = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+    with Session(engine) as session:
+        org = Organization(slug="trash-roundtrip-org", name="Trash Round-Trip Org")
+        session.add(org)
+        session.flush()
+
+        ws = Workspace(org_id=org.id, slug="trash-roundtrip-ws", name="Trash Round-Trip WS")
+        session.add(ws)
+        session.flush()
+
+        space = Space(workspace_id=ws.id, slug="main", name="Main Space")
+        session.add(space)
+        session.flush()
+
+        trashed_page = Node(
+            space_id=space.id,
+            parent_id=None,
+            type="page",
+            name="Archived Page",
+            slug="archived",
+            position="000000",
+            deleted_at=trashed_at,
+            current_revision_id=None,
+        )
+        session.add(trashed_page)
+        session.flush()
+
+        rev = Revision(
+            node_id=trashed_page.id,
+            content="# Archived\nSoft-deleted content.",
+            content_format="markdown",
+        )
+        session.add(rev)
+        session.flush()
+        trashed_page.current_revision_id = rev.id
+        session.commit()
+
+    with Session(engine) as session:
+        bundle_path = export_workspace(
+            slug="trash-roundtrip-ws",
+            session=session,
+            storage=export_storage,
+            output_path=tmp_path,
+            include_trash=True,
+        )
+
+    with zipfile.ZipFile(bundle_path) as zf:
+        manifest = _json.loads(zf.read("manifest.json"))
+    assert manifest.get("include_trash") is True
+    trashed_rec = next(n for n in manifest["nodes"] if n["slug"] == "archived")
+    assert trashed_rec.get("deleted_at") == trashed_at.isoformat()
+
+    with engine.connect() as conn:
+        conn.execute(text("TRUNCATE organizations, workspaces CASCADE"))
+        conn.commit()
+
+    restore_storage = FakeStorageAdapter()
+    with Session(engine) as session:
+        slug = restore_workspace(bundle_path, session, restore_storage)
+        session.commit()
+
+    assert slug == "trash-roundtrip-ws"
+
+    with Session(engine) as session:
+        restored = session.query(Node).filter_by(slug="archived").one()
+        assert restored.deleted_at is not None
+        assert restored.deleted_at == trashed_at
 
     engine.dispose()
 


### PR DESCRIPTION
Close #225 

- Introduced tests to verify the restoration of soft-deleted nodes with intact `deleted_at` timestamps when `include_trash` is enabled.
- Added functionality to restore node properties, ensuring folder schema and page property values are correctly handled during export and restore processes.
- Enhanced existing test cases for clarity and consistency in the restoration workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation-style rule changes; no export/restore implementation modified in this PR.
> 
> **Overview**
> Adds **integration and round-trip test coverage** for export/restore behaviors around trash and `NodeProperty`, plus a **Cursor rule** reminding contributors to run `ruff check` and `ruff format` on `api/**/*.py` before finishing (aligned with CI).
> 
> **Export:** New test asserts default exports omit a trashed folder **and its child page**, while `include_trash=True` puts both in the manifest.
> 
> **Restore:** New tests verify `include_trash` bundles restore soft-deleted nodes with **`deleted_at` unchanged**, and v4 manifests with **`node_properties`** restore folder schema (select options) and page values.
> 
> **Round-trip:** The main export→wipe→restore test now seeds and asserts **`node_properties`** parity; a separate test covers **`include_trash`** end-to-end (`deleted_at` on manifest and after restore).
> 
> No application logic changes appear in this diff—only tests and the ruff rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 262a6171d9c3b740b14578c36ddf10bf2304582f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->