### PR TITLE
feat: add include_trash option to workspace export functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,7 +382,7 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | GET/DELETE | /api/workspaces/{id} | Get / delete workspace | viewer/owner |
 | GET | /api/workspaces/{id}/tree | Full hierarchy (sidebar) | viewer |
 | GET | /api/workspaces/{id}/search?q= | Full-text search across workspace pages | viewer |
-| GET | /api/workspaces/{id}/export?slim=false | Download workspace as zip bundle | viewer |
+| GET | /api/workspaces/{id}/export?slim=false&include_trash=false | Download workspace as zip bundle | viewer |
 | GET | /api/workspaces/{id}/export/estimate | Pre-compression byte estimates for full & slim exports | viewer |
 | POST | /api/workspaces/restore | Restore a workspace from an uploaded export bundle zip | — |
 | GET/POST | /api/workspaces/{id}/spaces/ | List / create spaces | viewer/editor |

--- a/api/marrow/export.py
+++ b/api/marrow/export.py
@@ -328,9 +328,8 @@ def _build_manifest(
         "revisions": revision_records,
         "attachments": attachment_records,
         "node_properties": node_properties or [],
+        "include_trash": include_trash,
     }
-    if include_trash:
-        manifest["include_trash"] = True
     return manifest
 
 

--- a/api/marrow/routers/workspaces.py
+++ b/api/marrow/routers/workspaces.py
@@ -330,6 +330,7 @@ def estimate_workspace_export(
 def export_workspace_endpoint(
     workspace_id: UUID,
     slim: bool = False,
+    include_trash: bool = False,
     db: Session = Depends(get_db),
     auth: AuthContext = Depends(require_workspace_role(OrgRole.VIEWER)),
 ):
@@ -354,6 +355,7 @@ def export_workspace_endpoint(
             storage=storage,
             output_path=Path(tmp),
             slim=slim,
+            include_trash=include_trash,
         )
         data = bundle_path.read_bytes()
 

--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -5,6 +5,7 @@ Each test rolls back its transaction so the DB stays clean between runs.
 """
 
 import hashlib
+import io
 import json
 import os
 import zipfile
@@ -475,6 +476,7 @@ def test_include_trash_includes_deleted_nodes(session, tmp_path):
     with zipfile.ZipFile(result) as zf:
         manifest = json.loads(zf.read("manifest.json"))
     node_ids = {n["id"] for n in manifest["nodes"]}
+    assert manifest["include_trash"] is False
     assert str(live_node.id) in node_ids
     assert str(trashed_node.id) not in node_ids
 
@@ -489,8 +491,11 @@ def test_include_trash_includes_deleted_nodes(session, tmp_path):
     with zipfile.ZipFile(result2) as zf:
         manifest2 = json.loads(zf.read("manifest.json"))
     node_ids2 = {n["id"] for n in manifest2["nodes"]}
+    assert manifest2["include_trash"] is True
     assert str(live_node.id) in node_ids2
     assert str(trashed_node.id) in node_ids2
+    trashed_record = next(n for n in manifest2["nodes"] if n["id"] == str(trashed_node.id))
+    assert trashed_record["deleted_at"] is not None
 
 
 def test_export_excludes_descendants_of_trashed_folder(session, tmp_path):
@@ -708,3 +713,96 @@ def test_estimate_export_sizes(seeded, session):
     assert "slim_bytes" in sizes
     assert sizes["full_bytes"] >= sizes["slim_bytes"]
     assert sizes["slim_bytes"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# API export endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def export_api_client(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from marrow.app import app
+    from marrow.auth import reset_oidc_config
+
+    monkeypatch.delenv("OIDC_ISSUER", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    reset_oidc_config()
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_api_export_include_trash_param(export_api_client, tmp_path, monkeypatch):
+    """GET /export?include_trash=true includes trashed nodes and sets manifest flag."""
+    import uuid
+    from datetime import datetime, timezone
+
+    from marrow.dependencies import get_db
+
+    monkeypatch.setenv("STORAGE_PATH", str(tmp_path))
+
+    suffix = uuid.uuid4().hex[:8]
+    db = next(get_db())
+    try:
+        org = Organization(slug=f"api-trash-export-org-{suffix}", name="API Trash Export Org")
+        db.add(org)
+        db.flush()
+
+        ws = Workspace(
+            org_id=org.id, slug=f"api-trash-export-ws-{suffix}", name="API Trash Export WS"
+        )
+        db.add(ws)
+        db.flush()
+
+        space = Space(workspace_id=ws.id, slug="sp", name="Space")
+        db.add(space)
+        db.flush()
+
+        live_node = Node(
+            space_id=space.id, parent_id=None, type="page", name="Live", slug="live", position="a0"
+        )
+        db.add(live_node)
+        db.flush()
+
+        rev = Revision(node_id=live_node.id, content="Live content.")
+        db.add(rev)
+        db.flush()
+        live_node.current_revision_id = rev.id
+        db.flush()
+
+        trashed_node = Node(
+            space_id=space.id,
+            parent_id=None,
+            type="page",
+            name="Trashed",
+            slug="trashed",
+            position="a1",
+            deleted_at=datetime.now(timezone.utc),
+        )
+        db.add(trashed_node)
+        db.flush()
+        db.commit()
+
+        default_res = export_api_client.get(f"/api/workspaces/{ws.id}/export")
+        assert default_res.status_code == 200
+        with zipfile.ZipFile(io.BytesIO(default_res.content)) as zf:
+            default_manifest = json.loads(zf.read("manifest.json"))
+        default_ids = {n["id"] for n in default_manifest["nodes"]}
+        assert default_manifest["include_trash"] is False
+        assert str(live_node.id) in default_ids
+        assert str(trashed_node.id) not in default_ids
+
+        trash_res = export_api_client.get(f"/api/workspaces/{ws.id}/export?include_trash=true")
+        assert trash_res.status_code == 200
+        with zipfile.ZipFile(io.BytesIO(trash_res.content)) as zf:
+            trash_manifest = json.loads(zf.read("manifest.json"))
+        trash_ids = {n["id"] for n in trash_manifest["nodes"]}
+        assert trash_manifest["include_trash"] is True
+        assert str(live_node.id) in trash_ids
+        assert str(trashed_node.id) in trash_ids
+        trashed_record = next(n for n in trash_manifest["nodes"] if n["id"] == str(trashed_node.id))
+        assert trashed_record["deleted_at"] is not None
+    finally:
+        db.rollback()

--- a/web/components/export-dialog.tsx
+++ b/web/components/export-dialog.tsx
@@ -27,6 +27,7 @@ function formatBytes(bytes: number): string {
 export function ExportDialog({ workspaceId, workspaceName }: Props) {
   const [open, setOpen] = useState(false);
   const [slim, setSlim] = useState(false);
+  const [includeTrash, setIncludeTrash] = useState(false);
   const [estimate, setEstimate] = useState<{ full_bytes: number; slim_bytes: number } | null>(null);
   const [loadingEstimate, setLoadingEstimate] = useState(false);
 
@@ -46,7 +47,7 @@ export function ExportDialog({ workspaceId, workspaceName }: Props) {
   }
 
   function handleDownload() {
-    const url = exportWorkspaceUrl(workspaceId, slim);
+    const url = exportWorkspaceUrl(workspaceId, { slim, includeTrash });
     window.location.href = url;
     setOpen(false);
   }
@@ -117,6 +118,22 @@ export function ExportDialog({ workspaceId, workspaceName }: Props) {
               </div>
             </label>
           </div>
+
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={includeTrash}
+              onChange={(e) => setIncludeTrash(e.target.checked)}
+              className="mt-0.5"
+            />
+            <div>
+              <p className="text-sm font-medium">Include trash</p>
+              <p className="text-xs text-muted-foreground">
+                Export soft-deleted nodes with their <code className="text-xs">deleted_at</code>{" "}
+                timestamps so trash is preserved on restore.
+              </p>
+            </div>
+          </label>
 
           {slim && (
             <p className="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded px-2 py-1.5">

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -125,9 +125,15 @@ export function getExportSizeEstimate(
   return apiFetch(`/api/workspaces/${workspaceId}/export/estimate`);
 }
 
-export function exportWorkspaceUrl(workspaceId: string, slim: boolean): string {
-  const params = slim ? "?slim=true" : "";
-  return `${getApiUrl()}/api/workspaces/${workspaceId}/export${params}`;
+export function exportWorkspaceUrl(
+  workspaceId: string,
+  options: { slim?: boolean; includeTrash?: boolean } = {}
+): string {
+  const params = new URLSearchParams();
+  if (options.slim) params.set("slim", "true");
+  if (options.includeTrash) params.set("include_trash", "true");
+  const query = params.toString();
+  return `${getApiUrl()}/api/workspaces/${workspaceId}/export${query ? `?${query}` : ""}`;
 }
 
 export async function restoreWorkspace(file: File): Promise<Workspace> {


### PR DESCRIPTION

- Introduced an `include_trash` parameter to the `export_workspace_endpoint` for exporting soft-deleted nodes.
- Updated the `exportWorkspaceUrl` function to accept options, including `includeTrash`.
- Enhanced the `ExportDialog` component to allow users to select the inclusion of trashed nodes during export.
- Added tests to verify the correct handling of the `include_trash` parameter in the export process and its effect on the manifest.
- Updated documentation to reflect the new query parameter in the export API.

Closes #226 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the export/restore bundle contract (manifest always includes include_trash), but behavior is additive with integration tests; restore already depends on this flag for trash round-trips.
> 
> **Overview**
> Adds an optional **`include_trash`** flag end-to-end so workspace exports can include soft-deleted nodes (with **`deleted_at`** in the manifest) instead of omitting them by default.
> 
> **GET `/api/workspaces/{id}/export`** accepts **`include_trash`** (default false) and passes it through to **`export_workspace`**. **`manifest.json`** now always records **`include_trash`** as a boolean rather than only when true. **Export dialog** gets an “Include trash” checkbox; **`exportWorkspaceUrl`** builds query params via **`URLSearchParams`** (supports **`slim`** and **`include_trash`**). Tests assert the manifest flag and add an API integration test; **CLAUDE.md** documents the new query param.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 658f9775090af94b22401df2ae36cd34d5400ec2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->