### PR TITLE
refactor(web): dedup sidebar primitives (/simplify on v0.5.0..HEAD)

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -138,7 +138,6 @@
 
   /* Motion — one house curve, one small duration scale (#310) */
   --ease-signature: cubic-bezier(0.2, 0, 0, 1);
-  --ease-emphasis: cubic-bezier(0.2, 0, 0, 1);
   --dur-hover: 90ms;
   --dur-state: 140ms;
   --dur-enter: 130ms;

--- a/web/app/orgs/[orgId]/admin/layout.tsx
+++ b/web/app/orgs/[orgId]/admin/layout.tsx
@@ -7,7 +7,8 @@ import { ArrowLeft, ChevronLeft, ShieldAlert } from "lucide-react";
 import { toast } from "sonner";
 import { getOrg, listOrgMembers, getAuthStatus, listWorkspaces } from "@/lib/api";
 import type { AuthStatus, Organization, OrgMembership, Workspace } from "@/lib/types";
-import { cn, initials } from "@/lib/utils";
+import { initials } from "@/lib/utils";
+import { navRowClass } from "@/components/sidebar/row-styles";
 
 type SectionDef = { id: string; label: string };
 type GroupDef = { label: string; items: SectionDef[] };
@@ -156,10 +157,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                       <Link
                         href={href}
                         aria-current={isActive ? "page" : undefined}
-                        className={cn(
-                          "signal-flat signal-focus flex h-[var(--ctl-md)] items-center rounded-md px-2 text-base text-foreground hover:bg-accent-soft",
-                          isActive && "signal-nav-active",
-                        )}
+                        className={navRowClass(isActive)}
                       >
                         <span className="min-w-0 flex-1 truncate">{item.label}</span>
                       </Link>

--- a/web/components/app-sidebar.tsx
+++ b/web/components/app-sidebar.tsx
@@ -25,6 +25,8 @@ import {
 } from "lucide-react";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { cn, initials } from "@/lib/utils";
+import { useDismissableMenu, useOutsideDismiss } from "@/hooks/use-outside-dismiss";
+import { flyoutRowClass, navRowClass } from "@/components/sidebar/row-styles";
 import { logout } from "@/lib/api";
 import {
   DndContext,
@@ -67,41 +69,6 @@ interface Props {
   onInboxUnreadChange?: (count: number) => void;
 }
 
-// Dismiss-on-outside-click + Escape, for any menu/flyout. The single dismissal
-// scaffold in this file — both the self-stated menus (via useDismissableMenu)
-// and the externally-controlled Spaces flyout (via SpacesNav) build on it.
-function useOutsideDismiss(
-  ref: React.RefObject<HTMLElement | null>,
-  open: boolean,
-  onClose: () => void,
-) {
-  useEffect(() => {
-    if (!open) return;
-    function onDown(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
-    }
-    document.addEventListener("mousedown", onDown);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDown);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [ref, open, onClose]);
-}
-
-// Menu open-state + dismissal, shared by the workspace switcher and account menu
-// so the dismiss scaffold lives in one place.
-function useDismissableMenu() {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  const close = useCallback(() => setOpen(false), []);
-  useOutsideDismiss(ref, open, close);
-  return { open, setOpen, ref };
-}
-
 // ---------------------------------------------------------------------------
 // Tree-state persistence (open/closed folders) — per workspace per user
 // ---------------------------------------------------------------------------
@@ -130,6 +97,26 @@ function saveOpenState(key: string, state: Record<string, boolean>) {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(key, JSON.stringify(state));
+  } catch {
+    // localStorage may be full or disabled; ignore
+  }
+}
+
+// Guarded scalar localStorage access (SSR-safe, swallows quota/disabled errors)
+// — used for the last-picked space so both read and write share one try/catch.
+function loadString(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function saveString(key: string, value: string) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
   } catch {
     // localStorage may be full or disabled; ignore
   }
