### PR TITLE
fix: update version references and improve documentation clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Marrow is a self-hosted, open-source knowledge base (wiki) built around a non-negotiable **restore guarantee**: a Marrow export bundle must always be restorable to an exact replica of the original workspace. This guarantee is the architectural foundation — every decision flows from it.
 
-Current status: **v0.1 MVP** — core hierarchy, append-only revisions, export/restore, file attachments, and a working Next.js frontend are all implemented and tested.
+Current status: **v0.3.x** — node tree (folders + pages), v4 export/restore, OIDC + org RBAC, BlockNote editor, comments, properties, backlinks, SaaS billing gates, and global `/home` landing are implemented and tested. Comments, share links, and folder view definitions are not yet in export bundles (planned bundle v5 — see `references/To-do.md` item 8).
 
 ---
 
@@ -144,7 +144,7 @@ cd api && marrow reset-org-billing <slug>           # reset billing+onboarding s
 cd web && npm run dev
 cd web && npm run build
 cd web && npm run lint
-cd web && npm test
+# web/ has no test script yet — see What's Not Built Yet
 
 # Marketing site (web-marketing/) — runs on port 3001 in dev
 cd web-marketing && npm run dev
@@ -355,7 +355,7 @@ organizations → org_memberships (user roles: owner/editor/viewer)
 
 **Deferred FK**: `nodes.current_revision_id → revisions.id` is a deferred constraint, allowing a node and its first revision to be created in a single transaction.
 
