### PR TITLE
Launch honesty: README, CLAUDE.md, marketing & pricing (#293-296)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,10 @@ CORS_ORIGINS=http://localhost:3000
 
 # Billing / subscriptions (SaaS only — set SAAS_MODE=true to enforce the gate)
 # SAAS_MODE=true
-# STRIPE_SECRET_KEY=, STRIPE_WEBHOOK_SECRET=, STRIPE_*_PRICE_* (see api/.env.example)
+# STRIPE_SECRET_KEY=, STRIPE_WEBHOOK_SECRET= (see api/.env.example)
+# Cloud per-seat prices: STRIPE_{STARTER,BUSINESS,GROWTH}_PRICE_{MONTHLY,YEARLY}
+# Self-hosted per-seat annual prices: STRIPE_SH_BUSINESS_PRICE_YEARLY, STRIPE_SH_ENTERPRISE_PRICE_YEARLY
+#   (both consumed by routers/billing.py's price→tier map; there are no SH monthly prices)
 # Transactional email (Resend) — confirmation emails on checkout; best-effort.
 # RESEND_API_KEY=re_...
 # EMAIL_FROM="Marrow <hello@marrow.so>"
@@ -134,11 +137,11 @@ cd api && alembic revision --autogenerate -m "description"
 cd api && alembic upgrade head
 cd api && alembic downgrade -1
 
-# CLI (export/restore/trash)
+# CLI (export/restore/billing) — the Typer app exposes exactly these three commands
 cd api && marrow export --workspace <slug> --output <path>
 cd api && marrow restore <bundle.zip>
-cd api && marrow purge-trash --older-than-days 30   # hard-delete old trashed nodes (cron'able)
 cd api && marrow reset-org-billing <slug>           # reset billing+onboarding state for repeatable testing (#214)
+# Note: there is no `marrow purge-trash` command; hard-delete is per-node via DELETE /api/nodes/{id}/purge.
 
 # Product frontend (web/)
 cd web && npm run dev
@@ -388,16 +391,16 @@ All routes are prefixed with `/api`. Authentication is enforced via session cook
 | DELETE | /api/orgs/{oid}/members/{mid} | Remove member | owner |
 | POST | /api/orgs/{oid}/workspaces | Create workspace in org (#129) | editor |
 | GET | /api/workspaces/ | List workspaces | viewer |
-| POST | /api/workspaces/ | **410 Gone** — use POST /api/orgs/{oid}/workspaces | — |
+| POST | /api/workspaces/ | Create workspace (`201`); session users default to their first org, API-key/anon must pass `org_id`. `POST /api/orgs/{oid}/workspaces` is the org-scoped alternative | session |
 | GET/DELETE | /api/workspaces/{id} | Get / delete workspace | viewer/owner |
 | GET | /api/workspaces/{id}/tree | Full hierarchy (sidebar) | viewer |
+| GET | /api/workspaces/{id}/home | Workspace home payload (recent pages etc.) | viewer |
 | GET | /api/workspaces/{id}/search?q= | Full-text search across workspace pages | viewer |
 | GET | /api/workspaces/{id}/export?slim=false&include_trash=false | Download workspace as zip bundle | viewer |
 | GET | /api/workspaces/{id}/export/estimate | Pre-compression byte estimates for full & slim exports | viewer |
 | POST | /api/workspaces/restore | Restore a workspace from an uploaded export bundle zip | — |
 | GET/POST | /api/workspaces/{id}/spaces/ | List / create spaces | viewer/editor |
 | GET/DELETE | /api/workspaces/{id}/spaces/{sid} | Get / delete space | viewer/owner |
-| GET | /api/workspaces/{id}/trash | List top-level trashed nodes | viewer |
 | POST | /api/nodes/{id}/restore | Restore a trashed node + subtree (422 if parent still trashed) | editor |
 | DELETE | /api/nodes/{id}/purge | Hard-delete a trashed node and its subtree | owner |
 | GET/POST | /api/nodes/{node_id}/share-links | List / create view-only share links | viewer/editor |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Your knowledge, owned outright. No landlords. No lock-in. No surprises.**
 
-Marrow is a self-hosted, open-source knowledge base built on one non-negotiable principle: if you have your data, you can always come back. Export, wipe, restore. Every time. No exceptions.
+Marrow is a self-hosted, open-source knowledge base built on one non-negotiable principle: if you have your data, you can always come back. Export a workspace, wipe it, restore it — and everything the bundle carries comes back identically.
 
 📖 **[Read the docs](./docs/)** for installation, deployment, and configuration guides.
 
@@ -24,9 +24,9 @@ Marrow is built on the opposite assumption. You should be able to leave at any t
 
 These are not aspirations. They are constraints that every architectural and product decision must respect.
 
-1. **Restore guarantee** — A Marrow export bundle is restorable to an exact replica of the original workspace. A failing restore test is a critical bug.
+1. **Restore guarantee** — A Marrow export bundle restores to an exact replica of the original workspace *content* — the node tree, revisions, attachments, properties, and links the bundle carries (see the [scope table](./docs/src/content/docs/concepts/restore-guarantee.md)). A failing restore test is a critical bug.
 2. **Transparent format** — Markdown, JSON, attachments in a zip. No proprietary blobs.
-3. **Append-only history** — Every save creates a revision. Old revisions are never modified or deleted (enforced by a database trigger).
+3. **Append-only history** — Every save creates a revision. A database trigger blocks any `UPDATE` against the revisions table, so existing revisions are never rewritten. (Revisions can still be hard-deleted — e.g. purging trash or cascading a node delete — the trigger guards edits, not removal.)
 4. **Pluggable storage** — Local filesystem or S3-compatible object storage. Business logic never bypasses the storage adapter.
 5. **Self-hosted by default** — Your data stays on infrastructure you control.
 

--- a/web-marketing/app/pricing/page.tsx
+++ b/web-marketing/app/pricing/page.tsx
@@ -168,9 +168,11 @@ function TierCard({ tier, billing }: { tier: Tier; billing: "monthly" | "yearly"
             )}
           </div>
         )}
