### PR TITLE
fix: page menu backlink count and archive action

### DIFF
--- a/api/marrow/links.py
+++ b/api/marrow/links.py
@@ -3,8 +3,8 @@
 A page links to another node in two ways:
 
 * **Wiki-links** — a Markdown/BlockNote link whose href points at a node, e.g.
-  ``/w/{workspace}/pages/{node-id}``, ``/nodes/{node-id}``, or the export-relative
-  ``/pages/{node-id}``.
+  ``/w/{workspace}/n/{node-id}`` (app route), ``/w/{workspace}/pages/{node-id}``,
+  ``/nodes/{node-id}``, or the export-relative ``/pages/{node-id}``.
 * **`@` mentions** — a BlockNote ``mention`` inline element. User mentions carry
   a ``userId`` (not a node) and are ignored here; a mention that carries a
   ``nodeId`` prop is treated as a link for forward-compatibility.
@@ -35,8 +35,9 @@ _UUID = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F
 # adversarial input (ReDoS). Requires Python 3.11+.
 _MD_HREF_RE = re.compile(r"\[(?>[^\]]*)\]\(([^)]+)\)")
 
-# Pull the node id out of a /pages/{id} or /nodes/{id} href (with or without a /w/{ws} prefix).
-_NODE_HREF_RE = re.compile(rf"/(?:pages|nodes)/({_UUID})(?:[/?#]|$)")
+# Pull the node id out of a /pages/{id}, /nodes/{id}, or /n/{id} href (with or
+# without a /w/{ws} prefix and optional slug suffix).
+_NODE_HREF_RE = re.compile(rf"/(?:pages|nodes|n)/({_UUID})(?:[/?#]|$)")
 
 
 def _href_to_node_id(href: str) -> uuid.UUID | None:

--- a/api/tests/test_backlinks.py
+++ b/api/tests/test_backlinks.py
@@ -50,6 +50,17 @@ class TestExtractLinkTargets:
         content = f"[link](/nodes/{tid})"
         assert extract_link_targets(content, "markdown") == {tid}
 
+    def test_markdown_app_n_route_href(self):
+        tid = uuid.uuid4()
+        ws = uuid.uuid4()
+        content = f"[link](/w/{ws}/n/{tid}/my-slug)"
+        assert extract_link_targets(content, "markdown") == {tid}
+
+    def test_markdown_n_route_without_workspace(self):
+        tid = uuid.uuid4()
+        content = f"[link](/n/{tid})"
+        assert extract_link_targets(content, "markdown") == {tid}
+
     def test_markdown_external_links_ignored(self):
         content = "[ext](https://example.com) and [anchor](#section)"
         assert extract_link_targets(content, "markdown") == set()
@@ -70,6 +81,23 @@ class TestExtractLinkTargets:
                         "type": "link",
                         "href": f"/w/ws/pages/{tid}",
                         "content": [{"type": "text", "text": "here"}],
