### PR TITLE
docs(changelog): correct 0.5.0 release date to 2026-07-30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ steps) on its [GitHub release](https://github.com/marrow-software/marrow/release
 
 ## [Unreleased]
 
-## [0.5.0] — 2026-07-28
+## [0.5.0] — 2026-07-30
 
 This release clears the public MVP launch bar (wayfinder map [#258](https://github.com/marrow-software/marrow/issues/258)): every public-facing claim is now true today, explicitly labelled roadmap, or gone ([#288](https://github.com/marrow-software/marrow/issues/288)). It also lands the contributor-licensing (CLA) machinery and the folder/sidebar UX refactor.
 


### PR DESCRIPTION
The 0.5.0 heading was dated 2026-07-28 (when the entry was drafted). Correct it to the actual release/publish date, 2026-07-30, before the v0.5.0 tag is published.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only date correction with no runtime or behavioral impact.
> 
> **Overview**
> Updates the **0.5.0** section heading in `CHANGELOG.md` from **2026-07-28** to **2026-07-30** so the changelog matches the actual v0.5.0 publish date. No release notes or other content change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40b86b378578fd0570e70f83ab4835046025fc90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->