### PR TITLE
chore: land CLA machinery (Apache ICLA + CLA Assistant Lite + CONTRIBUTING.md)

### DIFF
--- a/.github/cla/signatures.json
+++ b/.github/cla/signatures.json
@@ -1,0 +1,3 @@
+{
+  "signedContributors": []
+}

--- a/.github/cla/signatures.json
+++ b/.github/cla/signatures.json
@@ -1,3 +1,0 @@
-{
-  "signedContributors": []
-}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,66 @@
+name: CLA
+
+# Gates external pull requests on a signed Marrow ICLA (see CLA.md).
+#
+# Signatures are committed to .github/cla/signatures.json in THIS repository —
+# deliberately not a third-party gist. The project's legal record lives in the
+# same place as its source. See issue #270.
+#
+# pull_request_target (not pull_request) is required: fork PRs need a token
+# with write access to commit the signature file. This workflow runs the base
+# branch's definition and never checks out or executes PR code.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: write # commit the signature file
+  pull-requests: write # comment on the PR
+  statuses: write # publish the CLA status check
+
+jobs:
+  cla:
+    name: CLA — signature check
+    runs-on: ubuntu-latest
+    # Only run on the sign-the-CLA comment, or on PR events.
+    if: >
+      (github.event.comment.body == 'recheck' ||
+       github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+      github.event_name == 'pull_request_target'
+    steps:
+      # contributor-assistant/github-action v2.6.1 (ca4a40a7d1004f18d9960b404b97e5f30a505a08)
+      - name: CLA Assistant Lite
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: '.github/cla/signatures.json'
+          path-to-document: 'https://github.com/marrow-software/marrow/blob/main/CLA.md'
+          branch: 'main'
+
+          custom-notsigned-prcomment: >
+            Thanks for the pull request — this is genuinely appreciated.
+
+            Before it can be merged, Marrow needs you to sign the
+            [Contributor License Agreement](https://github.com/marrow-software/marrow/blob/main/CLA.md).
+            **Please read it rather than skimming it** — Marrow is solo-maintained,
+            and the CLA preserves the option to license *future* versions
+            commercially. You keep the copyright on your code, and every release
+            already published stays Apache 2.0 irrevocably.
+            [CONTRIBUTING.md](https://github.com/marrow-software/marrow/blob/main/CONTRIBUTING.md)
+            explains the reasoning in full, including why you might reasonably
+            decline.
+
+            If you agree, reply to this thread with exactly:
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: >
+            CLA signed — thank you. This covers all your future contributions to
+            Marrow; you won't be asked again.
+
+          # The maintainer's own commits are covered by copyright ownership, and
+          # bots cannot hold copyright.
+          allowlist: 'spmcgraw,dependabot[bot],github-actions[bot],renovate[bot]'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -32,9 +32,10 @@ jobs:
        github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
       github.event_name == 'pull_request_target'
     steps:
-      # contributor-assistant/github-action v2.6.1 (ca4a40a7d1004f18d9960b404b97e5f30a505a08)
       - name: CLA Assistant Lite
-        uses: contributor-assistant/github-action@v2.6.1
+        # Pinned to a SHA, not a tag: tags are mutable, and this step runs under
+        # pull_request_target with contents: write.
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -42,7 +43,11 @@ jobs:
           path-to-document: 'https://github.com/marrow-software/marrow/blob/main/CLA.md'
           branch: 'main'
 
-          custom-notsigned-prcomment: >
+          # Literal block (|), not folded (>): folded style collapses blank lines
+          # to a single newline and the comment renders as one run-on paragraph.
+          # The action appends the sign phrase below this text between two
+          # horizontal rules, so ending on a colon is correct.
+          custom-notsigned-prcomment: |
             Thanks for the pull request — this is genuinely appreciated.
 
             Before it can be merged, Marrow needs you to sign the
@@ -57,7 +62,7 @@ jobs:
 
             If you agree, reply to this thread with exactly:
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
-          custom-allsigned-prcomment: >
+          custom-allsigned-prcomment: |
             CLA signed — thank you. This covers all your future contributions to
             Marrow; you won't be asked again.
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,7 +41,15 @@ jobs:
         with:
           path-to-signatures: '.github/cla/signatures.json'
           path-to-document: 'https://github.com/marrow-software/marrow/blob/main/CLA.md'
-          branch: 'main'
+
+          # Signatures are committed to an unprotected side branch, NOT to main.
+          # The `Requirements` ruleset makes main PR-only with no bypass actors,
+          # so GITHUB_TOKEN cannot push there and every signature would fail.
+          # GitHub Actions is not installable as a bypass actor on this org, so
+          # the alternative was a PAT or deploy key — a credential to rotate,
+          # for no gain. The #270 requirement is that the legal record lives in
+          # THIS repo rather than a third party's gist; that holds either way.
+          branch: 'cla-signatures'
 
           # Literal block (|), not folded (>): folded style collapses blank lines
           # to a single newline and the comment renders as one run-on paragraph.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,195 @@
+# Marrow Individual Contributor License Agreement
+
+**Version 1.0**
+
+Thank you for your interest in contributing to Marrow.
+
+This Contributor License Agreement ("Agreement") is adapted from the Apache
+Software Foundation Individual Contributor License Agreement v2.0, with one
+substantive addition: **Section 2a**, which grants the right to license Your
+Contributions under terms other than Apache 2.0.
+
+Please read this document carefully. **Section 8 ("What this means in plain
+language") is not legal text — it is a summary provided in good faith.** The
+operative terms are Sections 1 through 7.
+
+You accept and agree to the following terms and conditions for Your present
+and future Contributions submitted to Marrow. Except for the license granted
+herein to Marrow Software and recipients of software distributed by Marrow
+Software, **You reserve all right, title, and interest in and to Your
+Contributions.**
+
+---
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner or legal entity authorized
+by the copyright owner that is making this Agreement. For legal entities, the
+entity making a Contribution and all other entities that control, are
+controlled by, or are under common control with that entity are considered to
+be a single Contributor. For the purposes of this definition, "control" means
+(i) the power, direct or indirect, to cause the direction or management of
+such entity, whether by contract or otherwise, or (ii) ownership of fifty
+percent (50%) or more of the outstanding shares, or (iii) beneficial ownership
+of such entity.
+
+**"Marrow Software"** (or **"We"**, **"Us"**) means the maintainer of the
+Marrow project.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally
+submitted by You to Us for inclusion in, or documentation of, any of the
+products owned or managed by Us (the "Work"). For the purposes of this
+definition, "submitted" means any form of electronic, verbal, or written
+communication sent to Us or Our representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, Us for the
+purpose of discussing and improving the Work, but excluding communication that
+is conspicuously marked or otherwise designated in writing by You as "Not a
+Contribution."
+
+---
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us
+and to recipients of software distributed by Us a **perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable** copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contributions and such derivative works.
+
+### 2a. Grant of Relicensing Rights
+
+You further grant to Us the perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable, and **sublicensable** right to license and
+relicense Your Contributions, and derivative works thereof, **under any
+license terms We choose**, including proprietary or commercial terms, and to
+distribute Your Contributions under such terms as part of the Work or any
+derivative of it.
+
+This right is granted in addition to, and does not limit or replace, the
+license granted in Section 2. **You retain copyright ownership of Your
+Contributions** and remain free to license them to any other party on any
+terms.
+
+**This grant does not permit Us to retroactively change the license of any
+version of the Work that has already been publicly released.** Every release
+made under the Apache License 2.0 remains available under the Apache License
+2.0 in perpetuity, and this Agreement does not authorize Us to revoke,
+withdraw, or alter that license for any already-published release.
+
+---
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to Us
+and to recipients of software distributed by Us a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer the Work, where such license applies only to those
+patent claims licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s) with the Work
+to which such Contribution(s) was submitted.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Work to which You have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Work shall terminate as
+of the date such litigation is filed.
+
+---
+
+## 4. Representations
+
+You represent that You are legally entitled to grant the above licenses.
+
+If Your employer(s) has rights to intellectual property that You create that
+includes Your Contributions, You represent that You have received permission
+to make Contributions on behalf of that employer, that Your employer has
+waived such rights for Your Contributions to Us, or that Your employer has
+executed a separate Corporate Contributor License Agreement with Us.
+
+You represent that each of Your Contributions is Your original creation (see
+Section 6 for submissions on behalf of others). You represent that Your
+Contribution submissions include complete details of any third-party license
+or other restriction (including, but not limited to, related patents and
+trademarks) of which You are personally aware and which are associated with
+any part of Your Contributions.
+
+---
+
+## 5. No Obligation of Support or Inclusion
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all.
+
+Unless required by applicable law or agreed to in writing, You provide Your
+Contributions on an **"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND**, either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or
+FITNESS FOR A PARTICULAR PURPOSE.
+
+We are under no obligation to accept or include any Contribution in the Work.
+
+---
+
+## 6. Submissions on Behalf of Others
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to Us separately from any Contribution, identifying the complete
+details of its source and of any license or other restriction (including, but
+not limited to, related patents, trademarks, and license agreements) of which
+You are personally aware, and conspicuously marking the work as "Submitted on
+behalf of a third-party: [named here]".
+
+---
+
+## 7. Notification of Inaccuracy
+
+You agree to notify Us of any facts or circumstances of which You become aware
+that would make these representations inaccurate in any respect.
+
+---
+
+## 8. What this means in plain language
+
+*This section is a good-faith summary and is not operative legal text. Where
+it differs from Sections 1–7, those sections govern.*
+
+- **You keep your copyright.** This is a license, not an assignment. Your code
+  stays yours, and you can license it to anyone else however you like.
+- **We can relicense future versions.** Section 2a lets Marrow ship future
+  versions — including versions containing your Contribution — under
+  commercial or proprietary terms. Marrow is solo-maintained and this
+  preserves commercial optionality.
+- **Already-published releases stay Apache 2.0, permanently.** Nothing here
+  lets us reach back and un-license a release that already went out. That
+  promise is written into Section 2a itself, not just this summary.
+- **We are telling you this directly.** CLAs carry history — several projects
+  have used this exact machinery to relicense away from their communities.
+  You would work the implication out yourself; we would rather you hear it
+  from us. See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the fuller reasoning.
+
+---
+
+## How to sign
+
+You do not need to edit this file or submit anything separately.
+
+Open a pull request. A bot will comment asking you to sign, and you sign by
+replying with a single comment:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+Your signature is recorded in
+[`.github/cla/signatures.json`](./.github/cla/signatures.json) — a plain,
+readable file **in this repository**. Marrow's legal record lives in the same
+place as its source, not in a third party's storage. This is the same
+principle as the export bundle: the record is yours to read, audit, and take
+with you.
+
+You sign once. It covers all your future Contributions to Marrow.

--- a/CLA.md
+++ b/CLA.md
@@ -186,10 +186,13 @@ I have read the CLA Document and I hereby sign the CLA
 ```
 
 Your signature is recorded in
-[`.github/cla/signatures.json`](./.github/cla/signatures.json) — a plain,
-readable file **in this repository**. Marrow's legal record lives in the same
-place as its source, not in a third party's storage. This is the same
-principle as the export bundle: the record is yours to read, audit, and take
-with you.
+[`.github/cla/signatures.json`](https://github.com/marrow-software/marrow/blob/cla-signatures/.github/cla/signatures.json)
+on the `cla-signatures` branch — a plain, readable file **in this repository**.
+Marrow's legal record lives in the same place as its source, not in a third
+party's storage. This is the same principle as the export bundle: the record is
+yours to read, audit, and take with you.
+
+*(It sits on its own branch rather than `main` for a mechanical reason: `main`
+accepts changes only through pull requests, so the bot cannot commit to it.)*
 
 You sign once. It covers all your future Contributions to Marrow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,11 @@ marrow/
 │   ├── ci.yml                        # PR + push: api lint+test, web build, docs build
 │   ├── marketing.yml                 # web-marketing/ path-filtered CI + Cloudflare Pages deploy
 │   ├── release.yml                   # tags only: build/push API image to GHCR, deploy API → Fly.io + web → Cloudflare Workers
-│   └── codeql.yml                    # Weekly CodeQL analysis
+│   ├── codeql.yml                    # Weekly CodeQL analysis
+│   └── cla.yml                       # Gates external PRs on a signed CLA (see Contributor licensing)
+├── .github/cla/signatures.json       # CLA signature record — in-repo, deliberately not a third-party gist
+├── CLA.md                            # Marrow Individual CLA (adapted Apache ICLA + §2a relicensing grant)
+├── CONTRIBUTING.md                   # Contributor guide + the candour framing around the CLA
 ├── CLAUDE.md                         # This file
 ├── README.md
 └── LICENSE                           # Apache 2.0
@@ -546,6 +550,22 @@ These constraints are non-negotiable and must be respected in all contributions:
 2. **Append-only revisions**: saves always create new revisions; existing revisions are never modified or deleted. The database trigger enforces this — do not remove it.
 3. **Transparent export format**: export bundles must remain human-readable without tooling (Markdown + JSON, no proprietary blobs).
 4. **Pluggable storage**: business logic must not bypass the storage adapter interface. Never call filesystem APIs directly from routers or models.
+
+---
+
+## Contributor licensing (CLA)
+
+External contributions require a signed CLA before merge. Decided in [#270](https://github.com/marrow-software/marrow/issues/270), built in [#275](https://github.com/marrow-software/marrow/issues/275).
+
+- **`CLA.md`** — the Apache ICLA v2.0, adapted. Sections 1 and 3–7 are near-verbatim Apache text. **Section 2a is bespoke**: a perpetual, irrevocable, sublicensable right to relicense contributions under any terms, so relicensing future versions stays possible while the contributor keeps copyright. Section 2a also carves out **non-retroactivity** — already-published releases stay Apache 2.0 permanently, backing the [#260](https://github.com/marrow-software/marrow/issues/260) promise in operative text. Individual-only; no corporate CCLA until a company actually contributes.
+- **`.github/workflows/cla.yml`** — `contributor-assistant/github-action`, SHA-pinned. Runs on `pull_request_target` (fork PRs need a write-capable token) and **never checks out PR code**. Signatures are committed to `.github/cla/signatures.json` **in this repo** — deliberately not a third-party gist, same principle as the export bundle.
+- **`CONTRIBUTING.md`** — states plainly that Marrow is solo-maintained, that the CLA preserves commercial optionality on *future* versions, and that published releases stay Apache 2.0 irrevocably. Names the rug-pull concern directly rather than letting contributors infer it.
+
+**Constraints when touching any of this:**
+
+- The sign-off phrase (`I have read the CLA Document and I hereby sign the CLA`) appears in the workflow `if:` condition, `custom-pr-sign-comment`, `CLA.md`, and `CONTRIBUTING.md`. **All four must match exactly** — a typo in one silently breaks the gate.
+- Use literal block scalars (`|`) for the custom PR comments, never folded (`>`): folded style collapses blank lines and the bot comment renders as one run-on paragraph.
+- **§2a has not been reviewed by a lawyer** ([#281](https://github.com/marrow-software/marrow/issues/281)). Don't promote the CLA as settled, or lean on the relicensing option commercially, until it has been.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,7 +312,8 @@ marrow/
 │   ├── release.yml                   # tags only: build/push API image to GHCR, deploy API → Fly.io + web → Cloudflare Workers
 │   ├── codeql.yml                    # Weekly CodeQL analysis
 │   └── cla.yml                       # Gates external PRs on a signed CLA (see Contributor licensing)
-├── .github/cla/signatures.json       # CLA signature record — in-repo, deliberately not a third-party gist
+│                                     # (CLA signatures live at .github/cla/signatures.json on the
+│                                     #  `cla-signatures` branch, NOT on main — see Contributor licensing)
 ├── CLA.md                            # Marrow Individual CLA (adapted Apache ICLA + §2a relicensing grant)
 ├── CONTRIBUTING.md                   # Contributor guide + the candour framing around the CLA
 ├── CLAUDE.md                         # This file
@@ -558,7 +559,7 @@ These constraints are non-negotiable and must be respected in all contributions:
 External contributions require a signed CLA before merge. Decided in [#270](https://github.com/marrow-software/marrow/issues/270), built in [#275](https://github.com/marrow-software/marrow/issues/275).
 
 - **`CLA.md`** — the Apache ICLA v2.0, adapted. Sections 1 and 3–7 are near-verbatim Apache text. **Section 2a is bespoke**: a perpetual, irrevocable, sublicensable right to relicense contributions under any terms, so relicensing future versions stays possible while the contributor keeps copyright. Section 2a also carves out **non-retroactivity** — already-published releases stay Apache 2.0 permanently, backing the [#260](https://github.com/marrow-software/marrow/issues/260) promise in operative text. Individual-only; no corporate CCLA until a company actually contributes.
-- **`.github/workflows/cla.yml`** — `contributor-assistant/github-action`, SHA-pinned. Runs on `pull_request_target` (fork PRs need a write-capable token) and **never checks out PR code**. Signatures are committed to `.github/cla/signatures.json` **in this repo** — deliberately not a third-party gist, same principle as the export bundle.
+- **`.github/workflows/cla.yml`** — `contributor-assistant/github-action`, SHA-pinned. Runs on `pull_request_target` (fork PRs need a write-capable token) and **never checks out PR code**. Signatures are committed to `.github/cla/signatures.json` **in this repo** — deliberately not a third-party gist, same principle as the export bundle — but on the **`cla-signatures` branch, not `main`**. The `Requirements` ruleset makes `main` PR-only with no bypass actors, so the workflow's `GITHUB_TOKEN` cannot push there; GitHub Actions is not installable as a bypass actor on this org, so the alternative was a PAT or deploy key (a credential to rotate) for no real gain. **Do not repoint `branch:` at `main`** without first solving that write path — every signature will silently fail.
 - **`CONTRIBUTING.md`** — states plainly that Marrow is solo-maintained, that the CLA preserves commercial optionality on *future* versions, and that published releases stay Apache 2.0 irrevocably. Names the rug-pull concern directly rather than letting contributors infer it.
 
 **Constraints when touching any of this:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,174 @@
+# Contributing to Marrow
+
+Thanks for being here. This document covers two things: **how** to contribute,
+and — because you deserve a straight answer before you spend your time — **what
+you're agreeing to** when you do.
+
+---
+
+## The honest part, first
+
+**Marrow is solo-maintained.** One person. That shapes everything below.
+
+**Marrow requires a CLA.** Before your first pull request can be merged, you'll
+sign the [Marrow Individual Contributor License Agreement](./CLA.md). A bot
+handles it; it takes one comment.
+
+**Here's what the CLA actually does.** You keep the copyright on your code — the
+CLA is a license, not an assignment. But it grants Marrow the right to license
+your contribution under *any* terms, including commercial ones. In practice
+that means: **a future version of Marrow could ship under a non-open licence,
+and your contribution could be in it.**
+
+**You should know why that's there.** CLAs have scar tissue. HashiCorp, Elastic
+and Redis all had exactly this machinery in place, and all three used it to
+relicense away from the communities that helped build them. If you're the kind
+of person who evaluates a self-hosted knowledge base on whether it respects
+your ownership of your own data, you are exactly the kind of person who
+remembers that. You would work this out on your own. We'd rather tell you.
+
+**What it's actually for:** Marrow is trying to be a sustainable product built
+by one person. The CLA keeps commercial options open on *future* work. That's
+the whole reason. There's no plan on the table today — but pretending the
+option isn't there would be dishonest, and the option is worth more than the
+pretence.
+
+**And here's the part that isn't optional.** Every version of Marrow already
+released is Apache 2.0, **irrevocably**. That's not a promise of good
+behaviour, it's how the Apache License works — a released version can't be
+un-released. Section 2a of the CLA states it explicitly anyway: nothing in the
+CLA authorises us to retroactively change the licence of anything already
+published. If Marrow ever did relicense, every release up to that day stays
+free, forkable, and yours. That is the guarantee, and it's the same guarantee
+whether you like the direction the project takes or not.
+
+If that trade isn't one you want to make, that's a completely reasonable call,
+and no hard feelings. Filing issues, reporting bugs, and writing docs are all
+still enormously useful and none of them need a CLA.
+
+---
+
+## The restore guarantee
+
+Before you write any code, read the
+**[restore guarantee](./docs/src/content/docs/concepts/restore-guarantee.md)**.
+
+Marrow's entire architecture flows from one non-negotiable property: an export
+bundle must always restore to an exact replica of the original workspace. Any
+contribution that compromises the export/restore round-trip will not be merged,
+regardless of how good the rest of it is. `api/tests/test_round_trip.py` is the
+regression anchor — it must pass at all times.
+
+The other core constraints, in brief:
+
+1. **Restore guarantee** — `marrow restore <bundle.zip>` reproduces a workspace
+   exactly. A failing restore test is a critical bug.
+2. **Append-only revisions** — saves create new revisions; existing revisions
+   are never modified or deleted. A database trigger enforces this. Don't
+   remove it.
+3. **Transparent export format** — bundles stay human-readable without tooling
+   (Markdown + JSON, no proprietary blobs).
+4. **Pluggable storage** — business logic goes through the storage adapter
+   interface. Never call filesystem APIs directly from routers or models.
+
+---
+
+## Getting set up
+
+Full instructions are in [`README.md`](./README.md) and
+[`CLAUDE.md`](./CLAUDE.md). The short version:
+
+```bash
+docker compose up -d                  # PostgreSQL 16 on port 5433
+
+cd api
+python -m venv venv && source venv/bin/activate
+pip install -e ".[dev]"
+cp .env.example .env
+alembic upgrade head
+uvicorn main:app --reload             # http://localhost:8000
+
+cd web
+npm install
+npm run dev                           # http://localhost:3000
+```
+
+---
+
+## Making a change
+
+**Open an issue first.** Especially for features. Marrow has a deliberately
+narrow active scope, and an issue is much cheaper than a rejected PR. If
+you're picking up something already filed, say so on the issue so nobody
+duplicates your work.
+
+**Branch off `main`.** Use `feature/<short-description>` or
+`fix/<short-description>`. Don't work directly on `main`.
+
+**Keep it focused.** One concern per PR. A drive-by reformat bundled with a
+behaviour change is very hard to review and much slower to merge.
+
+**Update the docs.** If you change routes, schema, components, environment
+variables, or architectural decisions, update `CLAUDE.md` in the same PR. It's
+living documentation, not an afterthought.
+
+---
+
+## Before you open the PR
+
+Everything below runs in CI. Running it locally first saves you a round trip.
+
+```bash
+cd api && ruff check .          # lint
+cd api && ruff format .         # format
+cd api && pytest                # integration tests — needs a running database
+
+cd web && npm run lint
+cd web && npm run build
+
+cd docs && npm run build
+```
+
+Backend tests are **integration tests** and hit a real database — a fresh test
+database is created per run and dropped afterwards. `FakeStorageAdapter` keeps
+them off the filesystem.
+
+---
+
+## Opening the PR
+
+1. Push your branch and open a pull request against `main`.
+2. **Sign the CLA** when the bot asks. One comment, once, covers all your
+   future contributions:
+
+   ```
+   I have read the CLA Document and I hereby sign the CLA
+   ```
+
+   Your signature is recorded in
+   [`.github/cla/signatures.json`](./.github/cla/signatures.json) — a plain
+   readable file in this repository, not in a third party's storage.
+
+3. Wait for CI. The CLA check and the test suite both have to be green.
+4. Expect review comments. Solo maintenance means reviews can take a few days.
+
+---
+
+## Reporting bugs and security issues
+
+**Bugs:** open a GitHub issue with what you expected, what happened, and enough
+detail to reproduce it. If it involves export or restore, please attach the
+bundle if you can share it — that's the highest-priority class of bug in this
+project.
+
+**Security vulnerabilities:** please do **not** open a public issue. Report
+privately via GitHub's
+[security advisory](https://github.com/marrow-software/marrow/security/advisories/new)
+form.
+
+---
+
+## Licence
+
+Marrow is [Apache 2.0](./LICENSE). Contributions are accepted under the
+[Marrow ICLA](./CLA.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,8 +146,9 @@ them off the filesystem.
    ```
 
    Your signature is recorded in
-   [`.github/cla/signatures.json`](./.github/cla/signatures.json) — a plain
-   readable file in this repository, not in a third party's storage.
+   [`.github/cla/signatures.json`](https://github.com/marrow-software/marrow/blob/cla-signatures/.github/cla/signatures.json)
+   on the `cla-signatures` branch — a plain readable file in this repository,
+   not in a third party's storage.
 
 3. Wait for CI. The CLA check and the test suite both have to be green.
 4. Expect review comments. Solo maintenance means reviews can take a few days.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ cd docs && npm run build                    # docs site
 
 Marrow is open source because the philosophy demands it. A sovereign knowledge base built behind closed doors would be a contradiction.
 
+Start with **[CONTRIBUTING.md](./CONTRIBUTING.md)** — setup, workflow, and a straight answer about the [CLA](./CLA.md) before you spend your time.
+
 Before writing code, read the **[Restore guarantee](./docs/src/content/docs/concepts/restore-guarantee.md)**. Any contribution that compromises the export/restore round-trip will not be merged.
 
 ---


### PR DESCRIPTION
Closes #275. Implements the mechanism decided in [CLA/DCO before external contributions](https://github.com/marrow-software/marrow/issues/270). Launch-blocking.

## What's here

| File | |
|---|---|
| `CLA.md` | Apache ICLA v2.0, adapted. **Section 2a** is the substantive addition: perpetual, irrevocable, worldwide, sublicensable right to relicense under any terms. Contributor keeps copyright. Individual-only. |
| `.github/workflows/cla.yml` | `contributor-assistant/github-action@v2.6.1`, self-hosted. Bot comments on external PRs; job fails until signed. |
| `.github/cla/signatures.json` | Signature store, **in this repo** — not a third-party gist. Same principle as the export bundle: the record is readable and yours. |
| `CONTRIBUTING.md` | Setup + workflow, and the candour framing from #270. |
| `README.md` | Contributing section now points at `CONTRIBUTING.md`. |

Section 2a carries an explicit carve-out: nothing in the CLA authorises retroactively relicensing an already-published release. That backs the #260 irrevocability promise in the operative text, not just the summary.

`CONTRIBUTING.md` names the rug-pull concern directly — HashiCorp/Elastic/Redis by name — and says a contributor may reasonably decline. Per #270: they'd work it out anyway, better they hear it from us.

## Verified

- `cla.yml` parses as YAML; both triggers (`issue_comment`, `pull_request_target`) present; `signatures.json` is valid JSON.
- Every internal link target resolves (`LICENSE`, `CLA.md`, `CONTRIBUTING.md`, `restore-guarantee.md`).
- Allowlist uses the maintainer's actual login `spmcgraw`.

Not verified: the action has not yet run against a real external PR. That happens on merge.

## Two follow-ups, deliberately not done here

**1. Lawyer review of Section 2a.** Flagged in #275. This is the one clause whose entire job is to be enforceable, and I am not a lawyer. Recommend not publicising the CLA until reviewed — though merging is fine, since the gate failing closed is the safe direction.

**2. The gate is not yet merge-blocking.** The `Requirements` ruleset *does* have a `required_status_checks` rule (the map's note claiming `main` had none is stale), but it requires only `API — lint + test` and `Web — lint + build`. The CLA check is not among them, so today a maintainer can still merge an unsigned PR.

I did not add it pre-emptively on purpose: a required context string that doesn't exactly match the job's reported check name makes **every** PR on `main` unmergeable, including this one. Correct order is merge this, read the actual context off the first PR run, then add it to the ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update after code review

Reviewed on two axes (standards + spec). Three fixes landed; one flagged issue was investigated and **refuted**.

**Blocking defect found and fixed.** The signature write path was broken: the action committed to `main`, but ruleset `18504573` makes `main` PR-only with `bypass_actors: []`, so `GITHUB_TOKEN` could never push. Every signature would have failed silently — the gate was non-functional, not merely advisory. Adding the Actions app as a bypass actor was tried and rejected by GitHub (`422`, app not installed/installable on this org). Signatures now live on an unprotected **`cla-signatures`** branch (seeded). No credential introduced, `main`'s protection untouched, and the in-repo-not-a-gist requirement holds.

**Also fixed:** action repinned from a mutable patch tag to its SHA; custom PR comments switched from folded (`>`) to literal (`|`) block scalars, since folded style collapsed blank lines and would have rendered the bot comment as one run-on paragraph; `CLAUDE.md` updated per its own self-update rule with a new "Contributor licensing (CLA)" section.

**Refuted:** the trailing colon in "reply with exactly:" was flagged as possibly dangling. Checked against the action source at v2.6.1 (`src/pullrequest/pullRequestCommentContent.ts`) — `custom-notsigned-prcomment` is used as `lineOne` and the sign phrase is appended below it between two horizontal rules. The colon reads correctly; no change made.

**Still true:** the gate is not yet merge-blocking (#280) and §2a is lawyer-unreviewed (#281). Verify #280 by observation rather than config — two independent things had to be true here and only one was.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uses `pull_request_target` with `contents: write` (mitigated by not checking out PR code and SHA-pinned action), and §2a relicensing language is not lawyer-reviewed; the CLA check is not yet a required merge status.
> 
> **Overview**
> Adds **external-contributor licensing** before merge: a new **`CLA.md`** (Apache ICLA v2.0 plus bespoke **§2a** relicensing rights and an explicit **non-retroactivity** carve-out for already-released Apache 2.0 versions), **`CONTRIBUTING.md`** (workflow plus upfront CLA tradeoffs), and **`.github/workflows/cla.yml`** using SHA-pinned **CLA Assistant Lite** on `pull_request_target` / sign-comment events.
> 
> The workflow records signatures in-repo at **`.github/cla/signatures.json` on the `cla-signatures` branch** (not `main`, so `GITHUB_TOKEN` can commit without bypassing branch protection). **`README.md`** and **`CLAUDE.md`** are updated to point contributors at the new docs and document maintenance constraints (exact sign phrase across four places, literal YAML `|` for bot comments).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58adadeacc90a97f712baa4cb58701674e48724e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->