@@ -649,15 +636,6 @@ function WorkspaceSwitcher({
 // icon rail; the panels surface here in place of a separate rail flyout.
 // ---------------------------------------------------------------------------
 
-// One class string for every row in the nav strip — the Spaces trigger reuses
-// it so the whole strip shares one type + spacing scale (#316 AC), not per-row CSS.
-function navRowClass(active?: boolean) {
-  return cn(
-    "signal-flat signal-focus flex h-[var(--ctl-md)] items-center gap-2.5 rounded-md px-2 text-base text-foreground hover:bg-accent-soft",
-    active && "signal-nav-active",
-  );
-}
-
 function NavRow({
   Icon,
   label,
@@ -772,13 +750,6 @@ function FlyoutLabel({ children }: { children: React.ReactNode }) {
       {children}
     </p>
   );
-}
-
-// One class string for every interactive row in the flyout (space picks +
-// actions) — the flyout's counterpart to navRowClass, so the region shares one
-// style rather than repeating it per row (#316 AC).
-function flyoutRowClass() {
-  return "flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-base text-foreground hover:bg-accent-soft";
 }
 
 function SpacePickRow({ space, onPick }: { space: SpaceTreeItem; onPick: (id: string) => void }) {
@@ -1278,12 +1249,7 @@ export function AppSidebar({
   const spaceKey = useMemo(() => currentSpaceKey(tree.id, user?.id), [tree.id, user?.id]);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      setSelectedSpaceId(window.localStorage.getItem(spaceKey));
-    } catch {
-      setSelectedSpaceId(null);
-    }
+    setSelectedSpaceId(loadString(spaceKey));
   }, [spaceKey]);
 
   // Navigating (route change) closes the flyout — picking a page is a commit.
@@ -1305,13 +1271,7 @@ export function AppSidebar({
   const selectSpace = useCallback(
     (id: string) => {
       setSelectedSpaceId(id);
-      if (typeof window !== "undefined") {
-        try {
-          window.localStorage.setItem(spaceKey, id);
-        } catch {
-          // localStorage may be full or disabled; ignore
-        }
-      }
+      saveString(spaceKey, id);
       onPanelChange("pages");
     },
     [spaceKey, onPanelChange],

--- a/web/components/page-menu.tsx
+++ b/web/components/page-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ArrowRight,
   BookOpen,
@@ -24,6 +24,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { getBacklinks, getWatchStatus, unwatchNode, watchNode } from "@/lib/api";
+import { useOutsideDismiss } from "@/hooks/use-outside-dismiss";
 
 export type PageMenuDrawer = "backlinks" | "history";
 
@@ -155,16 +156,8 @@ export function PageMenu({
     }
   }
 
-  useEffect(() => {
-    if (!open) return;
-    function onDoc(e: MouseEvent) {
-      if (!wrapperRef.current?.contains(e.target as Node)) {
-        onOpenChange(false);
-      }
-    }
-    document.addEventListener("mousedown", onDoc);
-    return () => document.removeEventListener("mousedown", onDoc);
-  }, [open, onOpenChange]);
+  const closeMenu = useCallback(() => onOpenChange(false), [onOpenChange]);
+  useOutsideDismiss(wrapperRef, open, closeMenu);
 
   return (
     <div ref={wrapperRef} className="relative">

--- a/web/components/sidebar/row-styles.ts
+++ b/web/components/sidebar/row-styles.ts
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+
+// One class string for every row in the sidebar nav strip — the Spaces trigger
+// and the settings-shell nav (app/orgs/[orgId]/admin/layout.tsx) reuse it so the
+// whole chrome shares one type + spacing scale (#316 AC), not per-region CSS.
+export function navRowClass(active?: boolean) {
+  return cn(
+    "signal-flat signal-focus flex h-[var(--ctl-md)] items-center gap-2.5 rounded-md px-2 text-base text-foreground hover:bg-accent-soft",
+    active && "signal-nav-active",
+  );
+}
+
+// The flyout's counterpart to navRowClass (filter box, space picks, footer
+// actions) — so the switcher region shares one style rather than repeating it
+// per row (#316 AC).
+export function flyoutRowClass() {
+  return "flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-base text-foreground hover:bg-accent-soft";
+}

--- a/web/hooks/use-outside-dismiss.ts
+++ b/web/hooks/use-outside-dismiss.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Dismiss-on-outside-click + Escape, for any menu/flyout. The single dismissal
+// scaffold across the app chrome — the sidebar's self-stated menus (via
+// useDismissableMenu), its externally-controlled Spaces flyout, and the page
+// menu all build on it rather than hand-rolling their own document listener.
+export function useOutsideDismiss(
+  ref: React.RefObject<HTMLElement | null>,
+  open: boolean,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [ref, open, onClose]);
+}
+
+// Menu open-state + dismissal, shared by menus that own their own trigger (e.g.
+// the workspace switcher and account menu) so the dismiss scaffold lives in one
+// place.
+export function useDismissableMenu() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const close = useCallback(() => setOpen(false), []);
+  useOutsideDismiss(ref, open, close);
+  return { open, setOpen, ref };
+}


### PR DESCRIPTION
## What

A `/simplify` cleanup pass over the release diff (`v0.5.0..HEAD` — the Signal Phase 1 design work, #311) before cutting 0.6.0. Quality-only: reuse/simplification/altitude, **no behavior change** beyond one benign consistency gain.

Four review agents (reuse · simplification · efficiency · altitude) ran over the diff. The dominant, cross-agent finding: the sidebar's good primitives were locked module-private inside `app-sidebar.tsx`, which forced duplicate copies in `page-menu.tsx` and `admin/layout.tsx`. This PR promotes them.

## Changes

- **`hooks/use-outside-dismiss.ts`** (new) — `useOutsideDismiss` + `useDismissableMenu` lifted out of `app-sidebar.tsx`. `page-menu.tsx` now consumes the shared hook instead of hand-rolling its own `document` mousedown listener (also gains Escape-to-close, matching the rest of the chrome).
- **`components/sidebar/row-styles.ts`** (new) — `navRowClass` / `flyoutRowClass` lifted out. `admin/layout.tsx` settings nav consumes `navRowClass()` rather than a copy-pasted class string (this is CLAUDE.md's stated "one shared `navRowClass`").
- **`loadString` / `saveString`** guards added; the current-space localStorage read+write now share one try/catch instead of two inline blocks.
- Removed the dead **`--ease-emphasis`** token — a byte-identical, unused duplicate of `--ease-signature` that contradicts #310's "one curve".

Net **−50 lines** across four consumers, plus two small shared modules.

## What was deliberately skipped

- **globals.css token scale** (heading ramp, spacing scale, `--measure`, `--focus-ring`, `--lift`) flagged as "defined but unused" — these are the *deliberate* named-token vocabulary from #309/#310 (User Story 33) and are pinned by `check-tokens.mjs` on purpose. Pruning them would re-litigate the design decision.
- **Efficiency refactors** (lift Inbox notifications to the shell to kill a double-fetch; keep `PagesPanel` mounted across panel toggles to avoid rebuilding dnd-kit registrations on ⌘K) — real wins but they change data-flow / render structure, so they're follow-ups, not a cleanup-pass edit. Noted here for a future ticket.

## Verification

- `npm run test:tokens` ✅ (8 retired absent, 37 signature present)
- `npm run lint` ✅
- `npx tsc --noEmit` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI refactor and deduplication only; the page menu gains Escape-to-dismiss, which is a small UX consistency improvement, not a functional risk area.
> 
> **Overview**
> Promotes sidebar chrome helpers that were module-private in `app-sidebar.tsx` into shared modules so admin settings nav, the page menu, and the sidebar all use the same primitives.
> 
> Adds **`hooks/use-outside-dismiss.ts`** with `useOutsideDismiss` and `useDismissableMenu`. **`page-menu.tsx`** drops its custom mousedown listener and uses the hook (also **Escape-to-close**, aligned with other menus). **`app-sidebar.tsx`** imports the hooks instead of defining them inline.
> 
> Adds **`components/sidebar/row-styles.ts`** with `navRowClass` and `flyoutRowClass`. **`admin/layout.tsx`** replaces a duplicated nav class string with `navRowClass(isActive)`.
> 
> In the sidebar, **last-picked space** persistence goes through new **`loadString` / `saveString`** helpers instead of duplicated inline `localStorage` try/catch blocks.
> 
> Removes unused **`--ease-emphasis`** from `globals.css` (duplicate of `--ease-signature`). Net line reduction with no intended behavior change beyond consistent menu dismissal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1be77dc665da86246f12659d94bb7c4cbefb3870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->