### PR TITLE
chore: CI probe — observe CLA check context (#280)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,3 +173,5 @@ form.
 
 Marrow is [Apache 2.0](./LICENSE). Contributions are accepted under the
 [Marrow ICLA](./CLA.md).
+
+<!-- CI probe for #280: observing CLA status-check context name. This branch/PR is throwaway. -->


### PR DESCRIPTION
Throwaway PR for #280. Opening it triggers the CLA workflow on a real `pull_request_target` so we can read the **exact** status-check context name before adding it to the `Requirements` ruleset. Will be closed without merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only comment with no runtime, security, or data impact.
> 
> **Overview**
> **Throwaway CI probe for #280** — no product or docs behavior changes.
> 
> Adds a single HTML comment at the end of `CONTRIBUTING.md` so opening this PR triggers the real `pull_request_target` CLA workflow. The goal is to read the **exact** GitHub status-check context name before wiring it into the `Requirements` ruleset. The branch/PR is intended to be closed without merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdd1507834c9ed76a57941d9bca1cd44ac93a108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->