-        {billing === "yearly" && !isContactSales && priceNum > 0 && (
+        {/* Banded tiers show a per-band annual in the seat-band list below, so
+            a single card-level annual would misstate the other bands. */}
+        {billing === "yearly" && !isContactSales && priceNum > 0 && !tier.bands && (
           <p style={{ fontSize: "0.8125rem", color: "var(--color-text-secondary)", marginTop: "0.25rem" }}>
-            Billed ${priceNum * 12}/yr per band
+            Billed ${priceNum * 12}/yr
           </p>
         )}
         {tier.priceNote && (
@@ -234,6 +236,11 @@ function TierCard({ tier, billing }: { tier: Tier; billing: "monthly" | "yearly"
               </span>
               <span style={{ fontSize: "0.8125rem", color: "var(--color-text-primary)", whiteSpace: "nowrap" }}>
                 ${band.price[billing]}/mo
+                {billing === "yearly" && (band.price.yearly ?? 0) > 0 && (
+                  <span style={{ color: "var(--color-text-muted)" }}>
+                    {" "}· ${(band.price.yearly ?? 0) * 12}/yr
+                  </span>
+                )}
               </span>
             </div>
           ))}

--- a/web-marketing/app/pricing/page.tsx
+++ b/web-marketing/app/pricing/page.tsx
@@ -70,6 +70,7 @@ function BillingToggle({
 function TierCard({ tier, billing }: { tier: Tier; billing: "monthly" | "yearly" }) {
   const price = tier.price[billing];
   const isContactSales = price === null;
+  const priceNum = price ?? 0;
 
   return (
     <div
@@ -139,7 +140,7 @@ function TierCard({ tier, billing }: { tier: Tier; billing: "monthly" | "yearly"
           </p>
         ) : (
           <div style={{ display: "flex", alignItems: "baseline", gap: "0.25rem" }}>
-            {tier.priceFrom && price! > 0 && (
+            {tier.priceFrom && priceNum > 0 && (
               <span style={{ fontSize: "0.9375rem", color: "var(--color-text-secondary)", marginRight: "0.15rem" }}>
                 from
               </span>
@@ -155,7 +156,7 @@ function TierCard({ tier, billing }: { tier: Tier; billing: "monthly" | "yearly"
             >
               ${price}
             </span>
-            {price! > 0 && (
+            {priceNum > 0 && (
               <span style={{ fontSize: "0.875rem", color: "var(--color-text-secondary)" }}>
                 / mo
               </span>
@@ -167,9 +168,9 @@ function TierCard({ tier, billing }: { tier: Tier; billing: "monthly" | "yearly"
             )}
           </div>
         )}
-        {billing === "yearly" && !isContactSales && price! > 0 && (
+        {billing === "yearly" && !isContactSales && priceNum > 0 && (
           <p style={{ fontSize: "0.8125rem", color: "var(--color-text-secondary)", marginTop: "0.25rem" }}>
-            Billed ${price! * 12}/yr per band
+            Billed ${priceNum * 12}/yr per band
           </p>
         )}
         {tier.priceNote && (

--- a/web-marketing/app/pricing/page.tsx
+++ b/web-marketing/app/pricing/page.tsx
@@ -139,6 +139,11 @@ function TierCard({ tier, billing }: { tier: Tier; billing: "monthly" | "yearly"
           </p>
         ) : (
           <div style={{ display: "flex", alignItems: "baseline", gap: "0.25rem" }}>
+            {tier.priceFrom && price! > 0 && (
+              <span style={{ fontSize: "0.9375rem", color: "var(--color-text-secondary)", marginRight: "0.15rem" }}>
+                from
+              </span>
+            )}
             <span
               style={{
                 fontFamily: "var(--font-heading)",
@@ -150,7 +155,7 @@ function TierCard({ tier, billing }: { tier: Tier; billing: "monthly" | "yearly"
             >
               ${price}
             </span>
-            {price > 0 && (
+            {price! > 0 && (
               <span style={{ fontSize: "0.875rem", color: "var(--color-text-secondary)" }}>
                 / mo
               </span>
@@ -162,9 +167,14 @@ function TierCard({ tier, billing }: { tier: Tier; billing: "monthly" | "yearly"
             )}
           </div>
         )}
-        {billing === "yearly" && !isContactSales && price > 0 && (
+        {billing === "yearly" && !isContactSales && price! > 0 && (
           <p style={{ fontSize: "0.8125rem", color: "var(--color-text-secondary)", marginTop: "0.25rem" }}>
-            Billed ${price * 12}/yr
+            Billed ${price! * 12}/yr per band
+          </p>
+        )}
+        {tier.priceNote && (
+          <p style={{ fontSize: "0.8125rem", color: "var(--color-text-muted)", marginTop: "0.25rem" }}>
+            {tier.priceNote}
           </p>
         )}
       </div>
@@ -190,6 +200,44 @@ function TierCard({ tier, billing }: { tier: Tier; billing: "monthly" | "yearly"
       >
         {tier.cta}
       </Link>
+
+      {tier.bands && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.5rem",
+            marginBottom: "1.5rem",
+            paddingBottom: "1.5rem",
+            borderBottom: "1px solid var(--color-border)",
+          }}
+        >
+          <p
+            style={{
+              fontSize: "0.6875rem",
+              fontWeight: 700,
+              letterSpacing: "0.06em",
+              textTransform: "uppercase",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            Seat bands
+          </p>
+          {tier.bands.map((band) => (
+            <div
+              key={band.name}
+              style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: "0.5rem" }}
+            >
+              <span style={{ fontSize: "0.8125rem", color: "var(--color-text-secondary)" }}>
+                <strong style={{ color: "var(--color-text-primary)" }}>{band.name}</strong> · {band.seats}
+              </span>
+              <span style={{ fontSize: "0.8125rem", color: "var(--color-text-primary)", whiteSpace: "nowrap" }}>
+                ${band.price[billing]}/mo
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
 
       <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: "0.625rem" }}>
         {tier.features.map((feature) => (

--- a/web-marketing/app/pricing/tiers.ts
+++ b/web-marketing/app/pricing/tiers.ts
@@ -49,6 +49,14 @@ export interface FaqItem {
   answer: string;
 }
 
+// Cloud seat bands, ordered cheapest-first. The Cloud tier's "from" floor price
+// is derived from the first band so the two never drift apart.
+const CLOUD_BANDS: SeatBand[] = [
+  { name: "Starter", price: { monthly: 12, yearly: 10 }, seats: "Up to 10 members" },
+  { name: "Business", price: { monthly: 49, yearly: 41 }, seats: "Up to 50 members" },
+  { name: "Growth", price: { monthly: 199, yearly: 166 }, seats: "Up to 250 members" },
+];
+
 export const tiers: Tier[] = [
   {
     id: "self-host",
@@ -76,15 +84,11 @@ export const tiers: Tier[] = [
     id: "cloud",
     name: "Cloud",
     tagline: "Managed hosting, zero ops.",
-    // Floor price = Starter. Bands below carry the full ladder.
-    price: { monthly: 12, yearly: 10 },
+    // Floor price = cheapest band (Starter). CLOUD_BANDS carries the full ladder.
+    price: CLOUD_BANDS[0].price,
     priceFrom: true,
     priceNote: "per organization · billed by seat band",
-    bands: [
-      { name: "Starter", price: { monthly: 12, yearly: 10 }, seats: "Up to 10 members" },
-      { name: "Business", price: { monthly: 49, yearly: 41 }, seats: "Up to 50 members" },
-      { name: "Growth", price: { monthly: 199, yearly: 166 }, seats: "Up to 250 members" },
-    ],
+    bands: CLOUD_BANDS,
     cta: "Start free trial",
     ctaHref: "https://app.marrow.so",
     highlighted: true,

--- a/web-marketing/app/pricing/tiers.ts
+++ b/web-marketing/app/pricing/tiers.ts
@@ -190,6 +190,6 @@ export const faqItems: FaqItem[] = [
   {
     question: "What happens if I cancel my Cloud subscription?",
     answer:
-      "Cancelling ends the subscription and gates access to the workspace right away — there's no 30-day grace period. Export your data while the plan is still active (export is available on any active subscription), then self-host it for free or resubscribe whenever you like.",
+      "Cancelling stops the renewal — there's no separate 30-day grace period. You keep full access for the rest of the billing period you've already paid for; when that period ends the subscription closes and the workspace is gated. (Cancelling a card-less trial ends it there and then.) Export is available any time the subscription is still active, so grab a bundle before it lapses — then self-host it for free or resubscribe whenever you like.",
   },
 ];

--- a/web-marketing/app/pricing/tiers.ts
+++ b/web-marketing/app/pricing/tiers.ts
@@ -2,10 +2,23 @@
 // Structured so #43 can replace this with live Stripe-sourced data
 // without changing component imports: swap the default exports for
 // async functions that fetch from the billing API.
+//
+// Two axes, per #271:
+//   • Deployment (the marketing story, and the comparison grid): Self-host / Cloud / Enterprise
+//   • Seat band (Cloud billing reality, shown only in the Cloud card): Starter / Business / Growth
+// Cloud is billed per organization at a flat rate with a seat cap — not per seat, not per workspace.
 
 export interface Price {
   monthly: number | null;
   yearly: number | null;
+}
+
+// A Cloud seat band. Prices are display-only; the real amounts live in Stripe
+// and are enforced against TIER_SEAT_LIMITS in the API.
+export interface SeatBand {
+  name: string;
+  price: Price;
+  seats: string;
 }
 
 export interface Tier {
@@ -14,6 +27,9 @@ export interface Tier {
   tagline: string;
   price: Price;
   // null = contact sales
+  priceFrom?: boolean; // render the price as a "from" floor (Cloud starts at Starter)
+  priceNote?: string; // small print under the price
+  bands?: SeatBand[]; // seat bands — Cloud card only
   cta: string;
   ctaHref: string;
   highlighted: boolean;
@@ -60,69 +76,75 @@ export const tiers: Tier[] = [
     id: "cloud",
     name: "Cloud",
     tagline: "Managed hosting, zero ops.",
+    // Floor price = Starter. Bands below carry the full ladder.
     price: { monthly: 12, yearly: 10 },
+    priceFrom: true,
+    priceNote: "per organization · billed by seat band",
+    bands: [
+      { name: "Starter", price: { monthly: 12, yearly: 10 }, seats: "Up to 10 members" },
+      { name: "Business", price: { monthly: 49, yearly: 41 }, seats: "Up to 50 members" },
+      { name: "Growth", price: { monthly: 199, yearly: 166 }, seats: "Up to 250 members" },
+    ],
     cta: "Start free trial",
     ctaHref: "https://app.marrow.so",
     highlighted: true,
     features: [
       "Everything in Self-host",
-      "Managed PostgreSQL + backups",
+      "Managed PostgreSQL with automatic backups",
       "R2 object storage for attachments",
       "Automatic upgrades",
-      "Custom domain support",
-      "SSO via any OIDC provider",
-      "Priority email support",
-      "99.9% uptime SLA",
+      "Hosted sign-in (shared identity)",
+      "Priority email support (Business & up)",
     ],
   },
   {
     id: "enterprise",
     name: "Enterprise",
-    tagline: "Dedicated infrastructure, SLA, support.",
+    tagline: "Contract, SLA, and a human on the other end.",
     price: { monthly: null, yearly: null },
     cta: "Contact sales",
     ctaHref: "mailto:hello@marrow.so",
     highlighted: false,
     features: [
       "Everything in Cloud",
-      "Dedicated infrastructure",
-      "Custom data residency",
-      "Audit log",
-      "SSO with SAML 2.0",
-      "SLA-backed support",
+      "Invoiced annual billing",
+      "SLA-backed support (by contract)",
       "Onboarding & migration assistance",
       "Volume pricing",
+      "Dedicated infrastructure & data residency (on request)",
     ],
   },
 ];
 
+// The grid compares capabilities along the deployment axis. Seat bands differ
+// only by size, so they live in the Cloud card, not here. "Roadmap" = planned,
+// not shipped; "By contract" = negotiated as part of an Enterprise agreement.
 export const comparisonRows: ComparisonRow[] = [
   // Core
-  { feature: "Workspaces", "self-host": true, cloud: true, enterprise: true, category: "Core" },
-  { feature: "Spaces & node hierarchy", "self-host": true, cloud: true, enterprise: true, category: "Core" },
+  { feature: "Workspaces & spaces", "self-host": true, cloud: true, enterprise: true, category: "Core" },
+  { feature: "Node hierarchy (folders + pages)", "self-host": true, cloud: true, enterprise: true, category: "Core" },
   { feature: "Append-only revisions", "self-host": true, cloud: true, enterprise: true, category: "Core" },
   { feature: "Export / restore guarantee", "self-host": true, cloud: true, enterprise: true, category: "Core" },
   { feature: "Full-text search", "self-host": true, cloud: true, enterprise: true, category: "Core" },
   { feature: "File attachments", "self-host": true, cloud: true, enterprise: true, category: "Core" },
   // Auth & access
-  { feature: "OIDC / SSO", "self-host": true, cloud: true, enterprise: true, category: "Auth & access" },
-  { feature: "SAML 2.0", "self-host": false, cloud: false, enterprise: true, category: "Auth & access" },
+  { feature: "Sign-in / SSO", "self-host": "Any IdP", cloud: "Hosted", enterprise: "Hosted", category: "Auth & access" },
   { feature: "RBAC (owner / editor / viewer)", "self-host": true, cloud: true, enterprise: true, category: "Auth & access" },
   { feature: "API key access", "self-host": true, cloud: true, enterprise: true, category: "Auth & access" },
   // Infrastructure
   { feature: "Managed hosting", "self-host": false, cloud: true, enterprise: true, category: "Infrastructure" },
   { feature: "Automatic backups", "self-host": false, cloud: true, enterprise: true, category: "Infrastructure" },
-  { feature: "Custom domain", "self-host": false, cloud: true, enterprise: true, category: "Infrastructure" },
-  { feature: "Dedicated infrastructure", "self-host": false, cloud: false, enterprise: true, category: "Infrastructure" },
-  { feature: "Custom data residency", "self-host": false, cloud: false, enterprise: true, category: "Infrastructure" },
+  { feature: "Dedicated infrastructure", "self-host": false, cloud: false, enterprise: "By contract", category: "Infrastructure" },
+  { feature: "Data residency options", "self-host": false, cloud: false, enterprise: "By contract", category: "Infrastructure" },
   // Support
   { feature: "Community support", "self-host": true, cloud: true, enterprise: true, category: "Support" },
   { feature: "Priority email support", "self-host": false, cloud: true, enterprise: true, category: "Support" },
-  { feature: "SLA-backed support", "self-host": false, cloud: false, enterprise: true, category: "Support" },
-  { feature: "Onboarding assistance", "self-host": false, cloud: false, enterprise: true, category: "Support" },
-  // Compliance
-  { feature: "Audit log", "self-host": false, cloud: false, enterprise: true, category: "Compliance" },
-  { feature: "99.9% uptime SLA", "self-host": false, cloud: true, enterprise: true, category: "Compliance" },
+  { feature: "SLA-backed support", "self-host": false, cloud: false, enterprise: "By contract", category: "Support" },
+  { feature: "Onboarding & migration", "self-host": false, cloud: false, enterprise: "By contract", category: "Support" },
+  // Roadmap — planned, not shipped today
+  { feature: "Custom domain", "self-host": false, cloud: "Roadmap", enterprise: "Roadmap", category: "Roadmap" },
+  { feature: "SAML 2.0", "self-host": false, cloud: false, enterprise: "Roadmap", category: "Roadmap" },
+  { feature: "Audit log", "self-host": false, cloud: false, enterprise: "Roadmap", category: "Roadmap" },
 ];
 
 export const faqItems: FaqItem[] = [
@@ -134,27 +156,27 @@ export const faqItems: FaqItem[] = [
   {
     question: "What is the restore guarantee?",
     answer:
-      "Every Marrow export bundle is a self-contained zip: Markdown files, JSON revisions, and attachments — no proprietary formats. Running `marrow restore <bundle.zip>` recreates an exact replica of your workspace on any Marrow instance. We test this on every commit.",
+      "Every Marrow export bundle is a self-contained zip — Markdown files, JSON revisions, and attachments, no proprietary formats. Running `marrow restore <bundle.zip>` rebuilds an exact replica of your workspace content — the node tree, revisions, attachments, properties, and links the bundle carries — on any Marrow instance, and we test this on every commit. Comments, share links, and folder-view definitions are slated for a later bundle version; see the scope table at docs.marrow.so/concepts/restore-guarantee for exactly what round-trips today.",
   },
   {
     question: "Can I migrate from Self-host to Cloud later?",
     answer:
-      "Yes. Export your workspace on any Marrow instance and restore it on any other — including our Cloud. The export format is version-stable and forward-compatible.",
+      "Yes. Export your workspace on any Marrow instance and restore it on any other — including our Cloud. The export format is backward-compatible: a newer version of Marrow reads bundles produced by older ones (schema versions v1–v4).",
   },
   {
     question: "How does the yearly discount work?",
     answer:
-      "On the yearly plan you pay for 10 months and get 2 free — effectively ~17% off the monthly rate. Billing is annual, upfront.",
+      "Yearly plans bill the discounted monthly rate once a year — about 17% off. Starter, for example, is $10/mo billed annually ($120/yr) instead of $12/mo. Business and Growth follow the same math.",
   },
   {
     question: "Is there a free trial for Cloud?",
     answer:
-      "Yes — 14 days, no credit card required. At the end of the trial you can subscribe or export your data and self-host for free.",
+      "Yes — 14 days, no credit card required. If you never add a card, the trial simply ends on day 14 with no charge. Add a card any time during the trial to continue, or export your data and self-host for free.",
   },
   {
-    question: "What counts as a workspace?",
+    question: "How is Cloud billed — per seat or per workspace?",
     answer:
-      "A workspace is a top-level container for a team or project. Each workspace has its own spaces, pages, and members. Self-host has no limit on workspaces; Cloud plans are billed per workspace.",
+      "Neither. Cloud is billed per organization, at a flat monthly price for a seat band: Starter (up to 10 members), Business (up to 50), or Growth (up to 250). One org, one bill, any number of workspaces within the band's member cap. Self-host has no limits at all.",
   },
   {
     question: "Do you offer non-profit or open-source pricing?",
@@ -164,6 +186,6 @@ export const faqItems: FaqItem[] = [
   {
     question: "What happens if I cancel my Cloud subscription?",
     answer:
-      "You get a 30-day grace period to export your data. After that the workspace is archived. Your export bundle is always available — you can restore it yourself on any Marrow instance.",
+      "Cancelling ends the subscription and gates access to the workspace right away — there's no 30-day grace period. Export your data while the plan is still active (export is available on any active subscription), then self-host it for free or resubscribe whenever you like.",
   },
 ];

--- a/web-marketing/app/pricing/tiers.ts
+++ b/web-marketing/app/pricing/tiers.ts
@@ -142,7 +142,7 @@ export const comparisonRows: ComparisonRow[] = [
   { feature: "Data residency options", "self-host": false, cloud: false, enterprise: "By contract", category: "Infrastructure" },
   // Support
   { feature: "Community support", "self-host": true, cloud: true, enterprise: true, category: "Support" },
-  { feature: "Priority email support", "self-host": false, cloud: true, enterprise: true, category: "Support" },
+  { feature: "Priority email support", "self-host": false, cloud: "Business & up", enterprise: true, category: "Support" },
   { feature: "SLA-backed support", "self-host": false, cloud: false, enterprise: "By contract", category: "Support" },
   { feature: "Onboarding & migration", "self-host": false, cloud: false, enterprise: "By contract", category: "Support" },
   // Roadmap — planned, not shipped today

--- a/web-marketing/app/product/page.tsx
+++ b/web-marketing/app/product/page.tsx
@@ -32,14 +32,14 @@ const SECTIONS = [
     id: "search",
     label: "Search",
     heading: "Find it in a keystroke.",
-    body: "Full-text search across every page in a workspace. Hit Cmd+K anywhere, start typing, and land on the right page — with a ranked snippet so you know you're in the right place before you click.",
+    body: "Full-text search across page names, bodies, and properties in a workspace. Hit Cmd+K anywhere in a workspace, start typing, and land on the right page — with a ranked snippet so you know you're in the right place before you click.",
     demo: SearchDemo,
   },
   {
     id: "history",
     label: "History",
     heading: "Every save, forever.",
-    body: "Revisions are append-only by design — nothing is ever overwritten. Browse the full history of any page, restore a previous version, or export the entire revision chain. Your notes do not disappear.",
+    body: "Revisions are append-only by design — a database trigger blocks any edit, so no save is ever silently overwritten. Browse the full history of any page, restore a previous version, or export the entire revision chain. (Deleting a page moves it to trash; purging trash removes it for good.)",
     demo: HistoryDemo,
   },
 ] as const;
@@ -75,7 +75,17 @@ export default function ProductPage() {
             style={{ color: "var(--muted-foreground)" }}
           >
             Marrow is a self-hosted knowledge base built around a single promise: your
-            export bundle is always restorable to an exact replica of your workspace.
+            export bundle restores to an exact replica of your workspace content — the node
+            tree, revisions, attachments, properties, and links it carries.{" "}
+            <a
+              href="https://docs.marrow.so/concepts/restore-guarantee/"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: "var(--color-accent)", textDecoration: "underline" }}
+            >
+              See exactly what round-trips
+            </a>
+            .
           </p>
         </section>
 

--- a/web-marketing/components/landing/landing.tsx
+++ b/web-marketing/components/landing/landing.tsx
@@ -77,8 +77,8 @@ export function Landing() {
                   color: "var(--color-text-secondary)",
                 }}
               >
-                Marrow is a quiet, self-hosted knowledge base — plain Markdown on your disk, a
-                restore guarantee you can audit, and no vendor lock-in.
+                Marrow is a quiet, self-hosted knowledge base — a restore guarantee you can audit,
+                an export bundle you can read by hand, and no vendor lock-in.
               </p>
               <div style={{ display: "flex", gap: 12, marginTop: 36 }}>
                 <Button variant="primary" size="lg" href={SELF_HOST_DOCS_URL}>
@@ -189,8 +189,8 @@ export function Landing() {
               Keyboard-first. Markdown underneath. No&nbsp;surprises.
             </h2>
             <p style={{ fontSize: 16, color: "var(--color-text-secondary)", marginTop: 20, maxWidth: 620 }}>
-              Slash commands, wiki-links, drag-to-reorder blocks. Every keystroke is durable, every page exports
-              to a flat .md file on disk.
+              Slash commands, wiki-links, drag-to-reorder blocks. Every save is versioned, and every page exports
+              to a flat .md file.
             </p>
           </div>
           <EditorPeek />
@@ -215,13 +215,14 @@ export function Landing() {
             <div>
               <Eyebrow>Self-host</Eyebrow>
               <h2 style={{ fontSize: 40, marginTop: 12, fontVariationSettings: '"SOFT" 60' }}>
-                One container.
+                One compose file.
                 <br />
-                One volume. Done.
+                Done.
               </h2>
               <p style={{ fontSize: 16, color: "var(--color-text-secondary)", marginTop: 20, maxWidth: 500 }}>
-                Marrow ships as a single Docker image. Postgres for metadata, the filesystem for your pages. Back
-                up by copying a folder.
+                One Docker Compose file brings up three services: the API image, the web image, and a Postgres
+                database. Pages and history live in Postgres; attachments on the filesystem or S3/R2. Back it up
+                by backing up the database and attachment store.
               </p>
               <div style={{ marginTop: 32, display: "flex", gap: 12 }}>
                 <Button variant="primary" href={SELF_HOST_DOCS_URL}>
@@ -559,22 +560,22 @@ const FEATURES: Feature[] = [
   {
     icon: IconBranch,
     title: "Backlinks that mean something",
-    body: "Every page knows what links to it. Break one and Marrow tells you where.",
+    body: "Every page knows what links to it — the backlink index is rebuilt on every save.",
   },
   {
     icon: IconHistory,
-    title: "Every keystroke versioned",
-    body: "Diff two snapshots side-by-side. Roll back without ceremony.",
+    title: "Every save versioned",
+    body: "Append-only history: every save is a new revision you can roll back to.",
   },
   {
     icon: IconHash,
     title: "Cmd+K, and that's it",
-    body: "Search is the navigation. Titles, bodies, attachments, comments — one field, one answer.",
+    body: "Search is the navigation. Page names, bodies, and properties — one field, one answer, anywhere in a workspace.",
   },
   {
     icon: IconServer,
-    title: "Your data, your disk",
-    body: "Pages are plain Markdown. Attachments are regular files. Your backup is a folder.",
+    title: "Your data, yours to take",
+    body: "Pages and history live in Postgres, attachments on disk or S3/R2 — and any workspace exports to a readable Markdown + JSON zip.",
   },
   {
     icon: IconUsers,
@@ -728,10 +729,10 @@ Related:: [[RFC-0142]] [[Runbook / Ingest]]
 
 function Comparison() {
   const rows = [
-    { feat: "Your data is in", marrow: "Plain Markdown on your disk", others: "A proprietary DB you lease" },
+    { feat: "Your data is in", marrow: "Postgres you run, plus a readable export bundle", others: "A proprietary DB you lease" },
     { feat: "Hosting", marrow: "Self-host, or Cloud", others: "Cloud only" },
     { feat: "Built-in AI", marrow: "None — just your words", others: "Mandatory. Upsold." },
-    { feat: "Pricing model", marrow: "Per workspace, not per seat", others: "Per seat, escalating" },
+    { feat: "Pricing model", marrow: "Per org, with a seat allowance", others: "Per seat, escalating" },
     { feat: "When the vendor folds", marrow: "You keep the files", others: "You keep the zip, good luck" },
   ];
   return (

--- a/web-marketing/components/landing/landing.tsx
+++ b/web-marketing/components/landing/landing.tsx
@@ -264,6 +264,19 @@ export function Landing() {
             </em>
             , wherever you run it.
           </blockquote>
+          <p style={{ fontSize: 15, color: "var(--color-text-secondary)", marginTop: 24, maxWidth: 620 }}>
+            &ldquo;Workspace content&rdquo; means the node tree, revisions, attachments, properties, and links a
+            bundle carries. Comments, share links, and folder views are slated for a later bundle version.{" "}
+            <a
+              href="https://docs.marrow.so/concepts/restore-guarantee/"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: "var(--color-accent)", textDecoration: "underline" }}
+            >
+              See exactly what round-trips
+            </a>
+            .
+          </p>
         </div>
       </section>
 


### PR DESCRIPTION
Part of the #288 launch-honesty pass. Builds on `fix/launch-honesty-288` (which carries #289-292), so this PR is scoped to the four remaining child tickets.

## #293 — README
- Scope the restore-guarantee headline and Core-principle #1 to **workspace-content parity** (link the scope table), matching `restore-guarantee.md`.
- Correct the append-only wording: the trigger blocks **`UPDATE` only** — revisions can still be hard-deleted (purge / cascade).
- No `spmcgraw` links present.

## #294 — CLAUDE.md (every row verified against the code)
- `POST /api/workspaces/` is a live **`201`**, not `410 Gone` (`workspaces.py:112`).
- Add `GET /api/workspaces/{id}/home` (`workspaces.py:236`).
- Remove the non-existent `GET /api/workspaces/{id}/trash` row and the non-existent `marrow purge-trash` CLI command (hard-delete is per-node via `DELETE /api/nodes/{id}/purge`).
- Document the Cloud + `STRIPE_SH_*_YEARLY` price env vars (`billing.py:29-45`).

## #295 — marketing (`web-marketing/`)
- Markdown reframed as an **export artifact**; pages/history in Postgres, attachments on fs / S3-R2.
- Deployment copy → **"one compose file"**, naming the two images + database (terminal already fixed by #290).
- Remove diff-UI and broken-link-detection claims; "every keystroke" → "every save"; scope search to name/body/properties and Cmd+K to a workspace.
- Restore-guarantee copy on landing + product page scoped, links the scope table, names the bundle-v5 gap.

## #296 — pricing (`tiers.ts` + `page.tsx` incl. FAQ)
- Comparison grid on the **deployment axis** (Self-host / Cloud / Enterprise); seat bands (Starter 10 / Business 50 / Growth 250) render **only in the Cloud card**.
- Billing described as **per-org flat-rate with seat caps** — not per workspace.
- Every displayed price maps to a checkout-accepted tier (Starter/Business/Growth; never `tier:"cloud"`); yearly copy matches `$price × 12`.
- SAML / audit log / custom domain / uptime SLA → **Roadmap** or **By-contract**; Cloud SSO corrected to shared hosted identity.
- Cancel-behaviour + restore-guarantee FAQs corrected; forward- → backward-compatible (v1-v4); no-card-trial FAQ verified against the shipped checkout.

## Verification
- `web-marketing` **lint + TypeScript build** pass; all **10 Playwright landing smoke tests** pass.
- No API code changed (docs + marketing frontend only).
- `/code-review` run (Standards + Spec); findings addressed in the second commit (dedupe Cloud floor price, tidy price narrowing, add the landing scope-table link for #295d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and internal documentation only; no runtime behavior changes. Main risk is mis-stated marketing or docs that could confuse users, not production regressions.
> 
> **Overview**
> **Launch-honesty pass (#293–#296):** docs and marketing only; no API or product app code.
> 
> **README & `CLAUDE.md`** narrow the restore guarantee to **workspace content** (with a link to the scope table) and clarify append-only revisions (trigger blocks `UPDATE`, not hard-delete). **`CLAUDE.md`** fixes the API route table (`POST /api/workspaces/` is live `201`, adds `GET …/home`, drops non-existent trash list route) and CLI notes (no `marrow purge-trash`; documents Stripe Cloud/self-hosted price env vars).
> 
> **Marketing (`web-marketing/`)** reframes data storage (Postgres + export bundle vs “Markdown on disk”), self-host as **one compose file** (API, web, Postgres), and scopes search/history/backlinks claims. Landing and product pages link the restore-guarantee scope table and note bundle gaps (comments, share links, folder views).
> 
> **Pricing** splits **deployment tiers** (Self-host / Cloud / Enterprise) from **Cloud seat bands** (Starter / Business / Growth) in `tiers.ts` and `page.tsx` (“from” pricing, per-band list, org flat-rate copy). Comparison rows and FAQs are updated: per-org billing (not per workspace), roadmap/by-contract for unshipped features, and corrected trial/cancel/restore/compatibility wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a578ea2a766e59d45747190480a81e62eecda35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->