### PR TITLE
fix: solo-first onboarding and self-host-first landing (#242, #243)

### DIFF
--- a/web-marketing/components/chrome.tsx
+++ b/web-marketing/components/chrome.tsx
@@ -6,6 +6,7 @@ import { MarrowWordmark, SunIcon, MoonIcon } from "./icons";
 import { useTheme } from "./theme-provider";
 
 export const APP_URL = "https://app.marrow.so";
+export const SELF_HOST_DOCS_URL = "https://docs.marrow.so/deployment/docker-compose/";
 
 const navLinks = [
   { href: "/", label: "Product" },
@@ -101,12 +102,26 @@ export function SiteNav() {
             fontWeight: 500,
             padding: "0.5rem 1rem",
             borderRadius: "0.5rem",
+            border: "1px solid var(--color-border)",
+            color: "var(--color-text-primary)",
+            textDecoration: "none",
+          }}
+        >
+          Open Marrow
+        </a>
+        <a
+          href={SELF_HOST_DOCS_URL}
+          style={{
+            fontSize: "0.875rem",
+            fontWeight: 500,
+            padding: "0.5rem 1rem",
+            borderRadius: "0.5rem",
             background: "var(--color-accent)",
             color: "var(--color-accent-ink)",
             textDecoration: "none",
           }}
         >
-          Open Marrow
+          Self-host
         </a>
       </div>
     </header>

--- a/web-marketing/components/landing/landing.tsx
+++ b/web-marketing/components/landing/landing.tsx
@@ -4,7 +4,7 @@
 // APP_URL, pricing at /pricing, docs at docs.marrow.so.
 
 import type { ComponentType, CSSProperties } from "react";
-import { APP_URL, Button, Eyebrow } from "@/components/chrome";
+import { APP_URL, Button, Eyebrow, SELF_HOST_DOCS_URL } from "@/components/chrome";
 import {
   CheckIcon,
   IconArrow,
@@ -18,8 +18,6 @@ import {
   IconFeather,
   IconX,
 } from "@/components/icons";
-
-const DOCS_URL = "https://docs.marrow.so";
 
 export function Landing() {
   return (
@@ -79,15 +77,15 @@ export function Landing() {
                   color: "var(--color-text-secondary)",
                 }}
               >
-                Marrow is a quiet, self-hosted home for your team&apos;s notes, docs, and decisions — built in
-                plain Markdown, yours forever, editable anywhere.
+                Marrow is a quiet, self-hosted knowledge base — plain Markdown on your disk, a
+                restore guarantee you can audit, and no vendor lock-in.
               </p>
               <div style={{ display: "flex", gap: 12, marginTop: 36 }}>
-                <Button variant="primary" size="lg" href={APP_URL}>
-                  Try the editor <IconArrow size={15} />
+                <Button variant="primary" size="lg" href={SELF_HOST_DOCS_URL}>
+                  <IconServer size={15} /> Self-host with Docker
                 </Button>
-                <Button variant="secondary" size="lg" href="/pricing">
-                  Self-host for free
+                <Button variant="secondary" size="lg" href={APP_URL}>
+                  Try Marrow Cloud <IconArrow size={15} />
                 </Button>
               </div>
               <div
@@ -102,7 +100,7 @@ export function Landing() {
                 }}
               >
                 <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
-                  <IconGit size={14} /> MIT licensed
+                  <IconGit size={14} /> Apache 2.0
                 </span>
                 <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
                   <IconServer size={14} /> Postgres + Markdown
@@ -138,8 +136,10 @@ export function Landing() {
               fontVariationSettings: '"SOFT" 100',
             }}
           >
-            Your team&apos;s knowledge shouldn&apos;t depend on whether a&nbsp;vendor stays in&nbsp;business.{" "}
-            <span style={{ color: "var(--color-accent)" }}>Marrow is the part that&nbsp;stays.</span>
+            Your notes shouldn&apos;t vanish when a vendor changes the rules.{" "}
+            <span style={{ color: "var(--color-accent)" }}>
+              Marrow exports to files you own — the part that&nbsp;stays.
+            </span>
           </p>
         </div>
       </section>
@@ -224,8 +224,8 @@ export function Landing() {
                 up by copying a folder.
               </p>
               <div style={{ marginTop: 32, display: "flex", gap: 12 }}>
-                <Button variant="primary" href={DOCS_URL}>
-                  <IconServer size={14} /> Deploy On-prem
+                <Button variant="primary" href={SELF_HOST_DOCS_URL}>
+                  <IconServer size={14} /> Deploy on-prem
                 </Button>
               </div>
             </div>
@@ -316,11 +316,11 @@ export function Landing() {
             No lock-in, no migration rituals, no someday-when-we-have-time. Start writing today.
           </p>
           <div style={{ marginTop: 40, display: "flex", gap: 12, justifyContent: "center" }}>
-            <Button variant="primary" size="lg" href={APP_URL}>
-              Open Marrow <IconArrow size={15} />
+            <Button variant="primary" size="lg" href={SELF_HOST_DOCS_URL}>
+              <IconServer size={15} /> Self-host with Docker
             </Button>
-            <Button variant="secondary" size="lg" href="/pricing">
-              See pricing
+            <Button variant="secondary" size="lg" href={APP_URL}>
+              Try Marrow Cloud <IconArrow size={15} />
             </Button>
           </div>
         </div>
@@ -754,9 +754,8 @@ Related:: [[RFC-0142]] [[Runbook / Ingest]]
 function Comparison() {
   const rows = [
     { feat: "Your data is in", marrow: "Plain Markdown on your disk", others: "A proprietary DB you lease" },
-    { feat: "Works offline", marrow: "Yes — local-first sync", others: "Degraded or not at all" },
     { feat: "Hosting", marrow: "Self-host, or Cloud", others: "Cloud only" },
-    { feat: 'AI "features"', marrow: "Off by default. BYO key.", others: "Mandatory. Upsold." },
+    { feat: "Built-in AI", marrow: "None — just your words", others: "Mandatory. Upsold." },
     { feat: "Pricing model", marrow: "Per workspace, not per seat", others: "Per seat, escalating" },
     { feat: "When the vendor folds", marrow: "You keep the files", others: "You keep the zip, good luck" },
   ];

--- a/web-marketing/tests/landing.spec.ts
+++ b/web-marketing/tests/landing.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 const APP_URL = "https://app.marrow.so";
+const SELF_HOST_DOCS_URL = "https://docs.marrow.so/deployment/docker-compose/";
 
 // These are assertion-based DOM smoke tests (not pixel snapshots). Each one
 // would have caught a specific bug from the design-handoff alignment work:
@@ -20,9 +21,12 @@ test.describe("marketing landing", () => {
     await expect(page.locator('header svg[viewBox="0 0 32 32"]').first()).toBeVisible();
   });
 
-  test("primary CTA and Sign in both point at the app", async ({ page }) => {
+  test("nav CTAs are self-host-first: Self-host primary, Cloud secondary", async ({ page }) => {
     await page.goto("/");
     const header = page.locator("header");
+
+    const selfHost = header.getByRole("link", { name: "Self-host", exact: true });
+    await expect(selfHost).toHaveAttribute("href", SELF_HOST_DOCS_URL);
 
     const openMarrow = header.getByRole("link", { name: "Open Marrow" });
     await expect(openMarrow).toHaveAttribute("href", APP_URL);
@@ -30,9 +34,24 @@ test.describe("marketing landing", () => {
     const signIn = header.getByRole("link", { name: "Sign in", exact: true });
     await expect(signIn).toHaveAttribute("href", APP_URL);
 
-    // The primary CTA must not regress back to pointing at GitHub.
-    const openHref = await openMarrow.getAttribute("href");
-    expect(openHref).not.toContain("github");
+    const selfHostHref = await selfHost.getAttribute("href");
+    expect(selfHostHref).not.toContain("github");
+    expect(selfHostHref).not.toContain("app.marrow.so");
+  });
+
+  test("hero leads with self-host and accurate license badge", async ({ page }) => {
+    await page.goto("/");
+
+    const heroSelfHost = page.getByRole("link", { name: /Self-host with Docker/i }).first();
+    await expect(heroSelfHost).toHaveAttribute("href", SELF_HOST_DOCS_URL);
+
+    const heroCloud = page.getByRole("link", { name: /Try Marrow Cloud/i }).first();
+    await expect(heroCloud).toHaveAttribute("href", APP_URL);
+
+    await expect(page.getByRole("main").getByText("Apache 2.0")).toBeVisible();
+    await expect(page.getByText("MIT licensed")).toHaveCount(0);
+    await expect(page.getByText(/Works offline/i)).toHaveCount(0);
+    await expect(page.getByText(/local-first sync/i)).toHaveCount(0);
   });
 
   for (const path of ["/", "/product", "/pricing"]) {
@@ -40,8 +59,9 @@ test.describe("marketing landing", () => {
       const response = await page.goto(path);
       expect(response?.status()).toBe(200);
 
-      // SiteNav present: header with the brand glyph + the Open Marrow CTA.
+      // SiteNav present: header with the brand glyph + the self-host-first CTAs.
       await expect(page.locator('header svg[viewBox="0 0 32 32"]').first()).toBeVisible();
+      await expect(page.locator("header").getByRole("link", { name: "Self-host", exact: true })).toBeVisible();
       await expect(page.locator("header").getByRole("link", { name: "Open Marrow" })).toBeVisible();
 
       // No link anywhere resolves to the dead /signup route.

--- a/web/app/onboarding/page.tsx
+++ b/web/app/onboarding/page.tsx
@@ -53,7 +53,7 @@ export default function OnboardingPage() {
           return;
         }
         setOrg(pending);
-        setName(pending.name);
+        // Leave name empty so the personalized placeholder is visible; submit falls back to it.
         setLoading(false);
       } catch {
         if (!cancelled) router.replace("/login");
@@ -66,11 +66,12 @@ export default function OnboardingPage() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!org || !name.trim()) return;
+    const finalName = name.trim() || placeholder;
+    if (!org || !finalName) return;
     setBusy(true);
     setError(null);
     try {
-      await completeOnboarding(org.id, name.trim());
+      await completeOnboarding(org.id, finalName);
     } catch (err) {
       setBusy(false);
       setError(err instanceof Error ? err.message : "Couldn't save your name. Try again.");
@@ -116,7 +117,7 @@ export default function OnboardingPage() {
           />
           {error && <p className="text-destructive text-sm">{error}</p>}
         </div>
-        <Button type="submit" size="lg" className="w-full" disabled={busy || !name.trim()}>
+        <Button type="submit" size="lg" className="w-full" disabled={busy}>
           {busy ? "Saving…" : "Continue"}
         </Button>
       </form>

--- a/web/app/onboarding/page.tsx
+++ b/web/app/onboarding/page.tsx
@@ -9,14 +9,20 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 /**
- * First-run onboarding: name the auto-created organization. Shown when
- * AuthStatus.needs_onboarding is true (the user owns an org with
+ * First-run onboarding: name the auto-created org (solo-first copy in the UI).
+ * Shown when AuthStatus.needs_onboarding is true (the user owns an org with
  * onboarded_at unset). Gate order is onboarding → subscription → home.
  */
+function namePlaceholder(userName: string | undefined): string {
+  const first = userName?.trim().split(/\s+/)[0];
+  return first || "My knowledge";
+}
+
 export default function OnboardingPage() {
   const router = useRouter();
   const [org, setOrg] = useState<Organization | null>(null);
   const [name, setName] = useState("");
+  const [placeholder, setPlaceholder] = useState("My knowledge");
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -27,6 +33,7 @@ export default function OnboardingPage() {
       try {
         const status = await getAuthStatus();
         if (cancelled) return;
+        setPlaceholder(namePlaceholder(status.user?.name));
         if (!status.authenticated) {
           router.replace("/login");
           return;
@@ -66,7 +73,7 @@ export default function OnboardingPage() {
       await completeOnboarding(org.id, name.trim());
     } catch (err) {
       setBusy(false);
-      setError(err instanceof Error ? err.message : "Failed to save organization name");
+      setError(err instanceof Error ? err.message : "Couldn't save your name. Try again.");
       return;
     }
     try {
@@ -77,7 +84,7 @@ export default function OnboardingPage() {
       router.replace(path);
     } catch {
       setBusy(false);
-      setError("Organization saved, but we couldn't continue. Try refreshing the page.");
+      setError("Saved, but we couldn't continue. Try refreshing the page.");
     }
   }
 
@@ -93,10 +100,9 @@ export default function OnboardingPage() {
     <div className="flex min-h-screen items-center justify-center px-6">
       <form onSubmit={handleSubmit} className="w-full max-w-md space-y-6">
         <div className="space-y-2 text-center">
-          <h1 className="text-2xl font-bold tracking-tight">Name your organization</h1>
+          <h1 className="text-2xl font-bold tracking-tight">What should we call your Marrow?</h1>
           <p className="text-muted-foreground text-sm">
-            This is how your team&apos;s workspace will appear in Marrow. You can change it
-            anytime in organization settings.
+            This is your private home for notes and docs. You can invite others later.
           </p>
         </div>
         <div className="space-y-2">
@@ -104,9 +110,9 @@ export default function OnboardingPage() {
             autoFocus
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="Acme Inc."
+            placeholder={placeholder}
             disabled={busy}
-            aria-label="Organization name"
+            aria-label="Knowledge base name"
           />
           {error && <p className="text-destructive text-sm">{error}</p>}
         </div>


### PR DESCRIPTION
## Summary

- **#242 — Solo-first onboarding:** Reframe `/onboarding` for individual users ("What should we call your Marrow?"), personalized placeholder from the user's first name, and friendlier error copy.
- **#243 — Landing integrity + self-host-first CTAs:** Nav and hero lead with Self-host (Docker docs); Marrow Cloud is secondary. Fix Apache 2.0 license badge, remove unsupported offline/local-first claims, tighten comparison table copy, and update Playwright smoke tests.

Closes #242
Closes #243

## Test plan

- [x] `cd web-marketing && npm run lint && npm run build`
- [x] `cd web-marketing && npx playwright test` (7 tests pass)
- [x] `cd web && npm run lint`
- [ ] Manual: visit `/onboarding` after fresh login — copy reads solo-first, placeholder uses first name
- [ ] Manual: visit marrow.so landing — hero/nav CTAs are self-host-first, no MIT/offline claims


Made with [Cursor](https://cursor.com)