### PR TITLE
docs(changelog): cut 0.4.0 (beachhead activation + restore integrity)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -35,7 +35,7 @@ POSTGRES_PASSWORD=replace-with-a-strong-password
 
 # --- Optional ---
 # Pin the GHCR API image tag. Must match the git tag you checked out; update on upgrade.
-# MARROW_VERSION=v0.3.3
+# MARROW_VERSION=v0.4.0
 # API_PORT=8000
 # WEB_PORT=3000
 # CORS_ORIGINS=https://app.example.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Each release also has fuller narrative notes (highlights, breaking changes, upgrade
 steps) on its [GitHub release](https://github.com/marrow-software/marrow/releases).
 
+## [0.4.0] — 2026-07-10
+
+### Added
+- Page archiving from the page menu — soft-deletes the page (and warns when nested
+  content is trashed); flushes unsaved edits before archiving. (#229)
+- `include_trash` option on workspace export (API + export dialog) so soft-deleted
+  nodes round-trip when explicitly requested.
+- First-run workspace provisioning on onboarding completion — completing `/onboarding`
+  creates a default workspace + space so new users land in a writable tree, not an
+  empty `/home` picker. (#241)
+- Docs: v4 export/restore scope table and planned v5 gaps (comments, share links,
+  node views). (#244)
+- Docs: prominent API-key solo self-host quickstart (no IdP). (#245)
+- Docs: export/restore walkthrough linked from README. (#246)
+
+### Changed
+- Solo-first onboarding copy — ownership language instead of team/org vocabulary. (#242)
+- Marketing landing — self-host-first CTAs, Apache 2.0 badge, removed false claims
+  (offline sync, MIT license). (#243)
+- Backlink index export/restore hardened; wiki-links using `/n/{id}` app routes are
+  now indexed.
+
+### Fixed
+- Archive flow races (unsaved edits, in-flight saves, 404 edge cases).
+- Node route links in rail panels (starred, inbox, side drawer).
+- Post-gate redirect and onboarding enforcement on workspace routes.
+- Docs site TypeScript config resolution after `npm ci`.
+
 ## [0.3.3] — 2026-06-21
 
 ### Fixed
@@ -150,6 +178,7 @@ restore guarantee.
 - PostgreSQL full-text search.
 - BlockNote rich-text editor.
 
+[0.4.0]: https://github.com/marrow-software/marrow/releases/tag/v0.4.0
 [0.3.3]: https://github.com/marrow-software/marrow/releases/tag/v0.3.3
 [0.3.2]: https://github.com/marrow-software/marrow/releases/tag/v0.3.2
 [0.3.1]: https://github.com/marrow-software/marrow/releases/tag/v0.3.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Marrow is a self-hosted, open-source knowledge base (wiki) built around a non-negotiable **restore guarantee**: a Marrow export bundle must always be restorable to an exact replica of the original workspace. This guarantee is the architectural foundation — every decision flows from it.
 
-Current status: **v0.3.x** — node tree (folders + pages), v4 export/restore, OIDC + org RBAC, BlockNote editor, comments, properties, backlinks, SaaS billing gates, and global `/home` landing are implemented and tested. Comments, share links, and folder view definitions are not yet in export bundles (planned bundle v5 — see `references/To-do.md` item 8).
+Current status: **v0.4.x** — beachhead activation shipped (solo-first onboarding, workspace provisioning on onboard, self-host-first marketing, export/restore docs). Node tree (folders + pages), v4 export/restore, OIDC + org RBAC, BlockNote editor, comments, properties, backlinks, page archiving, SaaS billing gates, and global `/home` landing are implemented and tested. Comments, share links, and folder view definitions are not yet in export bundles (planned bundle v5 — see `references/To-do.md` item 8).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ The recommended production path is Docker Compose. The API image is pulled from 
 ```bash
 git clone https://github.com/marrow-software/marrow.git
 cd marrow
-git checkout v0.3.3          # recommended for production
+git checkout v0.4.0          # recommended for production
 
 cp .env.prod.example .env
 # edit .env — SECRET_KEY, POSTGRES_PASSWORD, MARROW_API_URL (your public API URL)
-# set MARROW_VERSION to the same tag you checked out (e.g. v0.3.3)
+# set MARROW_VERSION to the same tag you checked out (e.g. v0.4.0)
 
 docker compose -f docker-compose.prod.yml up -d --build
 curl http://localhost:8000/health
@@ -86,8 +86,8 @@ Check out the release tag, set `MARROW_VERSION` in `.env` to the same tag (so th
 
 ```bash
 git fetch --tags
-git checkout v0.3.3          # pick the release you want
-# edit .env — set MARROW_VERSION=v0.3.3 to match
+git checkout v0.4.0          # pick the release you want
+# edit .env — set MARROW_VERSION=v0.4.0 to match
 docker compose -f docker-compose.prod.yml pull api
 docker compose -f docker-compose.prod.yml up -d --build
 ```

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,7 +24,7 @@ services:
       retries: 5
 
   api:
-    image: ghcr.io/marrow-software/marrow-api:${MARROW_VERSION:-v0.3.3}
+    image: ghcr.io/marrow-software/marrow-api:${MARROW_VERSION:-v0.4.0}
     restart: unless-stopped
     depends_on:
       db:

--- a/docs/src/content/docs/configuration/env-vars.md
+++ b/docs/src/content/docs/configuration/env-vars.md
@@ -61,7 +61,7 @@ When using `docker-compose.prod.yml`, both files are replaced by a single root `
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `MARROW_VERSION` | `v0.3.3` (compose default) | GHCR API image tag. Set to the same git release tag you checked out; update in `.env` whenever you upgrade. Also labels the locally built web image. |
+| `MARROW_VERSION` | `v0.4.0` (compose default) | GHCR API image tag. Set to the same git release tag you checked out; update in `.env` whenever you upgrade. Also labels the locally built web image. |
 | `POSTGRES_USER` | `marrow` | Postgres username. |
 | `POSTGRES_DB` | `marrow` | Postgres database name. |
 | `POSTGRES_PASSWORD` | — | **Required.** Postgres password. |

--- a/docs/src/content/docs/deployment/docker-compose.md
+++ b/docs/src/content/docs/deployment/docker-compose.md
@@ -43,10 +43,10 @@ Pin a release tag so the API image and web source match:
 
 ```bash
 git fetch --tags
-git checkout v0.3.3          # recommended for production
+git checkout v0.4.0          # recommended for production
 ```
 
-Set `MARROW_VERSION` in `.env` to the same tag (e.g. `v0.3.3`), then:
+Set `MARROW_VERSION` in `.env` to the same tag (e.g. `v0.4.0`), then:
 
 ```bash
 docker compose -f docker-compose.prod.yml up -d --build
@@ -89,8 +89,8 @@ Check out the new release, update `MARROW_VERSION` in `.env` to the same tag, th
 
 ```bash
 git fetch --tags
-git checkout v0.3.3          # pick the release you want
-# edit .env — set MARROW_VERSION=v0.3.3 to match
+git checkout v0.4.0          # pick the release you want
+# edit .env — set MARROW_VERSION=v0.4.0 to match
 docker compose -f docker-compose.prod.yml pull api
 docker compose -f docker-compose.prod.yml up -d --build
 ```


### PR DESCRIPTION
## Summary
- Add CHANGELOG `[0.4.0]` entry for beachhead activation, restore integrity, and page archiving
- Bump `MARROW_VERSION` references from `v0.3.3` → `v0.4.0` in README, compose, and docs
- Update CLAUDE.md current status to v0.4.x

Release cut for tagging `v0.4.0` after merge.

## Test plan
- [x] CHANGELOG entry matches commits since v0.3.3
- [x] All version references updated consistently
- [ ] Merge → tag `v0.4.0` → push tag → verify release workflow


Made with [Cursor](https://cursor.com)