### PR TITLE
fix: ensure docs TypeScript config resolves after npm ci

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "prepare": "astro sync"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.36.3",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- Add `prepare: astro sync` to `docs/package.json` so `npm ci` generates `.astro/types.d.ts` automatically
- Exclude `node_modules` from `docs/tsconfig.json` so the IDE does not typecheck dependency sources

Fixes the `File 'astro/tsconfigs/strict' not found` error locally — that path resolves from `docs/node_modules/astro/` after running `npm ci` in `docs/`.

## Test plan
- [x] `cd docs && npm ci` — `prepare` runs `astro sync` successfully
- [x] TypeScript resolves `extends: astro/tsconfigs/strict` without errors
- [x] `cd docs && npm run build` passes
