### PR TITLE
refactor: centralize page save side effects in persist_page_revision (#255)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,7 @@ marrow/
 │   │   ├── export.py                 # Export workspace → zip bundle
 │   │   ├── restore.py                # Restore workspace ← zip bundle
 │   │   ├── provisioning.py           # Default workspace + space for personal org (#241)
+│   │   ├── page_revisions.py         # persist_page_revision — save path side effects (#255)
 │   │   ├── cli.py                    # Typer CLI (export, restore, reset-org-billing)
 │   │   └── routers/
 │   │       ├── auth.py               # OIDC login/callback/me/logout + personal org creation
@@ -227,7 +228,8 @@ marrow/
 │   │   ├── test_export.py
 │   │   ├── test_restore.py
 │   │   ├── test_round_trip.py        # Critical regression anchor
-│   │   └── test_search.py            # FTS trigger + search scoping tests
+│   │   ├── test_search.py            # FTS trigger + search scoping tests
+│   │   └── test_page_revisions.py    # persist_page_revision save-path integration (#255)
 │   └── storage/                      # Default local attachment storage (gitignored)
 │
 ├── web/                              # Next.js frontend
@@ -440,11 +442,13 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 > unrestricted (same pattern as the API-key/dev path). Share links are **not
 > yet in the export bundle** (planned bundle v5 — `references/To-do.md` item 8).
 >
-> **Watches & notifications (#103/#104):** `notifications` is a user-scoped Inbox feed; `create_notification()` in `marrow/notifications.py` is the single insertion point. `marrow/watches.py` fans out `watch_event` notifications: on a page save (`update_node` revision create), every watcher of the page **or any ancestor folder** is notified, excluding the acting user. Both tables are deliberately excluded from export/restore (user-scoped, workspace-independent) — the round-trip guarantee is unaffected.
+> **Page revision persistence (#255):** `persist_page_revision()` in `marrow/page_revisions.py` is the single save path for appending a page revision. Both `create_node` and `update_node` call it when writing page content. It owns link reconcile, mention delivery, and watch fan-out (watches are best-effort behind a nested savepoint). The router still owns `db.commit()` / IntegrityError → HTTP. See `CONTEXT.md`.
+>
+> **Watches & notifications (#103/#104):** `notifications` is a user-scoped Inbox feed; `create_notification()` in `marrow/notifications.py` is the single insertion point. `marrow/watches.py` fans out `watch_event` notifications: on a page save (`persist_page_revision`), every watcher of the page **or any ancestor folder** is notified, excluding the acting user. Both tables are deliberately excluded from export/restore (user-scoped, workspace-independent) — the round-trip guarantee is unaffected.
 >
 > **Search response shape (v0.2):** `SearchResultItem` fields are `node_id`, `name`, `snippet`, `space_id`, `space_name`, `node_path` (list of ancestor folder names, root→leaf), `rank`. The old `page_id`, `title`, `collection_id`, `collection_name` fields are gone.
 >
-> **Backlinks (#100, 2.6):** `GET /api/nodes/{nid}/backlinks` returns the nodes that link to `{nid}` (min role `viewer`, trashed sources excluded). `marrow/links.py` parses wiki-links (`/pages/{id}` and `/nodes/{id}` hrefs) and reconciles the `node_links` table on every page create/update via `reconcile_node_links()`. Export serializes the live DB index via `serialize_node_links()` into `links.json`; restore rebuilds it with `rebuild_node_links()`, honouring `manifest.include_trash` so links involving trashed nodes round-trip when the bundle was exported with `include_trash=True`.
+> **Backlinks (#100, 2.6):** `GET /api/nodes/{nid}/backlinks` returns the nodes that link to `{nid}` (min role `viewer`, trashed sources excluded). `marrow/links.py` parses wiki-links (`/pages/{id}` and `/nodes/{id}` hrefs) and reconciles the `node_links` table on every page create/update via `reconcile_node_links()` (invoked from `persist_page_revision`). Export serializes the live DB index via `serialize_node_links()` into `links.json`; restore rebuilds it with `rebuild_node_links()`, honouring `manifest.include_trash` so links involving trashed nodes round-trip when the bundle was exported with `include_trash=True`.
 > **Node properties (#42, 2.4):** Folder nodes declare a property schema (key + `value_type` + `options`); every descendant page inherits it (nearest-ancestor wins) and may set its own value. Effective properties resolve at read time via the ancestor folder chain. Property keys+values fold into the page `search_vector` at weight C — a single `marrow_node_search_vector(uuid)` SQL helper computes the full vector and all node search triggers (revision-insert, name-change, and the new `node_properties` change trigger) keep it consistent. Frontend: `property-editor.tsx` renders page value controls. Folder schema
 > management UI is deferred until a database page type hosts views (#239). Export/restore bundle **v4** carries a `node_properties` array in `manifest.json`; `export.serialize_node_properties` and the restore loop round-trip folder schemas and page values.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,15 @@
+# Marrow domain glossary
+
+Shared vocabulary for architecture and product work. Prefer these names in code, reviews, and ADRs.
+
+## page revision persistence
+
+The module (`api/marrow/page_revisions.py`, `persist_page_revision`) that appends an immutable page revision and reconciles derived indexes on every content save:
+
+- `node_links` via `reconcile_node_links`
+- `@`-mention Inbox notifications (delta vs previous revision)
+- `watch_event` fan-out (best-effort, nested savepoint)
+
+Caller owns the DB transaction (flush in the module; commit in the router). Both page create and page update content paths go through this module so save side effects stay in one place.
+
+Related constraints: append-only revisions (DB trigger); restore guarantee (user-scoped notifications/watches are never exported).

--- a/api/marrow/page_revisions.py
+++ b/api/marrow/page_revisions.py
@@ -1,0 +1,73 @@
+"""Page revision persistence — append a revision and run save side effects.
+
+Caller owns the transaction (flush here; commit in the router / CLI).
+Links and mention notifications participate in the main transaction; watch
+fan-out is best-effort behind a nested savepoint so a notification failure
+never rolls back the revision.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from .links import reconcile_node_links
+from .models import Node, Revision
+from .notifications import deliver_mention_notifications
+from .watches import fan_out_watch_event
+
+
+def persist_page_revision(
+    db: Session,
+    *,
+    node: Node,
+    content: str,
+    content_format: str,
+    actor_user_id: UUID | None,
+) -> Revision:
+    """Append a revision and run save side effects. Caller owns commit.
+
+    Only valid for ``type='page'`` nodes. Raises ``ValueError`` otherwise.
+    """
+    if node.type != "page":
+        raise ValueError("persist_page_revision requires a page node")
+
+    prev_rev = node.current_revision
+    prev_content = prev_rev.content if prev_rev else None
+    prev_format = prev_rev.content_format if prev_rev else None
+
+    rev = Revision(
+        node_id=node.id,
+        content=content,
+        content_format=content_format,
+    )
+    db.add(rev)
+    db.flush()
+    node.current_revision_id = rev.id
+
+    reconcile_node_links(db, node.id, content, content_format)
+
+    deliver_mention_notifications(
+        db,
+        node=node,
+        new_content=content,
+        content_format=content_format,
+        previous_content=prev_content,
+        previous_format=prev_format,
+        actor_user_id=actor_user_id,
+    )
+
+    # Notify watchers best-effort — must not block or fail the save.
+    # Use a savepoint so any partial notification rows are rolled back on
+    # failure rather than being committed by the caller's db.commit().
+    sp = db.begin_nested()
+    try:
+        fan_out_watch_event(db, node=node, actor_user_id=actor_user_id, event="save")
+        sp.commit()
+    except Exception:
+        sp.rollback()
+
+    node.updated_at = datetime.now(timezone.utc)
+    return rev

--- a/api/marrow/routers/nodes.py
+++ b/api/marrow/routers/nodes.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import Session
 
 from ..dependencies import AuthContext, get_db, get_storage, verify_auth
 from ..fractional_index import after as fi_after
-from ..links import reconcile_node_links
 from ..models import (
     Attachment,
     Node,
@@ -24,7 +23,7 @@ from ..models import (
     UserStar,
     Workspace,
 )
-from ..notifications import deliver_mention_notifications
+from ..page_revisions import persist_page_revision
 from ..rbac import _check_membership, require_node_role, require_space_role
 from ..schemas import (
     AttachmentRead,
@@ -35,7 +34,6 @@ from ..schemas import (
     RevisionRead,
     WatchStatus,
 )
-from ..watches import fan_out_watch_event
 
 router = APIRouter(tags=["nodes"])
 
@@ -116,25 +114,11 @@ def create_node(
         raise HTTPException(409, f"Slug '{slug}' already exists in this location")
 
     if body.type == "page":
-        content = body.content or ""
-        rev = Revision(
-            node_id=node.id,
-            content=content,
-            content_format=body.content_format,
-        )
-        db.add(rev)
-        db.flush()
-        node.current_revision_id = rev.id
-        db.flush()
-        reconcile_node_links(db, node.id, content, body.content_format)
-
-        deliver_mention_notifications(
+        persist_page_revision(
             db,
             node=node,
-            new_content=content,
+            content=body.content or "",
             content_format=body.content_format,
-            previous_content=None,
-            previous_format=None,
             actor_user_id=auth.user_id,
         )
 
@@ -210,45 +194,16 @@ def update_node(
     if body.description is not None and node.type == "folder":
         node.description = body.description
 
-    saved_revision = False
     if body.content is not None and node.type == "page":
-        prev_rev = node.current_revision
-        prev_content = prev_rev.content if prev_rev else None
-        prev_format = prev_rev.content_format if prev_rev else None
-
-        rev = Revision(
-            node_id=node.id,
-            content=body.content,
-            content_format=body.content_format or "markdown",
-        )
-        db.add(rev)
-        db.flush()
-        node.current_revision_id = rev.id
-        reconcile_node_links(db, node.id, body.content, body.content_format or "markdown")
-        saved_revision = True
-
-        deliver_mention_notifications(
+        persist_page_revision(
             db,
             node=node,
-            new_content=body.content,
+            content=body.content,
             content_format=body.content_format or "markdown",
-            previous_content=prev_content,
-            previous_format=prev_format,
             actor_user_id=auth.user_id,
         )
-
-    node.updated_at = datetime.now(timezone.utc)
-
-    if saved_revision:
-        # Notify watchers best-effort — must not block or fail the save.
-        # Use a savepoint so any partial notification rows are rolled back on
-        # failure rather than being committed by the db.commit() below.
-        sp = db.begin_nested()
-        try:
-            fan_out_watch_event(db, node=node, actor_user_id=auth.user_id, event="save")
-            sp.commit()
-        except Exception:
-            sp.rollback()
+    else:
+        node.updated_at = datetime.now(timezone.utc)
 
     try:
         db.commit()

--- a/api/tests/test_page_revisions.py
+++ b/api/tests/test_page_revisions.py
@@ -1,0 +1,257 @@
+"""Integration tests for persist_page_revision (#255)."""
+
+import json
+import os
+import uuid
+
+import pytest
+
+from marrow.models import (
+    Node,
+    NodeLink,
+    NodeWatch,
+    Notification,
+    Organization,
+    OrgMembership,
+    OrgRole,
+    Revision,
+    Space,
+    User,
+    Workspace,
+)
+from marrow.page_revisions import persist_page_revision
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://marrow:marrow@localhost:5433/marrow")
+
+
+@pytest.fixture
+def db():
+    from marrow.dependencies import get_db
+
+    session = next(get_db())
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+def _make_user(session, email: str) -> User:
+    user = User(
+        oidc_issuer="https://test.example.com",
+        oidc_subject=uuid.uuid4().hex,
+        email=email,
+        name="Test User",
+    )
+    session.add(user)
+    session.flush()
+    return user
+
+
+def _make_workspace(session) -> tuple:
+    org = Organization(slug=f"org-{uuid.uuid4().hex[:6]}", name="Test Org")
+    session.add(org)
+    session.flush()
+    ws = Workspace(org_id=org.id, slug=f"ws-{uuid.uuid4().hex[:6]}", name="Test WS")
+    session.add(ws)
+    session.flush()
+    space = Space(workspace_id=ws.id, slug="main", name="Main")
+    session.add(space)
+    session.flush()
+    return org, ws, space
+
+
+def _add_membership(session, org, user, role: OrgRole) -> None:
+    session.add(OrgMembership(org_id=org.id, user_id=user.id, email=user.email, role=role.value))
+    session.flush()
+
+
+def _make_empty_page(session, space, name: str = "Page") -> Node:
+    """Page node with no revision yet (create-path shape)."""
+    node = Node(
+        space_id=space.id,
+        parent_id=None,
+        type="page",
+        name=name,
+        slug=f"{name.lower()}-{uuid.uuid4().hex[:6]}",
+        position="a0",
+    )
+    session.add(node)
+    session.flush()
+    return node
+
+
+def _make_page(session, space, name: str = "Page", content: str = "hello") -> Node:
+    node = _make_empty_page(session, space, name=name)
+    rev = Revision(node_id=node.id, content=content, content_format="markdown")
+    session.add(rev)
+    session.flush()
+    node.current_revision_id = rev.id
+    session.flush()
+    return node
+
+
+def _doc_with_mention(user_id: uuid.UUID) -> str:
+    return json.dumps(
+        [
+            {
+                "type": "paragraph",
+                "content": [
+                    {
+                        "type": "mention",
+                        "props": {
+                            "userId": str(user_id),
+                            "displayName": "Someone",
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+
+
+class TestPersistPageRevision:
+    def test_creates_revision_and_links(self, db):
+        _, _, space = _make_workspace(db)
+        target = _make_page(db, space, "Target")
+        src = _make_empty_page(db, space, "Source")
+        db.commit()
+
+        rev = persist_page_revision(
+            db,
+            node=src,
+            content=f"[t](/pages/{target.id})",
+            content_format="markdown",
+            actor_user_id=None,
+        )
+        db.commit()
+
+        db.refresh(src)
+        assert src.current_revision_id == rev.id
+        assert rev.content == f"[t](/pages/{target.id})"
+        targets = {
+            row.target_node_id for row in db.query(NodeLink).filter_by(source_node_id=src.id)
+        }
+        assert targets == {target.id}
+
+    def test_mention_delta_notifies_once(self, db):
+        author = _make_user(db, "author-persist@test.com")
+        target = _make_user(db, "target-persist@test.com")
+        org, _, space = _make_workspace(db)
+        _add_membership(db, org, author, OrgRole.EDITOR)
+        page = _make_empty_page(db, space)
+        db.commit()
+
+        doc = _doc_with_mention(target.id)
+        persist_page_revision(
+            db,
+            node=page,
+            content=doc,
+            content_format="json",
+            actor_user_id=author.id,
+        )
+        db.commit()
+        assert db.query(Notification).filter_by(user_id=target.id, kind="mention").count() == 1
+
+        persist_page_revision(
+            db,
+            node=page,
+            content=doc,
+            content_format="json",
+            actor_user_id=author.id,
+        )
+        db.commit()
+        assert db.query(Notification).filter_by(user_id=target.id, kind="mention").count() == 1
+
+    def test_actor_excluded_from_mentions_and_watches(self, db):
+        actor = _make_user(db, "actor-persist@test.com")
+        org, _, space = _make_workspace(db)
+        _add_membership(db, org, actor, OrgRole.EDITOR)
+        page = _make_empty_page(db, space)
+        db.add(NodeWatch(user_id=actor.id, node_id=page.id))
+        db.commit()
+
+        persist_page_revision(
+            db,
+            node=page,
+            content=_doc_with_mention(actor.id),
+            content_format="json",
+            actor_user_id=actor.id,
+        )
+        db.commit()
+
+        assert db.query(Notification).filter_by(user_id=actor.id).count() == 0
+
+    def test_watcher_notified_on_first_persist(self, db):
+        """Create-path parity: first revision fans out watch events."""
+        watcher = _make_user(db, "watcher-persist@test.com")
+        editor = _make_user(db, "editor-persist@test.com")
+        org, _, space = _make_workspace(db)
+        _add_membership(db, org, watcher, OrgRole.VIEWER)
+        _add_membership(db, org, editor, OrgRole.EDITOR)
+        page = _make_empty_page(db, space)
+        db.add(NodeWatch(user_id=watcher.id, node_id=page.id))
+        db.commit()
+
+        persist_page_revision(
+            db,
+            node=page,
+            content="first save",
+            content_format="markdown",
+            actor_user_id=editor.id,
+        )
+        db.commit()
+
+        notes = db.query(Notification).filter_by(user_id=watcher.id, kind="watch_event").all()
+        assert len(notes) == 1
+        assert notes[0].payload["event"] == "save"
+        assert notes[0].payload["node_id"] == str(page.id)
+
+    def test_watch_failure_does_not_block_revision(self, db, monkeypatch):
+        watcher = _make_user(db, "watch-fail@test.com")
+        org, _, space = _make_workspace(db)
+        _add_membership(db, org, watcher, OrgRole.VIEWER)
+        page = _make_empty_page(db, space)
+        db.add(NodeWatch(user_id=watcher.id, node_id=page.id))
+        db.commit()
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("fan-out broken")
+
+        monkeypatch.setattr("marrow.page_revisions.fan_out_watch_event", _boom)
+
+        rev = persist_page_revision(
+            db,
+            node=page,
+            content="must persist",
+            content_format="markdown",
+            actor_user_id=None,
+        )
+        db.commit()
+
+        db.refresh(page)
+        assert page.current_revision_id == rev.id
+        assert rev.content == "must persist"
+        assert db.query(Notification).filter_by(user_id=watcher.id, kind="watch_event").count() == 0
+
+    def test_rejects_folder_node(self, db):
+        _, _, space = _make_workspace(db)
+        folder = Node(
+            space_id=space.id,
+            parent_id=None,
+            type="folder",
+            name="Folder",
+            slug=f"folder-{uuid.uuid4().hex[:6]}",
+            position="a0",
+        )
+        db.add(folder)
+        db.flush()
+
+        with pytest.raises(ValueError, match="page node"):
+            persist_page_revision(
+                db,
+                node=folder,
+                content="nope",
+                content_format="markdown",
+                actor_user_id=None,
+            )

--- a/api/tests/test_watches.py
+++ b/api/tests/test_watches.py
@@ -236,3 +236,38 @@ class TestWatchFanOut:
         notes = _watch_events(db, watcher_id)
         assert len(notes) == 1
         assert notes[0].payload["node_id"] == child_id
+
+    def test_create_page_notifies_folder_watcher(self, client, db):
+        """Create-path parity with update: first revision fans out watches (#255)."""
+        watcher = _make_user(db, "create-watcher@test.com")
+        editor = _make_user(db, "create-editor@test.com")
+        org, ws, space = _make_workspace(db)
+        _add_membership(db, org, watcher, OrgRole.VIEWER)
+        _add_membership(db, org, editor, OrgRole.EDITOR)
+        folder = _make_folder(db, space)
+        db.commit()
+        folder_id = str(folder.id)
+        space_id = str(space.id)
+        watcher_id = watcher.id
+
+        _auth_cookie(client, watcher)
+        assert client.post(f"/api/nodes/{folder_id}/watch").status_code == 201
+
+        _auth_cookie(client, editor)
+        res = client.post(
+            f"/api/spaces/{space_id}/nodes",
+            json={
+                "type": "page",
+                "name": "New child",
+                "parent_id": folder_id,
+                "content": "hello from create",
+                "content_format": "markdown",
+            },
+        )
+        assert res.status_code == 201, res.text
+        child_id = res.json()["id"]
+
+        notes = _watch_events(db, watcher_id)
+        assert len(notes) == 1
+        assert notes[0].payload["event"] == "save"
+        assert notes[0].payload["node_id"] == child_id


### PR DESCRIPTION
## Summary
- Add `persist_page_revision()` as the single save path for appending page revisions and running link reconcile, mention delivery, and watch fan-out.
- Thin `create_node` and `update_node` to call it while the router still owns `commit` / IntegrityError handling.
- Fix create/update asymmetry: page create with content now fans out watch events (same as update).
- Add integration tests and document the save path in `CONTEXT.md` / `CLAUDE.md`.

## Test plan
- [x] `pytest api/tests/test_page_revisions.py`
- [x] `pytest api/tests/test_watches.py::TestWatchFanOut`
- [x] `pytest api/tests/test_notifications.py::TestMentionDelivery`
- [x] `ruff check` + `ruff format` on touched API files

Closes #255

Made with [Cursor](https://cursor.com)