-**Comments**: Page-level only for v1; `node_id` must reference a `type='page'` node, enforced in `routers/comments.py` (the issue explicitly allowed check-or-app-level). One level of replies via `parent_comment_id` (nested replies are rejected with 400). Resolve = setting `resolved_at`. A future `block_id` column can be added additively for block-level comments without a breaking migration. RLS `tenant_isolation` is enabled on `comments` via the node-indirect tenant expression, identical to `revisions`/`attachments`. Comments are **not yet in the export bundle** — they ride along with the node-aware export/restore rewrite (bundle v4, #132/#133); until then `export.py`/`restore.py` remain pre-existing broken stubs for the v0.2 transition.
+**Comments**: Page-level only for v1; `node_id` must reference a `type='page'` node, enforced in `routers/comments.py` (the issue explicitly allowed check-or-app-level). One level of replies via `parent_comment_id` (nested replies are rejected with 400). Resolve = setting `resolved_at`. A future `block_id` column can be added additively for block-level comments without a breaking migration. RLS `tenant_isolation` is enabled on `comments` via the node-indirect tenant expression, identical to `revisions`/`attachments`. Comments are **not yet in the export bundle** (planned bundle v5 — `references/To-do.md` item 8).
 
 ### API Routes Summary
 
@@ -425,27 +425,24 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 > properties (#42). Views are presentation-only — CRUD never touches nodes.
 > `rbac.require_view_role` resolves view → folder node → org for role checks.
 > Frontend: `lib/api.ts` `*NodeView` helpers + `components/folder-views.tsx`
-> (presentational switcher; wiring into the node-aware sidebar lands with the
-> frontend node rewrite). Export of view definitions lands with bundle v4 (#132).
+> (presentational switcher; wiring into folder pages is tracked in
+> `references/To-do.md` item 5). Export of view definitions is planned for
+> bundle v5 (`references/To-do.md` item 8).
 
 > **Share links (#40):** `share_links` grant view-only public access to a node.
 > `GET /shared/{token}` requires no account: a page returns its current
 > revision content; a folder returns its visible (non-trashed) subtree
 > recursively. Expired links return 410, unknown/revoked return 404. The
 > public endpoint relies on RLS treating an unset `app.current_org` as
-> unrestricted (same pattern as the API-key/dev path). Export/restore
-> integration ("bundle v4") is **deferred**: `export.py`/`restore.py` still
-> reference removed Page/Collection classes and NameError at runtime until the
-> #132/#133 rewrites land — share links should be added to the bundle there.
->
-> **Note (#123 → #125):** v0.1's collection-scoped and global page routes were removed by the schema migration. Node CRUD/tree/attachment/revision routes land in #124 (2.0b) under `/api/nodes/...` and `/api/spaces/{sid}/nodes`. The workspace `/search` endpoint is node-aware as of #125 (2.0c). The `/tree`, `/export`, and `/restore` endpoints are still wired but their handlers will NameError at runtime until the node-aware rewrites land in #124, #132, and #133.
+> unrestricted (same pattern as the API-key/dev path). Share links are **not
+> yet in the export bundle** (planned bundle v5 — `references/To-do.md` item 8).
 >
 > **Watches & notifications (#103/#104):** `notifications` is a user-scoped Inbox feed; `create_notification()` in `marrow/notifications.py` is the single insertion point. `marrow/watches.py` fans out `watch_event` notifications: on a page save (`update_node` revision create), every watcher of the page **or any ancestor folder** is notified, excluding the acting user. Both tables are deliberately excluded from export/restore (user-scoped, workspace-independent) — the round-trip guarantee is unaffected.
 >
 > **Search response shape (v0.2):** `SearchResultItem` fields are `node_id`, `name`, `snippet`, `space_id`, `space_name`, `node_path` (list of ancestor folder names, root→leaf), `rank`. The old `page_id`, `title`, `collection_id`, `collection_name` fields are gone.
 >
 > **Backlinks (#100, 2.6):** `GET /api/nodes/{nid}/backlinks` returns the nodes that link to `{nid}` (min role `viewer`, trashed sources excluded). `marrow/links.py` parses wiki-links (`/pages/{id}` and `/nodes/{id}` hrefs) and reconciles the `node_links` table on every page create/update via `reconcile_node_links()`. Export serializes the live DB index via `serialize_node_links()` into `links.json`; restore rebuilds it with `rebuild_node_links()`, honouring `manifest.include_trash` so links involving trashed nodes round-trip when the bundle was exported with `include_trash=True`.
-> **Node properties (#42, 2.4):** Folder nodes declare a property schema (key + `value_type` + `options`); every descendant page inherits it (nearest-ancestor wins) and may set its own value. Effective properties resolve at read time via the ancestor folder chain. Property keys+values fold into the page `search_vector` at weight C — a single `marrow_node_search_vector(uuid)` SQL helper computes the full vector and all node search triggers (revision-insert, name-change, and the new `node_properties` change trigger) keep it consistent. Frontend: `web/components/property-editor.tsx` renders chips/date pickers/dropdowns/checkboxes below the page title. Export/restore bundle bumped to **v4** (`node_properties` array in `manifest.json`); the v4 export/restore *handlers* still depend on the #132/#133 node-aware rewrite to run end-to-end, but the property serialization (`export.serialize_node_properties`) and restore loop are in place and symmetric.
+> **Node properties (#42, 2.4):** Folder nodes declare a property schema (key + `value_type` + `options`); every descendant page inherits it (nearest-ancestor wins) and may set its own value. Effective properties resolve at read time via the ancestor folder chain. Property keys+values fold into the page `search_vector` at weight C — a single `marrow_node_search_vector(uuid)` SQL helper computes the full vector and all node search triggers (revision-insert, name-change, and the new `node_properties` change trigger) keep it consistent. Frontend: `web/components/property-editor.tsx` renders chips/date pickers/dropdowns/checkboxes below the page title. Export/restore bundle **v4** carries a `node_properties` array in `manifest.json`; `export.serialize_node_properties` and the restore loop round-trip folder schemas and page values.
 
 ### Storage Adapter Interface
 
@@ -463,8 +460,8 @@ class StorageAdapter(ABC):
 marrow-export-{workspace-slug}-{timestamp}.zip          # full
 marrow-export-{workspace-slug}-slim-{timestamp}.zip     # slim
 ├── manifest.json        # workspace + org metadata, full node tree, schema version (v4)
-├── pages/
-│   ├── {node-id}.md     # human-readable Markdown (page-typed nodes)
+├── nodes/
+│   ├── {node-id}.md     # human-readable Markdown (page-typed nodes only)
 │   └── {node-id}.json   # canonical BlockNote JSON (JSON-format pages only)
 ├── revisions/
 │   └── {node-id}/
@@ -475,12 +472,12 @@ marrow-export-{workspace-slug}-slim-{timestamp}.zip     # slim
 └── links.json           # node_links index (internal_links + orphaned_nodes; broken_links always [])
 ```
 
-**Schema versions**: v1/v2 were Markdown-only. v3 added `.json` as canonical. v4 (Marrow 0.2) carries the `nodes` tree (folders + pages, with `parent_id`, `position`, `deleted_at`) instead of the old `collections`+`pages` shape. Restore supports v1–v4 — older bundles are auto-upgraded onto the node tree on read.
-v1/v2 bundles had only `.md` files. v3 adds `.json` as canonical for JSON-format revisions.
-v4 adds a `node_properties` array to `manifest.json` (folder schemas + page values).
-Restore supports v1, v2, v3, and v4 bundles.
+Folder nodes appear in `manifest.json` only — no files under `nodes/`. v3 bundles used a `pages/` directory; v4 renamed it to `nodes/`.
 
-**Slim bundles** omit the `revisions/` directory entirely and set `"slim": true` + `"revisions": []` in `manifest.json`. Restore recreates one revision per page from `pages/` content. CLI: `marrow export --slim`; API: `?slim=true`.
+**Schema versions**: v1/v2 were Markdown-only. v3 added `.json` as canonical under `pages/`. v4 (Marrow 0.2) carries the `nodes` tree (folders + pages, with `parent_id`, `position`, `deleted_at`, `include_trash`) instead of the old `collections`+`pages` manifest shape; content files live under `nodes/`. Restore supports v1–v4 — older bundles are auto-upgraded onto the node tree on read.
+v4 adds a `node_properties` array to `manifest.json` (folder schemas + page values).
+
+**Slim bundles** omit the `revisions/` directory entirely and set `"slim": true` + `"revisions": []` in `manifest.json`. Restore recreates one revision per page from `nodes/` content. CLI: `marrow export --slim`; API: `?slim=true`.
 
 **Trash**: soft-deleted nodes are excluded from exports by default. Pass `marrow export --include-trash` (or `?include_trash=true`) to include them; the manifest records `"include_trash": bool` so restore replays each node's `deleted_at`.
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Check out the release tag, set `MARROW_VERSION` in `.env` to the same tag (so th
 
 ```bash
 git fetch --tags
-git checkout v0.3.4          # pick the release you want
-# edit .env — set MARROW_VERSION=v0.3.4 to match
+git checkout v0.3.3          # pick the release you want
+# edit .env — set MARROW_VERSION=v0.3.3 to match
 docker compose -f docker-compose.prod.yml pull api
 docker compose -f docker-compose.prod.yml up -d --build
 ```

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -31,7 +31,7 @@ export default defineConfig({
         },
       ],
       editLink: {
-        baseUrl: "https://github.com/spmcgraw/marrow/edit/main/docs/",
+        baseUrl: "https://github.com/marrow-software/marrow/edit/main/docs/",
       },
       sidebar: [
         {

--- a/docs/src/content/docs/concepts/export-format.md
+++ b/docs/src/content/docs/concepts/export-format.md
@@ -19,7 +19,7 @@ The `marrow restore` CLI also accepts the legacy `freehold-export-*` prefix from
 ```
 bundle.zip
 ├── manifest.json
-├── pages/
+├── nodes/
 │   ├── {node-id}.md
 │   └── {node-id}.json
 ├── revisions/
@@ -31,24 +31,34 @@ bundle.zip
 └── links.json
 ```
 
+**Folder nodes** appear only in `manifest.json` — they have no files under `nodes/`. Only page-typed nodes get content files.
+
 ### `manifest.json`
 
-Contains workspace and org metadata, all entity IDs, and the bundle schema version. Schema is currently **v4** (Marrow 0.2+). Restore supports v1, v2, v3, and v4: older bundles are auto-upgraded — their legacy collection/page structure is mapped onto the new `nodes` tree on read. v4 manifests carry the full node tree (folders + pages), each node's `parent_id`, `position` (fractional index), and `deleted_at`.
+Contains workspace and org metadata, all entity IDs, and the bundle schema version. Schema is currently **v4** (Marrow 0.2+). Restore supports v1, v2, v3, and v4: older bundles are auto-upgraded — their legacy collection/page structure is mapped onto the new `nodes` tree on read.
 
-### `pages/`
+v4 manifests carry:
 
-Current state of every page-typed node.
+- The full **node tree** (folders + pages), each node's `parent_id`, `position` (fractional index), and `deleted_at`
+- **`node_properties`** — folder property schemas and page values
+- **`include_trash`** — whether soft-deleted nodes were included in the export
+
+### `nodes/`
+
+Current state of every **page-typed** node.
 
 - `{node-id}.md` — Markdown render of the current revision (always present).
 - `{node-id}.json` — canonical BlockNote JSON (present when the current revision is JSON-format).
 
 The Markdown is for humans. The JSON is what gets restored byte-for-byte.
 
+v3 bundles used a `pages/` directory with the same file naming; v4 renamed it to `nodes/` to match the unified node tree.
+
 ### `revisions/`
 
-The full append-only history. Each page-typed node has a subfolder containing every revision. Same `.md` + `.json` convention as `pages/`.
+The full append-only history. Each page-typed node has a subfolder containing every revision. Same `.md` + `.json` convention as `nodes/`.
 
-**Slim bundles** omit this directory entirely. The manifest sets `"slim": true` and `"revisions": []`. Restore recreates a single revision per page from the `pages/` content.
+**Slim bundles** omit this directory entirely. The manifest sets `"slim": true` and `"revisions": []`. Restore recreates a single revision per page from the `nodes/` content.
 
 CLI: `marrow export --slim`. API: `?slim=true`.
 
@@ -67,7 +77,7 @@ Every attachment, named by attachment ID with the original extension.
 
 ### `links.json`
 
-Internal node-to-node links, broken links, and orphaned pages. Used to reconstruct cross-references on restore.
+Internal node-to-node links, broken links, and orphaned nodes. Used to reconstruct cross-references on restore. The `orphaned_nodes` array lists nodes with no inbound links from other exported nodes.
 
 ## Bundle schema versions
 
@@ -75,8 +85,8 @@ Internal node-to-node links, broken links, and orphaned pages. Used to reconstru
 | --- | --- | --- |
 | v1 | Initial | Markdown-only revisions. |
 | v2 | — | Added `links.json`. |
-| v3 | 0.1 | Added `.json` files alongside `.md` for canonical BlockNote content. |
-| v4 | 0.2 (current) | Collapsed `collections` + `pages` into a single `nodes` tree (folders + pages); added `parent_id`, `position`, `deleted_at`, and `include_trash`. |
+| v3 | 0.1 | Added `.json` files alongside `.md` for canonical BlockNote content; content under `pages/`. |
+| v4 | 0.2 (current) | Collapsed `collections` + `pages` into a single `nodes` tree (folders + pages); content under `nodes/`; added `parent_id`, `position`, `deleted_at`, `include_trash`, and `node_properties`. |
 
 Restore is backward-compatible: any older bundle restores cleanly into a current Marrow workspace. v1/v2/v3 bundles are auto-upgraded — their legacy collection/page layout is mapped onto the v4 node tree on read.
 

--- a/docs/src/content/docs/deployment/docker-compose.md
+++ b/docs/src/content/docs/deployment/docker-compose.md
@@ -89,8 +89,8 @@ Check out the new release, update `MARROW_VERSION` in `.env` to the same tag, th
 
 ```bash
 git fetch --tags
-git checkout v0.3.4          # pick the release you want
-# edit .env — set MARROW_VERSION=v0.3.4 to match
+git checkout v0.3.3          # pick the release you want
+# edit .env — set MARROW_VERSION=v0.3.3 to match
 docker compose -f docker-compose.prod.yml pull api
 docker compose -f docker-compose.prod.yml up -d --build
 ```

--- a/docs/src/content/docs/getting-started/quickstart.md
+++ b/docs/src/content/docs/getting-started/quickstart.md
@@ -14,7 +14,7 @@ This walks you through running Marrow on your machine for development. For produ
 ## 1. Clone the repo
 
 ```bash
-git clone https://github.com/spmcgraw/marrow.git
+git clone https://github.com/marrow-software/marrow.git
 cd marrow
 ```
 
@@ -54,9 +54,9 @@ The frontend runs at `http://localhost:3000`.
 
 ## 5. Try it
 
-- Open `http://localhost:3000`.
+- Open `http://localhost:3000`. The app root (`/`) redirects to `/home`; in anonymous dev mode (no OIDC), unauthenticated users are sent to `/login` and then `/workspaces`.
 - Create a workspace, then a space, then add folders and pages inside that space.
-- Type into the editor — it auto-saves after 2 seconds and creates a revision on every save.
+- Type into the BlockNote editor — it auto-saves after 2 seconds and creates a revision on every save.
 - Hover over a folder in the sidebar to create child folders and pages via the `+` buttons.
 - Try `cd api && marrow export --workspace <slug> --output ./out.zip` and inspect the bundle. Then `marrow restore ./out.zip` into a fresh database to confirm the round-trip.
 

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -19,4 +19,4 @@ Marrow is a self-hosted, open-source knowledge base. Every workspace can be expo
 3. **Transparent format.** Bundles are plain Markdown + JSON in a zip.
 4. **Self-hosted.** Your data never leaves the infrastructure you control.
 
-[GitHub →](https://github.com/spmcgraw/marrow)
+[GitHub →](https://github.com/marrow-software/marrow)


### PR DESCRIPTION
- Changed version references from v0.3.4 to v0.3.3 in deployment and README files to reflect the correct release.
- Updated the GitHub link in multiple documentation files to point to the correct repository.
- Enhanced clarity in the quickstart guide by specifying the BlockNote editor and improving instructions for accessing the application.
- Revised export format documentation to clarify the structure of exported bundles and the handling of nodes.

Closes #224 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and internal documentation updates only; no runtime, auth, or data-path changes.
> 
> **Overview**
> This PR is **documentation-only** — no application code changes.
> 
> **Release pinning:** Self-host update/checkout examples in `README.md` and the Docker Compose deployment guide now use **`v0.3.3`** (and matching `MARROW_VERSION`) instead of `v0.3.4`.
> 
> **Repository URLs:** Clone links, docs “Edit on GitHub” base URL, and the docs index GitHub link now target **`marrow-software/marrow`** instead of the old `spmcgraw/marrow` org/repo.
> 
> **Export bundle docs:** `CLAUDE.md` and `docs/.../export-format.md` describe v4 bundles with content under **`nodes/`** (not `pages/`), folder-only entries in `manifest.json`, **`node_properties`**, and **`orphaned_nodes`** in `links.json`. Stale wording about broken export/restore stubs and deferred bundle v4 work is replaced with accurate v4 round-trip notes; comments, share links, and folder views are called out as **planned bundle v5** (`references/To-do.md`).
> 
> **Product status in CLAUDE.md:** Current status is updated to **v0.3.x** with a concise feature list; the web test command note reflects that **`web/` has no test script yet**.
> 
> **Quickstart:** Documents **`/home`** routing, login/workspaces flow in dev, and the **BlockNote** editor by name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d3483eaa98482d7e877bb6627e2b0d9667faf70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->