### PR TITLE
docs: prominent API-key path for solo self-host (#245)

### DIFF
--- a/docs/src/content/docs/getting-started/quickstart.md
+++ b/docs/src/content/docs/getting-started/quickstart.md
@@ -5,6 +5,59 @@ description: Run Marrow locally for development.
 
 This walks you through running Marrow on your machine for development. For production deployment, see [Docker Compose](/deployment/docker-compose/) or [Cloudflare](/deployment/cloudflare/).
 
+## Solo self-host without OIDC
+
+If you want a **single-user instance with no identity provider** — common for beachhead self-hosters auditing the bundle — use a static API key instead of OIDC.
+
+:::caution[Production security]
+An API key grants **superuser access**: it bypasses org RBAC (same as the CLI). Fine for a solo instance you control; **not** for multi-tenant production unless every caller is trusted. Prefer [OIDC](/configuration/oidc/) when multiple people share one deployment.
+:::
+
+### Local dev (API + web)
+
+1. Generate a key: `openssl rand -hex 32`
+2. **Backend** — in `api/.env`:
+
+   ```text
+   API_KEY=your-generated-key-here
+   ```
+
+3. **Frontend** — in `web/.env.local`:
+
+   ```text
+   MARROW_API_KEY=your-generated-key-here
+   ```
+
+4. Start Postgres, API, and web as in [steps 2–4](#2-start-postgresql) below. The browser sends the key automatically; no login screen.
+
+**CLI** talks to Postgres directly (not the HTTP API). With `api/.env` configured and venv active:
+
+```bash
+cd api
+source .venv/bin/activate
+marrow export --workspace mydocs --output ./backup.zip
+marrow restore ./backup.zip
+```
+
+**HTTP API** calls use the same key as a header:
+
+```bash
+curl -H "X-API-Key: your-generated-key-here" http://localhost:8000/api/workspaces/
+```
+
+### Docker Compose (solo production)
+
+For a minimal solo stack, set the same key in the root `.env` used by `docker-compose.prod.yml`:
+
+```text
+API_KEY=your-generated-key-here
+MARROW_API_KEY=your-generated-key-here
+```
+
+Leave OIDC vars unset and `MARROW_OIDC_ENABLED` unset/false. See [Docker Compose deployment](/deployment/docker-compose/) for the full bring-up sequence.
+
+Full variable reference: [Environment variables](/configuration/env-vars/).
+
 ## Prerequisites
 
 - Python 3.11+

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -7,7 +7,7 @@ Marrow is a self-hosted, open-source knowledge base. Every workspace can be expo
 
 ## Where to start
 
-- **[Quickstart](/getting-started/quickstart/)** — get a local instance running.
+- **[Quickstart](/getting-started/quickstart/)** — get a local instance running (includes a [solo API-key path](/getting-started/quickstart/#solo-self-host-without-oidc) with no IdP).
 - **[Docker Compose](/deployment/docker-compose/)** — production-style self-host.
 - **[OIDC](/configuration/oidc/)** — wire Marrow up to Google, Keycloak, or any OIDC provider.
 - **[Restore guarantee](/concepts/restore-guarantee/)** — the architectural foundation.


### PR DESCRIPTION
## Summary
- Add a "Solo self-host without OIDC" section to the quickstart covering `API_KEY` / `MARROW_API_KEY`, CLI vs HTTP `X-API-Key`, and Docker Compose solo setup
- Update the docs index to call out the API-key path
- Retain production RBAC-bypass warning for API-key auth

Closes #245

## Test plan
- [x] `cd docs && npm run build`
- [ ] Skim rendered page at `/getting-started/quickstart/#solo-self-host-without-oidc`


Made with [Cursor](https://cursor.com)