+                    },
+                ],
+            }
+        ]
+        assert extract_link_targets(json.dumps(blocks), "json") == {tid}
+
+    def test_json_app_n_route_href(self):
+        tid = uuid.uuid4()
+        ws = uuid.uuid4()
+        blocks = [
+            {
+                "type": "paragraph",
+                "content": [
+                    {
+                        "type": "link",
+                        "href": f"/w/{ws}/n/{tid}",
+                        "content": [{"type": "text", "text": "Dev Test"}],
                     },
                 ],
             }

--- a/web/components/app-sidebar.tsx
+++ b/web/components/app-sidebar.tsx
@@ -710,6 +710,7 @@ function PagesPanel({
         />
       )}
       <DndContext
+        id={`marrow-sidebar-${tree.id}`}
         sensors={sensors}
         collisionDetection={closestCenter}
         onDragStart={onDragStart}

--- a/web/components/inset-header.tsx
+++ b/web/components/inset-header.tsx
@@ -13,6 +13,7 @@ interface Props {
   onShare: () => void;
   starred?: boolean;
   onToggleStar?: () => void;
+  onArchived?: () => void;
 }
 
 const MOCK_AVATARS = [
@@ -75,6 +76,7 @@ export function EditorHeader({
   onShare,
   starred,
   onToggleStar,
+  onArchived,
 }: Props) {
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -101,10 +103,12 @@ export function EditorHeader({
 
       <PageMenu
         nodeId={nodeId}
+        pageName={pageTitle}
         open={menuOpen}
         onOpenChange={setMenuOpen}
         starred={starred}
         onToggleStar={onToggleStar}
+        onArchived={onArchived}
         onOpenDrawer={(which) => {
           setMenuOpen(false);
           onOpenDrawer(which);

--- a/web/components/inset-header.tsx
+++ b/web/components/inset-header.tsx
@@ -13,7 +13,8 @@ interface Props {
   onShare: () => void;
   starred?: boolean;
   onToggleStar?: () => void;
-  onArchived?: () => void;
+  onArchive?: () => Promise<void>;
+  archiveNestedCount?: number;
 }
 
 const MOCK_AVATARS = [
@@ -76,7 +77,8 @@ export function EditorHeader({
   onShare,
   starred,
   onToggleStar,
-  onArchived,
+  onArchive,
+  archiveNestedCount,
 }: Props) {
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -104,11 +106,12 @@ export function EditorHeader({
       <PageMenu
         nodeId={nodeId}
         pageName={pageTitle}
+        archiveNestedCount={archiveNestedCount}
         open={menuOpen}
         onOpenChange={setMenuOpen}
         starred={starred}
         onToggleStar={onToggleStar}
-        onArchived={onArchived}
+        onArchive={onArchive}
         onOpenDrawer={(which) => {
           setMenuOpen(false);
           onOpenDrawer(which);

--- a/web/components/page-editor.tsx
+++ b/web/components/page-editor.tsx
@@ -208,8 +208,22 @@ export function PageEditor({ initialPage }: Props) {
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const saveNow = useCallback(async () => {
+  const syncEditorToPending = useCallback(() => {
+    if (isInitializingRef.current) return;
+    pendingContentRef.current = JSON.stringify(editor.document);
+  }, [editor]);
+
+  const isPageDirty = useCallback(() => {
+    return (
+      titleRef.current !== savedTitleRef.current ||
+      pendingContentRef.current !== savedContentRef.current
+    );
+  }, []);
+
+  const persistPageChanges = useCallback(async (): Promise<void> => {
     if (archivedRef.current) return;
+
+    syncEditorToPending();
 
     const currentTitle = titleRef.current;
     const currentContent = pendingContentRef.current;
@@ -224,33 +238,41 @@ export function PageEditor({ initialPage }: Props) {
     setStatus("saving");
     const generation = ++saveGenerationRef.current;
     const savePromise = (async () => {
-      try {
-        await updateNode(initialPage.id, {
-          name: newTitle,
-          content: newContent,
-          content_format: "json",
-        });
-        if (archivedRef.current) return;
-        savedTitleRef.current = currentTitle;
-        savedContentRef.current = currentContent;
-        setStatus("saved");
-        setTimeout(() => setStatus("idle"), 2000);
-      } catch (err) {
-        if (archivedRef.current) return;
-        toast.error(`Save failed: ${String(err)}`);
-        setStatus("error");
-      }
+      await updateNode(initialPage.id, {
+        name: newTitle,
+        content: newContent,
+        content_format: "json",
+      });
+      if (archivedRef.current) return;
+      savedTitleRef.current = currentTitle;
+      savedContentRef.current = currentContent;
+      setStatus("saved");
+      setTimeout(() => setStatus("idle"), 2000);
     })();
 
     saveInFlightRef.current = savePromise;
     try {
       await savePromise;
+    } catch (err) {
+      if (!archivedRef.current) {
+        toast.error(`Save failed: ${String(err)}`);
+        setStatus("error");
+      }
+      throw err;
     } finally {
       if (saveGenerationRef.current === generation) {
         saveInFlightRef.current = null;
       }
     }
-  }, [initialPage.id]);
+  }, [initialPage.id, syncEditorToPending]);
+
+  const saveNow = useCallback(async () => {
+    try {
+      await persistPageChanges();
+    } catch {
+      // persistPageChanges already surfaced the error toast
+    }
+  }, [persistPageChanges]);
 
   const scheduleSave = useCallback(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -444,27 +466,35 @@ export function PageEditor({ initialPage }: Props) {
     }
   }
 
+  /** Flush debounced edits and in-flight saves before destructive actions. */
+  const flushBeforeArchive = useCallback(async (): Promise<void> => {
+    syncEditorToPending();
+    cancelPendingSave();
+
+    if (saveInFlightRef.current) {
+      await saveInFlightRef.current;
+    }
+
+    syncEditorToPending();
+    if (isPageDirty()) {
+      await persistPageChanges();
+    }
+  }, [isPageDirty, persistPageChanges, syncEditorToPending]);
+
   const nodeInTree = tree ? findNodeById(tree, initialPage.id) : null;
   const archiveNestedCount =
     nodeInTree != null ? countDescendants(nodeInTree) : undefined;
 
   async function handleArchive() {
-    if (archivedRef.current) return;
+    if (archivedRef.current) {
+      throw new Error("Archive already in progress");
+    }
     if (!workspaceId) {
       toast.error("Couldn't archive page: workspace not found");
       throw new Error("workspaceId missing");
     }
 
-    cancelPendingSave();
-
-    if (saveInFlightRef.current) {
-      try {
-        await saveInFlightRef.current;
-      } catch {
-        // saveNow already surfaced the error — don't archive over a failed save.
-        throw new Error("Pending save failed");
-      }
-    }
+    await flushBeforeArchive();
 
     archivedRef.current = true;
 

--- a/web/components/page-editor.tsx
+++ b/web/components/page-editor.tsx
@@ -19,7 +19,7 @@ import "@blocknote/core/fonts/inter.css";
 import "@blocknote/mantine/style.css";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import { useTheme } from "next-themes";
 import {
   BlockNoteSchema,
@@ -39,7 +39,12 @@ import { calloutBlockSpec, calloutSlashMenuItem } from "@/components/editor/call
 import { mentionInlineContentSpec } from "@/components/editor/mention-inline-content";
 import { pageLinkSlashMenuItem } from "@/components/editor/page-link-slash-item";
 import { PropertyEditor } from "@/components/property-editor";
-import { useWorkspaceTree, findNodeById } from "@/components/workspace-tree-context";
+import {
+  useWorkspaceTree,
+  archiveDestinationPath,
+  countDescendants,
+  findNodeById,
+} from "@/components/workspace-tree-context";
 import {
   Dialog,
   DialogContent,
@@ -68,6 +73,7 @@ import { CommentBubbleFab } from "@/components/comment-bubble-fab";
 import { useComments } from "@/hooks/use-comments";
 import {
   attachmentFileUrl,
+  deleteNode,
   listAttachments,
   listOrgMembers,
   searchWorkspace,
@@ -129,7 +135,6 @@ export function PageEditor({ initialPage }: Props) {
   const [status, setStatus] = useState<SaveStatus>("idle");
   const [starred, setStarred] = useState(false);
   const { resolvedTheme } = useTheme();
-  const router = useRouter();
   const tree = useWorkspaceTree();
 
   // Extract workspaceId from the URL for page mention search
@@ -160,6 +165,8 @@ export function PageEditor({ initialPage }: Props) {
   const pendingContentRef = useRef(initialPage.content ?? "");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isInitializingRef = useRef(false);
+  const archivedRef = useRef(false);
+  const saveInFlightRef = useRef<Promise<void> | null>(null);
 
   useEffect(() => {
     titleRef.current = title;
@@ -201,6 +208,8 @@ export function PageEditor({ initialPage }: Props) {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const saveNow = useCallback(async () => {
+    if (archivedRef.current) return;
+
     const currentTitle = titleRef.current;
     const currentContent = pendingContentRef.current;
 
@@ -209,21 +218,35 @@ export function PageEditor({ initialPage }: Props) {
       currentContent !== savedContentRef.current ? currentContent : undefined;
 
     if (!newTitle && newContent === undefined) return;
+    if (archivedRef.current) return;
 
     setStatus("saving");
+    const savePromise = (async () => {
+      try {
+        await updateNode(initialPage.id, {
+          name: newTitle,
+          content: newContent,
+          content_format: "json",
+        });
+        if (archivedRef.current) return;
+        savedTitleRef.current = currentTitle;
+        savedContentRef.current = currentContent;
+        setStatus("saved");
+        setTimeout(() => setStatus("idle"), 2000);
+      } catch (err) {
+        if (archivedRef.current) return;
+        toast.error(`Save failed: ${String(err)}`);
+        setStatus("error");
+      }
+    })();
+
+    saveInFlightRef.current = savePromise;
     try {
-      await updateNode(initialPage.id, {
-        name: newTitle,
-        content: newContent,
-        content_format: "json",
-      });
-      savedTitleRef.current = currentTitle;
-      savedContentRef.current = currentContent;
-      setStatus("saved");
-      setTimeout(() => setStatus("idle"), 2000);
-    } catch (err) {
-      toast.error(`Save failed: ${String(err)}`);
-      setStatus("error");
+      await savePromise;
+    } finally {
+      if (saveInFlightRef.current === savePromise) {
+        saveInFlightRef.current = null;
+      }
     }
   }, [initialPage.id]);
 
@@ -412,19 +435,39 @@ export function PageEditor({ initialPage }: Props) {
     }
   }
 
-  function handleArchived() {
-    if (!workspaceId) return;
-    const parentId = initialPage.parent_id;
-    if (parentId && tree) {
-      const parent = findNodeById(tree, parentId);
-      if (parent) {
-        router.push(`/w/${workspaceId}/n/${parent.id}/${parent.slug}`);
-        router.refresh();
-        return;
-      }
+  function cancelPendingSave() {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
     }
-    router.push(`/w/${workspaceId}`);
-    router.refresh();
+  }
+
+  const nodeInTree = tree ? findNodeById(tree, initialPage.id) : null;
+  const archiveNestedCount =
+    nodeInTree != null ? countDescendants(nodeInTree) : undefined;
+
+  async function handleArchive() {
+    if (!workspaceId || archivedRef.current) return;
+
+    cancelPendingSave();
+    archivedRef.current = true;
+
+    if (saveInFlightRef.current) {
+      await saveInFlightRef.current.catch(() => {});
+    }
+
+    try {
+      await deleteNode(initialPage.id);
+      toast.success("Page archived");
+      const dest = archiveDestinationPath(workspaceId, initialPage, tree);
+      // Hard navigation: router.refresh() on the deleted URL re-fetches this page
+      // and 404s; a full load of the destination also refreshes the sidebar tree.
+      window.location.replace(dest);
+    } catch (err) {
+      archivedRef.current = false;
+      toast.error(`Couldn't archive page: ${String(err)}`);
+      throw err;
+    }
   }
 
   return (
@@ -437,7 +480,8 @@ export function PageEditor({ initialPage }: Props) {
         onShare={() => setShareOpen(true)}
         starred={starred}
         onToggleStar={handleToggleStar}
-        onArchived={handleArchived}
+        onArchive={handleArchive}
+        archiveNestedCount={archiveNestedCount}
       />
 
       <ShareDialog

--- a/web/components/page-editor.tsx
+++ b/web/components/page-editor.tsx
@@ -19,7 +19,7 @@ import "@blocknote/core/fonts/inter.css";
 import "@blocknote/mantine/style.css";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useTheme } from "next-themes";
 import {
   BlockNoteSchema,
@@ -39,7 +39,7 @@ import { calloutBlockSpec, calloutSlashMenuItem } from "@/components/editor/call
 import { mentionInlineContentSpec } from "@/components/editor/mention-inline-content";
 import { pageLinkSlashMenuItem } from "@/components/editor/page-link-slash-item";
 import { PropertyEditor } from "@/components/property-editor";
-import { useWorkspaceTree } from "@/components/workspace-tree-context";
+import { useWorkspaceTree, findNodeById } from "@/components/workspace-tree-context";
 import {
   Dialog,
   DialogContent,
@@ -129,6 +129,8 @@ export function PageEditor({ initialPage }: Props) {
   const [status, setStatus] = useState<SaveStatus>("idle");
   const [starred, setStarred] = useState(false);
   const { resolvedTheme } = useTheme();
+  const router = useRouter();
+  const tree = useWorkspaceTree();
 
   // Extract workspaceId from the URL for page mention search
   const params = useParams<{ workspaceId?: string }>();
@@ -274,7 +276,6 @@ export function PageEditor({ initialPage }: Props) {
   // @-mention suggestion menu — queries workspace members
   // ---------------------------------------------------------------------------
 
-  const tree = useWorkspaceTree();
   const orgId = tree?.org_id ?? null;
   const membersCacheRef = useRef<{ orgId: string; members: OrgMembership[] } | null>(null);
 
@@ -411,6 +412,21 @@ export function PageEditor({ initialPage }: Props) {
     }
   }
 
+  function handleArchived() {
+    if (!workspaceId) return;
+    const parentId = initialPage.parent_id;
+    if (parentId && tree) {
+      const parent = findNodeById(tree, parentId);
+      if (parent) {
+        router.push(`/w/${workspaceId}/n/${parent.id}/${parent.slug}`);
+        router.refresh();
+        return;
+      }
+    }
+    router.push(`/w/${workspaceId}`);
+    router.refresh();
+  }
+
   return (
     <div className="relative flex h-full flex-col">
       <EditorHeader
@@ -421,6 +437,7 @@ export function PageEditor({ initialPage }: Props) {
         onShare={() => setShareOpen(true)}
         starred={starred}
         onToggleStar={handleToggleStar}
+        onArchived={handleArchived}
       />
 
       <ShareDialog

--- a/web/components/page-editor.tsx
+++ b/web/components/page-editor.tsx
@@ -167,6 +167,7 @@ export function PageEditor({ initialPage }: Props) {
   const isInitializingRef = useRef(false);
   const archivedRef = useRef(false);
   const saveInFlightRef = useRef<Promise<void> | null>(null);
+  const saveGenerationRef = useRef(0);
 
   useEffect(() => {
     titleRef.current = title;
@@ -221,6 +222,7 @@ export function PageEditor({ initialPage }: Props) {
     if (archivedRef.current) return;
 
     setStatus("saving");
+    const generation = ++saveGenerationRef.current;
     const savePromise = (async () => {
       try {
         await updateNode(initialPage.id, {
@@ -244,7 +246,7 @@ export function PageEditor({ initialPage }: Props) {
     try {
       await savePromise;
     } finally {
-      if (saveInFlightRef.current === savePromise) {
+      if (saveGenerationRef.current === generation) {
         saveInFlightRef.current = null;
       }
     }
@@ -447,7 +449,11 @@ export function PageEditor({ initialPage }: Props) {
     nodeInTree != null ? countDescendants(nodeInTree) : undefined;
 
   async function handleArchive() {
-    if (!workspaceId || archivedRef.current) return;
+    if (archivedRef.current) return;
+    if (!workspaceId) {
+      toast.error("Couldn't archive page: workspace not found");
+      throw new Error("workspaceId missing");
+    }
 
     cancelPendingSave();
     archivedRef.current = true;

--- a/web/components/page-editor.tsx
+++ b/web/components/page-editor.tsx
@@ -166,8 +166,7 @@ export function PageEditor({ initialPage }: Props) {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isInitializingRef = useRef(false);
   const archivedRef = useRef(false);
-  const saveInFlightRef = useRef<Promise<void> | null>(null);
-  const saveGenerationRef = useRef(0);
+  const saveChainRef = useRef<Promise<void>>(Promise.resolve());
 
   useEffect(() => {
     titleRef.current = title;
@@ -223,47 +222,46 @@ export function PageEditor({ initialPage }: Props) {
   const persistPageChanges = useCallback(async (): Promise<void> => {
     if (archivedRef.current) return;
 
-    syncEditorToPending();
-
-    const currentTitle = titleRef.current;
-    const currentContent = pendingContentRef.current;
-
-    const newTitle = currentTitle !== savedTitleRef.current ? currentTitle : undefined;
-    const newContent =
-      currentContent !== savedContentRef.current ? currentContent : undefined;
-
-    if (!newTitle && newContent === undefined) return;
-    if (archivedRef.current) return;
-
-    setStatus("saving");
-    const generation = ++saveGenerationRef.current;
-    const savePromise = (async () => {
-      await updateNode(initialPage.id, {
-        name: newTitle,
-        content: newContent,
-        content_format: "json",
-      });
+    const doSave = async () => {
       if (archivedRef.current) return;
-      savedTitleRef.current = currentTitle;
-      savedContentRef.current = currentContent;
-      setStatus("saved");
-      setTimeout(() => setStatus("idle"), 2000);
-    })();
 
-    saveInFlightRef.current = savePromise;
-    try {
-      await savePromise;
-    } catch (err) {
-      if (!archivedRef.current) {
-        toast.error(`Save failed: ${String(err)}`);
-        setStatus("error");
+      syncEditorToPending();
+
+      const currentTitle = titleRef.current;
+      const currentContent = pendingContentRef.current;
+
+      const newTitle = currentTitle !== savedTitleRef.current ? currentTitle : undefined;
+      const newContent =
+        currentContent !== savedContentRef.current ? currentContent : undefined;
+
+      if (!newTitle && newContent === undefined) return;
+      if (archivedRef.current) return;
+
+      setStatus("saving");
+      try {
+        await updateNode(initialPage.id, {
+          name: newTitle,
+          content: newContent,
+          content_format: "json",
+        });
+        if (archivedRef.current) return;
+        savedTitleRef.current = currentTitle;
+        savedContentRef.current = currentContent;
+        setStatus("saved");
+        setTimeout(() => setStatus("idle"), 2000);
+      } catch (err) {
+        if (!archivedRef.current) {
+          toast.error(`Save failed: ${String(err)}`);
+          setStatus("error");
+        }
+        throw err;
       }
-      throw err;
-    } finally {
-      if (saveGenerationRef.current === generation) {
-        saveInFlightRef.current = null;
-      }
-    }
+    };
+
+    const chained = saveChainRef.current.then(doSave, doSave);
+    // Keep the chain alive after a failure so later saves can run.
+    saveChainRef.current = chained.catch(() => {});
+    await chained;
   }, [initialPage.id, syncEditorToPending]);
 
   const saveNow = useCallback(async () => {
@@ -466,19 +464,16 @@ export function PageEditor({ initialPage }: Props) {
     }
   }
 
-  /** Flush debounced edits and in-flight saves before destructive actions. */
+  /** Flush debounced edits and all queued saves before destructive actions. */
   const flushBeforeArchive = useCallback(async (): Promise<void> => {
     syncEditorToPending();
     cancelPendingSave();
 
-    if (saveInFlightRef.current) {
-      await saveInFlightRef.current;
-    }
-
-    syncEditorToPending();
     if (isPageDirty()) {
       await persistPageChanges();
     }
+
+    await saveChainRef.current;
   }, [isPageDirty, persistPageChanges, syncEditorToPending]);
 
   const nodeInTree = tree ? findNodeById(tree, initialPage.id) : null;

--- a/web/components/page-editor.tsx
+++ b/web/components/page-editor.tsx
@@ -456,11 +456,17 @@ export function PageEditor({ initialPage }: Props) {
     }
 
     cancelPendingSave();
-    archivedRef.current = true;
 
     if (saveInFlightRef.current) {
-      await saveInFlightRef.current.catch(() => {});
+      try {
+        await saveInFlightRef.current;
+      } catch {
+        // saveNow already surfaced the error — don't archive over a failed save.
+        throw new Error("Pending save failed");
+      }
     }
+
+    archivedRef.current = true;
 
     try {
       await deleteNode(initialPage.id);

--- a/web/components/page-menu.tsx
+++ b/web/components/page-menu.tsx
@@ -23,7 +23,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { deleteNode, getBacklinks, getWatchStatus, unwatchNode, watchNode } from "@/lib/api";
+import { getBacklinks, getWatchStatus, unwatchNode, watchNode } from "@/lib/api";
 
 export type PageMenuDrawer = "backlinks" | "history";
 
@@ -72,8 +72,10 @@ interface Props {
   nodeId?: string;
   /** Display name for archive confirmation. */
   pageName?: string;
-  /** Invoked after a successful archive (e.g. navigate away). */
-  onArchived?: () => void;
+  /** Nested pages/folders archived with this page; omit when unknown. */
+  archiveNestedCount?: number;
+  /** Soft-delete handler — caller owns navigation and save cancellation. */
+  onArchive?: () => Promise<void>;
 }
 
 export function PageMenu({
@@ -85,7 +87,8 @@ export function PageMenu({
   onToggleStar,
   nodeId,
   pageName = "this page",
-  onArchived,
+  archiveNestedCount = 0,
+  onArchive,
 }: Props) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [watching, setWatching] = useState<boolean | null>(null);
@@ -139,16 +142,14 @@ export function PageMenu({
   }
 
   async function confirmArchive() {
-    if (!nodeId || archiveBusy) return;
+    if (!nodeId || archiveBusy || !onArchive) return;
     setArchiveBusy(true);
     try {
-      await deleteNode(nodeId);
+      await onArchive();
       setArchiveOpen(false);
       onOpenChange(false);
-      toast.success("Page archived");
-      onArchived?.();
     } catch {
-      toast.error("Couldn't archive page");
+      // onArchive shows the error toast
     } finally {
       setArchiveBusy(false);
     }
@@ -256,8 +257,19 @@ export function PageMenu({
           <DialogHeader>
             <DialogTitle>Archive this page?</DialogTitle>
             <DialogDescription>
-              Archiving moves &ldquo;{pageName}&rdquo; and everything nested under it to
-              trash.
+              {archiveNestedCount != null && archiveNestedCount > 0 ? (
+                <>
+                  Archiving moves &ldquo;{pageName}&rdquo; and {archiveNestedCount} nested{" "}
+                  {archiveNestedCount === 1 ? "item" : "items"} to trash.
+                </>
+              ) : archiveNestedCount === 0 ? (
+                <>Archiving moves &ldquo;{pageName}&rdquo; to trash.</>
+              ) : (
+                <>
+                  Archiving moves &ldquo;{pageName}&rdquo; and everything nested under it to
+                  trash.
+                </>
+              )}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/web/components/page-menu.tsx
+++ b/web/components/page-menu.tsx
@@ -87,7 +87,7 @@ export function PageMenu({
   onToggleStar,
   nodeId,
   pageName = "this page",
-  archiveNestedCount = 0,
+  archiveNestedCount,
   onArchive,
 }: Props) {
   const wrapperRef = useRef<HTMLDivElement>(null);

--- a/web/components/page-menu.tsx
+++ b/web/components/page-menu.tsx
@@ -256,7 +256,8 @@ export function PageMenu({
           <DialogHeader>
             <DialogTitle>Archive this page?</DialogTitle>
             <DialogDescription>
-              &ldquo;{pageName}&rdquo; will be moved to trash.
+              Archiving moves &ldquo;{pageName}&rdquo; and everything nested under it to
+              trash.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/web/components/page-menu.tsx
+++ b/web/components/page-menu.tsx
@@ -14,7 +14,16 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
-import { getWatchStatus, unwatchNode, watchNode } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { deleteNode, getBacklinks, getWatchStatus, unwatchNode, watchNode } from "@/lib/api";
 
 export type PageMenuDrawer = "backlinks" | "history";
 
@@ -37,7 +46,7 @@ type Item =
     };
 
 const ITEMS: Item[] = [
-  { kind: "drawer", id: "backlinks", icon: LinkIcon, label: "Backlinks", meta: "0" },
+  { kind: "drawer", id: "backlinks", icon: LinkIcon, label: "Backlinks" },
   { kind: "drawer", id: "history", icon: History, label: "Version history" },
   { kind: "divider" },
   { kind: "action", id: "star", icon: Star, label: "Star", meta: "⌥S" },
@@ -61,6 +70,10 @@ interface Props {
   onToggleStar?: () => void;
   /** Node (page or folder) this menu acts on; enables the Watch toggle. */
   nodeId?: string;
+  /** Display name for archive confirmation. */
+  pageName?: string;
+  /** Invoked after a successful archive (e.g. navigate away). */
+  onArchived?: () => void;
 }
 
 export function PageMenu({
@@ -71,10 +84,15 @@ export function PageMenu({
   starred = false,
   onToggleStar,
   nodeId,
+  pageName = "this page",
+  onArchived,
 }: Props) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [watching, setWatching] = useState<boolean | null>(null);
   const [watchBusy, setWatchBusy] = useState(false);
+  const [backlinkCount, setBacklinkCount] = useState<number | null>(null);
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const [archiveBusy, setArchiveBusy] = useState(false);
 
   // Load the current watch state each time the menu opens so the toggle
   // reflects reality (it may have changed in another tab/session).
@@ -84,6 +102,17 @@ export function PageMenu({
     getWatchStatus(nodeId)
       .then((s) => !cancelled && setWatching(s.watching))
       .catch(() => !cancelled && setWatching(null));
+    return () => {
+      cancelled = true;
+    };
+  }, [open, nodeId]);
+
+  useEffect(() => {
+    if (!open || !nodeId) return;
+    let cancelled = false;
+    getBacklinks(nodeId)
+      .then((links) => !cancelled && setBacklinkCount(links.length))
+      .catch(() => !cancelled && setBacklinkCount(null));
     return () => {
       cancelled = true;
     };
@@ -106,6 +135,22 @@ export function PageMenu({
       toast.error("Couldn't update watch status");
     } finally {
       setWatchBusy(false);
+    }
+  }
+
+  async function confirmArchive() {
+    if (!nodeId || archiveBusy) return;
+    setArchiveBusy(true);
+    try {
+      await deleteNode(nodeId);
+      setArchiveOpen(false);
+      onOpenChange(false);
+      toast.success("Page archived");
+      onArchived?.();
+    } catch {
+      toast.error("Couldn't archive page");
+    } finally {
+      setArchiveBusy(false);
     }
   }
 
@@ -153,9 +198,14 @@ export function PageMenu({
             }
 
             const isStar = item.kind === "action" && item.id === "star";
+            const isArchive = item.kind === "action" && item.id === "archive";
             const Icon = item.icon;
             const destructive = item.kind === "action" && item.destructive;
             const label = isStar ? (starred ? "Unstar" : "Star") : item.label;
+            const meta =
+              item.kind === "drawer" && item.id === "backlinks" && backlinkCount !== null
+                ? String(backlinkCount)
+                : item.meta;
 
             return (
               <button
@@ -168,6 +218,9 @@ export function PageMenu({
                   } else if (isStar && onToggleStar) {
                     onToggleStar();
                     onOpenChange(false);
+                  } else if (isArchive) {
+                    onOpenChange(false);
+                    setArchiveOpen(true);
                   } else {
                     toast.info(`${label} — coming soon`);
                     onOpenChange(false);
@@ -187,9 +240,9 @@ export function PageMenu({
                   }`}
                 />
                 <span className="flex-1">{label}</span>
-                {item.meta && (
+                {meta && (
                   <span className="font-mono text-[10px] text-muted-foreground">
-                    {item.meta}
+                    {meta}
                   </span>
                 )}
               </button>
@@ -197,6 +250,35 @@ export function PageMenu({
           })}
         </div>
       )}
+
+      <Dialog open={archiveOpen} onOpenChange={(next) => !archiveBusy && setArchiveOpen(next)}>
+        <DialogContent showCloseButton={!archiveBusy} className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Archive this page?</DialogTitle>
+            <DialogDescription>
+              &ldquo;{pageName}&rdquo; will be moved to trash.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={archiveBusy}
+              onClick={() => setArchiveOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={archiveBusy}
+              onClick={confirmArchive}
+            >
+              {archiveBusy ? "Archiving…" : "Archive"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/web/components/workspace-tree-context.tsx
+++ b/web/components/workspace-tree-context.tsx
@@ -51,6 +51,28 @@ export function findNodeById(
   return null;
 }
 
+/** Post-archive navigation target: parent node, or workspace home when unknown. */
+export function archiveDestinationPath(
+  workspaceId: string,
+  page: { parent_id: string | null },
+  tree: WorkspaceTree | null,
+): string {
+  if (page.parent_id && tree) {
+    const parent = findNodeById(tree, page.parent_id);
+    if (parent) {
+      return `/w/${workspaceId}/n/${parent.id}/${parent.slug}`;
+    }
+  }
+  return `/w/${workspaceId}`;
+}
+
+export function countDescendants(node: NodeTreeItem): number {
+  return node.children.reduce(
+    (sum, child) => sum + 1 + countDescendants(child),
+    0,
+  );
+}
+
 /**
  * @deprecated v0.1 collection-based breadcrumb. Always returns null in v0.2 —
  * callers should migrate to findNodeBreadcrumb. Kept as a no-op for incremental

--- a/web/components/workspace-tree-context.tsx
+++ b/web/components/workspace-tree-context.tsx
@@ -40,6 +40,17 @@ export function findNodeBreadcrumb(
   return null;
 }
 
+export function findNodeById(
+  tree: WorkspaceTree,
+  nodeId: string,
+): NodeTreeItem | null {
+  for (const space of tree.spaces) {
+    const path = findPath(space.nodes, nodeId, []);
+    if (path) return path[path.length - 1];
+  }
+  return null;
+}
+
 /**
  * @deprecated v0.1 collection-based breadcrumb. Always returns null in v0.2 —
  * callers should migrate to findNodeBreadcrumb. Kept as a no-op for incremental


### PR DESCRIPTION
## Summary

Closes #229.

- Page menu fetches and displays a live backlink count from `getBacklinks` when opened (replaces hardcoded `"0"`).
- Archive opens a confirm dialog, calls `deleteNode`, then navigates to the parent node (or workspace home) and refreshes the sidebar tree.
- Star and watch behavior unchanged; full trash list UI remains out of scope.

## Test plan

- [x] Open a page with backlinks — page menu shows the correct count next to "Backlinks"
- [x] Open a page with no backlinks — count shows `0`
- [x] Click Archive — confirm dialog shows page title; Cancel dismisses without changes
- [x] Confirm Archive — page is soft-deleted, toast appears, navigates to parent folder/page
- [x] Archive a space-root page — navigates to workspace home
- [x] Star and Watch toggles still work as before


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Archive is a destructive user action with navigation and save-race handling; backlink regex and UI changes are well-tested but archive touches core editor persistence paths.
> 
> **Overview**
> The page menu now loads a **live backlink count** from `getBacklinks` when opened (replacing the hardcoded `"0"`), and **Archive** is wired end-to-end: confirm dialog with page title and nested-item messaging, soft-delete via `deleteNode`, then hard navigation to the parent page or workspace home.
> 
> **PageEditor** flushes debounced and in-flight saves before archive, blocks further saves after delete, and uses new tree helpers (`findNodeById`, `countDescendants`, `archiveDestinationPath`) for confirmation copy and redirect. Sidebar **DndContext** gets a stable `id` per workspace.
> 
> On the API, backlink parsing now recognizes app **`/n/{node-id}`** hrefs (with optional `/w/{workspace}` prefix and slug suffix) in markdown and BlockNote JSON, with matching unit tests—so links inserted as `/w/.../n/...` reconcile into `node_links` correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff800560c3c9ef0e74900a15bb16ab0d614303ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->